### PR TITLE
fix: remove the duplicated worker name initializations

### DIFF
--- a/client/spring-zeebe/src/main/java/io/camunda/zeebe/spring/client/annotation/value/factory/ReadZeebeWorkerValue.java
+++ b/client/spring-zeebe/src/main/java/io/camunda/zeebe/spring/client/annotation/value/factory/ReadZeebeWorkerValue.java
@@ -38,8 +38,6 @@ public class ReadZeebeWorkerValue extends ReadAnnotationValue<MethodInfo, ZeebeW
           String name = resolver.resolve(annotation.name());
           if (name != null && name.length() > 0) {
             builder.name(name);
-          } else {
-            builder.name(methodInfo.getBeanName() + "#" + methodInfo.getMethodName());
           }
 
           return builder.build();


### PR DESCRIPTION
I think that we should rely in this case only on `io.camunda.zeebe.spring.client.annotation.processor.ZeebeWorkerAnnotationProcessor.start` as a single source of truth.
Closes #204 