### PR TITLE
fixes ZeebeVariable deserialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Add the following Maven dependency to your Spring Boot Starter project:
 <dependency>
   <groupId>io.camunda</groupId>
   <artifactId>spring-zeebe-starter</artifactId>
-  <version>8.0.9</version>
+  <version>8.0.10</version>
 </dependency>
 ```
 

--- a/client/spring-zeebe/src/test/java/io/camunda/zeebe/spring/client/bean/ClassInfoTest.java
+++ b/client/spring-zeebe/src/test/java/io/camunda/zeebe/spring/client/bean/ClassInfoTest.java
@@ -46,6 +46,16 @@ public class ClassInfoTest {
     }
   }
 
+  public static class WithZeebeWorkerVariablesComplexType {
+    public static class ComplexTypeDTO {
+      private String var1;
+      private String var2;
+    }
+    @ZeebeWorker(type = "bar", timeout = 100L, fetchVariables = "var2")
+    public void handle(@ZeebeVariable String var1, @ZeebeVariable ComplexTypeDTO var2) {
+    }
+  }
+
   public static class NoPropertiesSet {
     @ZeebeWorker
     public void handle() {

--- a/client/spring-zeebe/src/test/java/io/camunda/zeebe/spring/client/bean/value/factory/ReadZeebeWorkerValueTest.java
+++ b/client/spring-zeebe/src/test/java/io/camunda/zeebe/spring/client/bean/value/factory/ReadZeebeWorkerValueTest.java
@@ -137,6 +137,21 @@ public class ReadZeebeWorkerValueTest {
     assertEquals("null#handle", zeebeWorkerValue.get().getName()); // we are not using beans here - so beanName is null
   }
 
+  @Test
+  public void applyOnWithZeebeWorkerVariablesComplexType() {
+    //given
+    final ReadZeebeWorkerValue readZeebeWorkerValue = new ReadZeebeWorkerValue(null, DEFAULT_WORKER_NAME);
+    final MethodInfo methodInfo = extract(ClassInfoTest.WithZeebeWorkerVariablesComplexType.class);
+
+    //when
+    final Optional<ZeebeWorkerValue> zeebeWorkerValue = readZeebeWorkerValue.apply(methodInfo);
+
+    //then
+    assertTrue(zeebeWorkerValue.isPresent());
+    assertThat(Arrays.asList("var1", "var2")).hasSameElementsAs(Arrays.asList(zeebeWorkerValue.get().getFetchVariables()));
+    assertEquals(methodInfo, zeebeWorkerValue.get().getMethodInfo());
+  }
+
   private MethodInfo extract(Class<?> clazz) {
 
     final Method method = Arrays.stream(clazz.getMethods()).filter(m -> m.getName().equals("handle")).findFirst().get();

--- a/test/testcontainer/src/test/java/io/camunda/zeebe/spring/client/jobhandling/SmokeTest.java
+++ b/test/testcontainer/src/test/java/io/camunda/zeebe/spring/client/jobhandling/SmokeTest.java
@@ -7,11 +7,14 @@ import io.camunda.zeebe.client.api.worker.JobClient;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
+import io.camunda.zeebe.spring.client.annotation.ZeebeVariable;
 import io.camunda.zeebe.spring.client.annotation.ZeebeWorker;
 import io.camunda.zeebe.spring.test.ZeebeSpringTest;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.testcontainers.shaded.com.fasterxml.jackson.core.JsonProcessingException;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -20,6 +23,7 @@ import java.util.Map;
 import static io.camunda.zeebe.process.test.assertions.BpmnAssert.assertThat;
 import static io.camunda.zeebe.spring.test.ZeebeTestThreadSupport.waitForProcessInstanceCompleted;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest(classes = {SmokeTest.class})
 @ZeebeSpringTest
@@ -32,7 +36,10 @@ public class SmokeTest {
   private ZeebeTestEngine engine;
 
   private static boolean calledTest1 = false;
+
   private static boolean calledTest2 = false;
+  private static ComplexTypeDTO test2ComplexTypeDTO = null;
+  private static String test2Var2 = null;
 
   @ZeebeWorker(name="test1", type = "test1", autoComplete = true)
   public void handleTest1(JobClient client, ActivatedJob job) {
@@ -57,12 +64,66 @@ public class SmokeTest {
     assertTrue(calledTest1);
   }
 
+  @ZeebeWorker(name = "test2", type = "test2", autoComplete = true, pollInterval = 10)
+  public void handleTest2(final JobClient client, final ActivatedJob job, @ZeebeVariable ComplexTypeDTO dto, @ZeebeVariable String var2) {
+    calledTest2 = true;
+    test2ComplexTypeDTO = dto;
+    test2Var2 = var2;
+  }
+
+  @Test
+  void testShouldDeserializeComplexTypeZebeeVariable() {
+    final String processId = "test2";
+    BpmnModelInstance bpmnModel = Bpmn.createExecutableProcess(processId).startEvent().serviceTask().zeebeJobType(processId).endEvent().done();
+    client.newDeployResourceCommand().addProcessModel(bpmnModel, processId + ".bpmn").send().join();
+
+    ComplexTypeDTO dto = new ComplexTypeDTO();
+    dto.setVar1("value1");
+    dto.setVar2("value2");
+
+    Map<String, Object> variables = new HashMap<>();
+    variables.put("dto", dto);
+    variables.put("var2", "stringValue");
+
+    ProcessInstanceEvent processInstance = startProcessInstance(client, processId, variables);
+    waitForProcessInstanceCompleted(processInstance);
+
+    Assertions.assertTrue(calledTest2);
+    assertNotNull(test2ComplexTypeDTO);
+    assertNotEquals(new ComplexTypeDTO(), test2ComplexTypeDTO);
+    assertEquals("value1", test2ComplexTypeDTO.getVar1());
+    assertEquals("value2", test2ComplexTypeDTO.getVar2());
+    assertNotNull(test2Var2);
+    assertEquals("stringValue", test2Var2);
+  }
+
   private ProcessInstanceEvent startProcessInstance(ZeebeClient client, String bpmnProcessId) {
     return startProcessInstance(client, bpmnProcessId, new HashMap<>());
   }
 
   private ProcessInstanceEvent startProcessInstance(ZeebeClient client, String bpmnProcessId, Map<String, Object> variables) {
     return client.newCreateInstanceCommand().bpmnProcessId(bpmnProcessId).latestVersion().variables(variables).send().join();
+  }
+
+  private static class ComplexTypeDTO {
+    private String var1;
+    private String var2;
+
+    public String getVar1() {
+      return var1;
+    }
+
+    public void setVar1(String var1) {
+      this.var1 = var1;
+    }
+
+    public String getVar2() {
+      return var2;
+    }
+
+    public void setVar2(String var2) {
+      this.var2 = var2;
+    }
   }
 
 }


### PR DESCRIPTION
Fixes the deserialization of complex types using an ObjectMapper when annotating a worker job method with `@ZeebeVariable`