### PR TITLE
Bugfix: This could not be interpreted by spring

### DIFF
--- a/client/spring-zeebe/src/main/java/io/camunda/zeebe/spring/client/annotation/ZeebeWorker.java
+++ b/client/spring-zeebe/src/main/java/io/camunda/zeebe/spring/client/annotation/ZeebeWorker.java
@@ -11,7 +11,7 @@ import java.lang.annotation.Target;
 @Documented
 public @interface ZeebeWorker {
 
-  String type() default "${zeebe.client.worker.defaultType}";
+  String type() default "${zeebe.client.worker.default-type}";
 
   String name() default ""; // set to empty string which leads to default from ZeebeClientBuilderImpl being used in ZeebeWorkerPostProcessor
 


### PR DESCRIPTION
When trying to use the parameter from the `application.yaml`, the worker could not be started.

Convention is to use `-` instead of camelCase for `application.yaml` files. Usually, spring can resolve this when mapping yaml values to Java classes, but it seems that for an expression, the `-` way is required.