### PR TITLE
Adding @ZeebeHeaders to fetch and inject headers as params

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,24 @@ public ProcessVariables handleFoo(@ZeebeVariablesAsType ProcessVariables variabl
 }
 ```
 
+In the same manner you can also access the headers using `@ZeebeCustomHeaders` 
+
+```java
+@ZeebeWorker(type = "foo", autoComplete = true)
+public void handleFoo(final ActivatedJob job, @ZeebeCustomHeaders Map<String, String> headers){
+  // do whatever you need to do
+} 
+```
+
+Or using both `@ZeebeVariablesAsType` and `@ZeebeCustomHeaders`
+
+```java
+@ZeebeWorker(type = "foo", autoComplete = true)
+public ProcessVariables handleFoo(@ZeebeVariablesAsType ProcessVariables variables, @ZeebeCustomHeaders Map<String, String> headers){
+  // do whatever you need to do
+  return variables;
+}
+```
 
 ### Throwing ZeebeBpmnError's
 

--- a/client/spring-zeebe/src/main/java/io/camunda/zeebe/spring/client/annotation/ZeebeCustomHeaders.java
+++ b/client/spring-zeebe/src/main/java/io/camunda/zeebe/spring/client/annotation/ZeebeCustomHeaders.java
@@ -5,4 +5,4 @@ import java.lang.annotation.*;
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-public @interface ZeebeHeaders {}
+public @interface ZeebeCustomHeaders {}

--- a/client/spring-zeebe/src/main/java/io/camunda/zeebe/spring/client/annotation/ZeebeHeaders.java
+++ b/client/spring-zeebe/src/main/java/io/camunda/zeebe/spring/client/annotation/ZeebeHeaders.java
@@ -1,0 +1,8 @@
+package io.camunda.zeebe.spring.client.annotation;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface ZeebeHeaders {}

--- a/client/spring-zeebe/src/main/java/io/camunda/zeebe/spring/client/jobhandling/JobHandlerInvokingSpringBeans.java
+++ b/client/spring-zeebe/src/main/java/io/camunda/zeebe/spring/client/jobhandling/JobHandlerInvokingSpringBeans.java
@@ -6,7 +6,7 @@ import io.camunda.zeebe.client.api.response.ActivatedJob;
 import io.camunda.zeebe.client.api.worker.JobClient;
 import io.camunda.zeebe.client.api.worker.JobHandler;
 import io.camunda.zeebe.client.impl.Loggers;
-import io.camunda.zeebe.spring.client.annotation.ZeebeHeaders;
+import io.camunda.zeebe.spring.client.annotation.ZeebeCustomHeaders;
 import io.camunda.zeebe.spring.client.annotation.ZeebeVariable;
 import io.camunda.zeebe.spring.client.annotation.ZeebeVariablesAsType;
 import io.camunda.zeebe.spring.client.bean.ParameterInfo;
@@ -84,7 +84,7 @@ public class JobHandlerInvokingSpringBeans implements JobHandler {
         } catch (RuntimeException e) {
           throw new RuntimeException("Cannot assign process variables to type '" + clazz.getName() + "', cause is: " + e.getMessage(), e);
         }
-      } else if (param.getParameterInfo().isAnnotationPresent(ZeebeHeaders.class)) {
+      } else if (param.getParameterInfo().isAnnotationPresent(ZeebeCustomHeaders.class)) {
         try {
           arg = job.getCustomHeaders();
         } catch (RuntimeException e) {

--- a/client/spring-zeebe/src/main/java/io/camunda/zeebe/spring/client/jobhandling/JobHandlerInvokingSpringBeans.java
+++ b/client/spring-zeebe/src/main/java/io/camunda/zeebe/spring/client/jobhandling/JobHandlerInvokingSpringBeans.java
@@ -6,6 +6,7 @@ import io.camunda.zeebe.client.api.response.ActivatedJob;
 import io.camunda.zeebe.client.api.worker.JobClient;
 import io.camunda.zeebe.client.api.worker.JobHandler;
 import io.camunda.zeebe.client.impl.Loggers;
+import io.camunda.zeebe.spring.client.annotation.ZeebeHeaders;
 import io.camunda.zeebe.spring.client.annotation.ZeebeVariable;
 import io.camunda.zeebe.spring.client.annotation.ZeebeVariablesAsType;
 import io.camunda.zeebe.spring.client.bean.ParameterInfo;
@@ -82,6 +83,12 @@ public class JobHandlerInvokingSpringBeans implements JobHandler {
           arg = job.getVariablesAsType(clazz);
         } catch (RuntimeException e) {
           throw new RuntimeException("Cannot assign process variables to type '" + clazz.getName() + "', cause is: " + e.getMessage(), e);
+        }
+      } else if (param.getParameterInfo().isAnnotationPresent(ZeebeHeaders.class)) {
+        try {
+          arg = job.getCustomHeaders();
+        } catch (RuntimeException e) {
+          throw new RuntimeException("Cannot assign headers '" + param.getParameterName() + "' to parameter, cause is: " + e.getMessage(), e);
         }
       }
       args.add(arg);


### PR DESCRIPTION
As of ZeebeVariable and ZeebeVariablesAsType
This feature should enable the possibility to get headers injected :

``` java
@ZeebeWorker(type = "foo", autoComplete = true)
public void handleFoo(final ActivatedJob job, @ZeebeHeaders Map<String, String> headers){
  // do whatever you need to do
}
``` 
We could have both variables and headers combined as :

``` java
@ZeebeWorker(type = "foo", autoComplete = true)
public ProcessVariables handleFoo(@ZeebeVariablesAsType ProcessVariables variables, @ZeebeHeaders Map<String, String> headers){
  // do whatever you need to do
  return variables;
}
``` 