### PR TITLE
Remove unused dependency on zeebe-test

### DIFF
--- a/test/pom.xml
+++ b/test/pom.xml
@@ -25,12 +25,6 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>zeebe-test</artifactId>
-    </dependency>
-
-
-    <dependency>
-      <groupId>io.camunda</groupId>
       <artifactId>zeebe-broker</artifactId>
     </dependency>
 


### PR DESCRIPTION
`zeebe-test` will be deprecated soon so here we remove it from the dependencies of the `spring-zeebe-test` module. `zeebe-test` wasn't used internally so no further changes were necessary. 

Users of `spring-zeebe` can still add a direct dependency on `zeebe-test` if they need it. 

closes #133 