### PR TITLE
Add JsonMapper

### DIFF
--- a/client/spring-zeebe/src/main/java/io/camunda/zeebe/spring/client/json/ZeebeClientJsonMapper.java
+++ b/client/spring-zeebe/src/main/java/io/camunda/zeebe/spring/client/json/ZeebeClientJsonMapper.java
@@ -1,0 +1,68 @@
+package io.camunda.zeebe.spring.client.json;
+
+import java.io.InputStream;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.JsonMapper;
+
+/**
+ * Provides the {@link JsonMapper} of the {@link ZeebeClient}
+ * as a Spring Bean that can be injected,
+ * e.g. for logging or debugging variable objects.
+ * 
+ * <p>Usage example:
+ * <pre>
+ *{@code @Autowired}
+ *private JsonMapper mapper;
+ * 
+ *{@code @ZeebeWorker(type = "my-service")}
+ *public void invokeMyService(@ZeebeVariablesAsType ProcessVariables variables) {
+ *  LOG.info("Invoking myService with variables: " + mapper.toJson(variables));
+ *}
+ * </pre>
+ */
+@Component
+public class ZeebeClientJsonMapper implements JsonMapper {
+    
+    @Autowired
+    ZeebeClient client;
+    
+    private JsonMapper getMapper() {
+        return client.getConfiguration().getJsonMapper();
+    }
+    
+    @Override
+    public <T> T fromJson(String json, Class<T> typeClass) {
+        return getMapper().fromJson(json, typeClass);
+    }    
+
+    @Override
+    public Map<String, Object> fromJsonAsMap(String json) {
+        return getMapper().fromJsonAsMap(json);
+    }    
+
+    @Override
+    public Map<String, String> fromJsonAsStringMap(String json) {
+        return getMapper().fromJsonAsStringMap(json);
+    }    
+
+    @Override
+    public String toJson(Object value) {
+        return getMapper().toJson(value);
+    }    
+
+    @Override
+    public String validateJson(String propertyName, String jsonInput) {
+        return getMapper().validateJson(propertyName, jsonInput);
+    }
+
+    @Override
+    public String validateJson(String propertyName, InputStream jsonInput) {
+        return getMapper().validateJson(propertyName, jsonInput);
+    }
+    
+}

--- a/client/spring-zeebe/src/test/java/io/camunda/zeebe/spring/client/json/ZeebeClientJsonMapperTest.java
+++ b/client/spring-zeebe/src/test/java/io/camunda/zeebe/spring/client/json/ZeebeClientJsonMapperTest.java
@@ -1,0 +1,73 @@
+package io.camunda.zeebe.spring.client.json;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.ByteArrayInputStream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.JsonMapper;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = ZeebeClientJsonMapper.class)
+class ZeebeClientJsonMapperTest {
+
+    @Autowired
+    private JsonMapper mapper;
+
+    @MockBean(answer = Answers.RETURNS_DEEP_STUBS)
+    private ZeebeClient client;
+
+    @Test
+    void testInjectMapper() {
+        assertNotNull(mapper);
+        assertInstanceOf(ZeebeClientJsonMapper.class, mapper);
+    }
+
+    @Test
+    void testFromJson() {
+        mapper.fromJson("{}", Object.class);
+        Mockito.verify(client.getConfiguration().getJsonMapper()).fromJson("{}", Object.class);
+    }
+
+    @Test
+    void testFromJsonAsMap() {
+        mapper.fromJsonAsMap("{}");
+        Mockito.verify(client.getConfiguration().getJsonMapper()).fromJsonAsMap("{}");
+    }
+
+    @Test
+    void testFromJsonAsStringMap() {
+        mapper.fromJsonAsStringMap("{}");
+        Mockito.verify(client.getConfiguration().getJsonMapper()).fromJsonAsStringMap("{}");
+    }
+
+    @Test
+    void testToJson() {
+        mapper.toJson("");
+        Mockito.verify(client.getConfiguration().getJsonMapper()).toJson("");
+    }
+
+    @Test
+    void testValidateJson() {
+        mapper.validateJson("variables", "{}");
+        Mockito.verify(client.getConfiguration().getJsonMapper()).validateJson("variables", "{}");
+    }
+
+    @Test
+    void testValidateJsonInputStream() {
+        ByteArrayInputStream jsonInputStream = new ByteArrayInputStream("{}".getBytes());
+        mapper.validateJson("variables", jsonInputStream);
+        Mockito.verify(client.getConfiguration().getJsonMapper()).validateJson("variables", jsonInputStream);
+    }
+
+}


### PR DESCRIPTION
Provides the `JsonMapper` of the `ZeebeClient` as a Spring Bean that can be injected, e.g. for logging or debugging variable objects.

Usage example:

```
@Autowired
private JsonMapper mapper;
 
@ZeebeWorker(type = "my-service")
public void invokeMyService(@ZeebeVariablesAsType ProcessVariables variables) {
  LOG.info("Invoking myService with variables: " + mapper.toJson(variables));
}
```

A unit test is included.