### PR TITLE
fixes ZeebeVariable deserialization using JsonMapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,9 @@ If you need to customize the ObjectMapper that the Zeebe client uses to work wit
 class MyConfiguration {
   @Bean
   public JsonMapper jsonMapper() {
-    new ZeebeObjectMapper().enable(DeserializationFeature.ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT);
+    ObjectMapper objectMapper = new ObjectMapper()
+      .configure(DeserializationFeature.ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT, true);
+    new ZeebeObjectMapper(objectMapper);
   }
 }
 ```

--- a/client/spring-zeebe-starter/src/main/java/io/camunda/zeebe/spring/client/config/ZeebeClientStarterAutoConfiguration.java
+++ b/client/spring-zeebe-starter/src/main/java/io/camunda/zeebe/spring/client/config/ZeebeClientStarterAutoConfiguration.java
@@ -3,6 +3,7 @@ package io.camunda.zeebe.spring.client.config;
 import io.camunda.zeebe.client.ZeebeClientBuilder;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl;
+import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
 import io.camunda.zeebe.spring.client.annotation.customizer.ZeebeWorkerValueCustomizer;
 import io.camunda.zeebe.spring.client.properties.PropertyBasedZeebeWorkerValueCustomizer;
 import io.camunda.zeebe.spring.client.properties.ZeebeClientConfigurationProperties;
@@ -31,7 +32,7 @@ public class ZeebeClientStarterAutoConfiguration {
   @Bean
   @Primary
   public ZeebeClientBuilder builder(
-    @Autowired(required = false) JsonMapper jsonMapper,
+    JsonMapper jsonMapper,
     @Autowired(required = false) List<ClientInterceptor> clientInterceptorList
   ) {
     final ZeebeClientBuilderImpl builder = new ZeebeClientBuilderImpl();
@@ -49,9 +50,7 @@ public class ZeebeClientStarterAutoConfiguration {
     if (configurationProperties.isPlaintextConnectionEnabled()) {
       builder.usePlaintext();
     }
-    if (jsonMapper != null) {
-      builder.withJsonMapper(jsonMapper);
-    }
+    builder.withJsonMapper(jsonMapper);
     final List<ClientInterceptor> legacyInterceptors = configurationProperties.getInterceptors();
     if (!legacyInterceptors.isEmpty()) {
       builder.withInterceptors(legacyInterceptors.toArray(new ClientInterceptor[0]));
@@ -65,5 +64,11 @@ public class ZeebeClientStarterAutoConfiguration {
   @ConditionalOnMissingBean(name = "propertyBasedZeebeWorkerValueCustomizer")
   public ZeebeWorkerValueCustomizer propertyBasedZeebeWorkerValueCustomizer() {
     return new PropertyBasedZeebeWorkerValueCustomizer(this.configurationProperties);
+  }
+
+  @Bean("jsonMapper")
+  @ConditionalOnMissingBean(JsonMapper.class)
+  public JsonMapper jsonMapper() {
+    return new ZeebeObjectMapper();
   }
 }

--- a/client/spring-zeebe-starter/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java
+++ b/client/spring-zeebe-starter/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java
@@ -14,8 +14,12 @@ import java.util.Properties;
 
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.core.env.Environment;
 
 @ConfigurationProperties(prefix = "zeebe.client")
 public class ZeebeClientConfigurationProperties implements ZeebeClientProperties {
@@ -41,11 +45,9 @@ public class ZeebeClientConfigurationProperties implements ZeebeClientProperties
   @NestedConfigurationProperty
   private Job job = new Job();
 
-  /**
-   * TODO: Think about how to support this in Spring Boot and potentially even remove it from the ZeebeClientProperties
-   * interface upstream
-   */
-  private JsonMapper jsonMapper = new ZeebeObjectMapper();
+  @Lazy
+  @Autowired
+  private JsonMapper jsonMapper;
 
   /**
    * TODO: Think about how to support this in Spring Boot and potentially even remove it from the ZeebeClientProperties

--- a/client/spring-zeebe-starter/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java
+++ b/client/spring-zeebe-starter/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java
@@ -1,9 +1,15 @@
 package io.camunda.zeebe.spring.client.properties;
 
+import io.camunda.zeebe.client.CredentialsProvider;
+import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl;
 import io.camunda.zeebe.spring.client.annotation.value.ZeebeWorkerValue;
 import io.grpc.ClientInterceptor;
-import io.camunda.zeebe.client.CredentialsProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+import org.springframework.context.annotation.Lazy;
+
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -11,15 +17,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
-
-import io.camunda.zeebe.client.api.JsonMapper;
-import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.annotation.Lazy;
-import org.springframework.core.env.Environment;
 
 @ConfigurationProperties(prefix = "zeebe.client")
 public class ZeebeClientConfigurationProperties implements ZeebeClientProperties {

--- a/client/spring-zeebe-starter/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientStarterAutoConfigurationCustomJsonMapperTest.java
+++ b/client/spring-zeebe-starter/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientStarterAutoConfigurationCustomJsonMapperTest.java
@@ -1,0 +1,94 @@
+package io.camunda.zeebe.spring.client.config;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.ZeebeClientBuilder;
+import io.camunda.zeebe.client.api.JsonMapper;
+import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Duration;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@TestPropertySource(
+  properties = {
+    "zeebe.client.broker.gatewayAddress=localhost12345",
+    "zeebe.client.requestTimeout=99s",
+    "zeebe.client.job.timeout=99s",
+    "zeebe.client.job.pollInterval=99s",
+    "zeebe.client.worker.maxJobsActive=99",
+    "zeebe.client.worker.threads=99",
+    "zeebe.client.worker.defaultName=testName",
+    "zeebe.client.worker.defaultType=testType",
+    "zeebe.client.worker.override.foo.enabled=false",
+    "zeebe.client.message.timeToLive=99s",
+    "zeebe.client.security.certpath=aPath",
+    "zeebe.client.security.plaintext=true"
+  }
+)
+@ContextConfiguration(classes = { ZeebeClientStarterAutoConfiguration.class, ZeebeClientStarterAutoConfigurationCustomJsonMapperTest.TestConfig.class })
+public class ZeebeClientStarterAutoConfigurationCustomJsonMapperTest {
+
+  public static class TestConfig {
+    @Bean
+    public ZeebeClient zeebeClient() {
+      return ZeebeClient.newClient();
+    }
+
+    @Bean
+    public JsonMapper jsonMapper() {
+      ObjectMapper objectMapper = new ObjectMapper()
+        .configure(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES, true)
+        .configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, true);
+      return new ZeebeObjectMapper(objectMapper);
+    }
+  }
+
+  @Autowired
+  private JsonMapper jsonMapper;
+
+  @Autowired
+  private ZeebeClientStarterAutoConfiguration autoConfiguration;
+
+  @Test
+  void getJsonMapper() {
+    assertThat(jsonMapper).isNotNull();
+    assertThat(autoConfiguration).isNotNull();
+    assertThat(autoConfiguration.jsonMapper()).isSameAs(jsonMapper);
+
+    Object objectMapper = ReflectionTestUtils.getField(jsonMapper, "objectMapper");
+
+    assertThat(objectMapper).isNotNull();
+    assertThat(objectMapper).isInstanceOf(ObjectMapper.class);
+    assertThat(((ObjectMapper)objectMapper).getDeserializationConfig()).isNotNull();
+    assertThat(((ObjectMapper)objectMapper).getDeserializationConfig().isEnabled(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES)).isTrue();
+    assertThat(((ObjectMapper)objectMapper).getDeserializationConfig().isEnabled(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)).isTrue();
+  }
+
+  @Test
+  void testBuilder() {
+    ZeebeClientBuilder builder = autoConfiguration.builder(jsonMapper, Collections.emptyList());
+
+    assertThat(builder).isNotNull();
+
+    ZeebeClient client = builder.build();
+    assertThat(client.getConfiguration().getJsonMapper()).isSameAs(jsonMapper);
+    assertThat(client.getConfiguration().getGatewayAddress()).isEqualTo("localhost12345");
+    assertThat(client.getConfiguration().getDefaultRequestTimeout()).isEqualTo(Duration.ofSeconds(99));
+    assertThat(client.getConfiguration().getCaCertificatePath()).isEqualTo("aPath");
+    assertThat(client.getConfiguration().isPlaintextConnectionEnabled()).isTrue();
+    assertThat(client.getConfiguration().getDefaultJobWorkerMaxJobsActive()).isEqualTo(99);
+    assertThat(client.getConfiguration().getDefaultJobPollInterval()).isEqualTo(Duration.ofSeconds(99));
+  }
+}

--- a/client/spring-zeebe-starter/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientStarterAutoConfigurationTest.java
+++ b/client/spring-zeebe-starter/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientStarterAutoConfigurationTest.java
@@ -1,0 +1,86 @@
+package io.camunda.zeebe.spring.client.config;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.ZeebeClientBuilder;
+import io.camunda.zeebe.client.api.JsonMapper;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.ListUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Duration;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@TestPropertySource(
+  properties = {
+    "zeebe.client.broker.gatewayAddress=localhost12345",
+    "zeebe.client.requestTimeout=99s",
+    "zeebe.client.job.timeout=99s",
+    "zeebe.client.job.pollInterval=99s",
+    "zeebe.client.worker.maxJobsActive=99",
+    "zeebe.client.worker.threads=99",
+    "zeebe.client.worker.defaultName=testName",
+    "zeebe.client.worker.defaultType=testType",
+    "zeebe.client.worker.override.foo.enabled=false",
+    "zeebe.client.message.timeToLive=99s",
+    "zeebe.client.security.certpath=aPath",
+    "zeebe.client.security.plaintext=true"
+  }
+)
+@ContextConfiguration(classes = { ZeebeClientStarterAutoConfiguration.class, ZeebeClientStarterAutoConfigurationTest.TestConfig.class })
+public class ZeebeClientStarterAutoConfigurationTest {
+
+  public static class TestConfig {
+    @Bean
+    public ZeebeClient zeebeClient() {
+      return ZeebeClient.newClient();
+    }
+  }
+
+  @Autowired
+  private JsonMapper jsonMapper;
+  @Autowired
+  private ZeebeClientStarterAutoConfiguration autoConfiguration;
+
+  @Test
+  void getJsonMapper() {
+    assertThat(jsonMapper).isNotNull();
+    assertThat(autoConfiguration).isNotNull();
+    assertThat(autoConfiguration.jsonMapper()).isSameAs(jsonMapper);
+
+    Object objectMapper = ReflectionTestUtils.getField(jsonMapper, "objectMapper");
+
+    assertThat(objectMapper).isNotNull();
+    assertThat(objectMapper).isInstanceOf(ObjectMapper.class);
+    assertThat(((ObjectMapper)objectMapper).getDeserializationConfig()).isNotNull();
+    assertThat(((ObjectMapper)objectMapper).getDeserializationConfig().isEnabled(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES)).isFalse();
+    assertThat(((ObjectMapper)objectMapper).getDeserializationConfig().isEnabled(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)).isFalse();
+  }
+
+  @Test
+  void testBuilder() {
+    ZeebeClientBuilder builder = autoConfiguration.builder(jsonMapper, Collections.emptyList());
+
+    assertThat(builder).isNotNull();
+
+    ZeebeClient client = builder.build();
+    assertThat(client.getConfiguration().getJsonMapper()).isSameAs(jsonMapper);
+    assertThat(client.getConfiguration().getGatewayAddress()).isEqualTo("localhost12345");
+    assertThat(client.getConfiguration().getDefaultRequestTimeout()).isEqualTo(Duration.ofSeconds(99));
+    assertThat(client.getConfiguration().getCaCertificatePath()).isEqualTo("aPath");
+    assertThat(client.getConfiguration().isPlaintextConnectionEnabled()).isTrue();
+    assertThat(client.getConfiguration().getDefaultJobWorkerMaxJobsActive()).isEqualTo(99);
+    assertThat(client.getConfiguration().getDefaultJobPollInterval()).isEqualTo(Duration.ofSeconds(99));
+  }
+}

--- a/client/spring-zeebe-starter/src/test/java/io/camunda/zeebe/spring/client/properties/ZeebeClientSpringConfigurationPropertiesTest.java
+++ b/client/spring-zeebe-starter/src/test/java/io/camunda/zeebe/spring/client/properties/ZeebeClientSpringConfigurationPropertiesTest.java
@@ -119,7 +119,8 @@ public class ZeebeClientSpringConfigurationPropertiesTest {
 
   @Test
   void getJsonMapper() {
+    assertThat(jsonMapper).isNotNull();
     assertThat(properties.getJsonMapper()).isNotNull();
-    assertThat(properties.getJsonMapper()).isSameAs(properties.getJsonMapper()).isSameAs(jsonMapper);
+    assertThat(properties.getJsonMapper()).isSameAs(properties.getJsonMapper());
   }
 }

--- a/client/spring-zeebe-starter/src/test/java/io/camunda/zeebe/spring/client/properties/ZeebeClientSpringConfigurationPropertiesTest.java
+++ b/client/spring-zeebe-starter/src/test/java/io/camunda/zeebe/spring/client/properties/ZeebeClientSpringConfigurationPropertiesTest.java
@@ -4,10 +4,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
 
+import io.camunda.zeebe.client.api.JsonMapper;
+import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -34,11 +38,18 @@ public class ZeebeClientSpringConfigurationPropertiesTest {
 
   @EnableConfigurationProperties(ZeebeClientConfigurationProperties.class)
   public static class TestConfig {
-
+    @Bean("jsonMapper")
+    @ConditionalOnMissingBean(JsonMapper.class)
+    public JsonMapper jsonMapper() {
+      return new ZeebeObjectMapper();
+    }
   }
 
   @Autowired
   private ZeebeClientConfigurationProperties properties;
+
+  @Autowired
+  private JsonMapper jsonMapper;
 
   @Test
   public void hasBrokerContactPoint() throws Exception {
@@ -104,5 +115,11 @@ public class ZeebeClientSpringConfigurationPropertiesTest {
   @Test
   void shouldFooWorkerDisabled() {
     assertThat(properties.getWorker().getOverride().get("foo").getEnabled()).isFalse();
+  }
+
+  @Test
+  void getJsonMapper() {
+    assertThat(properties.getJsonMapper()).isNotNull();
+    assertThat(properties.getJsonMapper()).isSameAs(properties.getJsonMapper()).isSameAs(jsonMapper);
   }
 }

--- a/client/spring-zeebe/src/main/java/io/camunda/zeebe/spring/client/AbstractZeebeBaseClientSpringConfiguration.java
+++ b/client/spring-zeebe/src/main/java/io/camunda/zeebe/spring/client/AbstractZeebeBaseClientSpringConfiguration.java
@@ -4,18 +4,16 @@ import io.camunda.connector.api.secret.SecretStore;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.api.worker.BackoffSupplier;
 import io.camunda.zeebe.client.impl.worker.ExponentialBackoffBuilderImpl;
-import io.camunda.zeebe.spring.client.annotation.value.factory.ReadAnnotationValueConfiguration;
-import io.camunda.zeebe.spring.client.jobhandling.JobWorkerManager;
-import io.camunda.zeebe.spring.client.jobhandling.DefaultCommandExceptionHandlingStrategy;
 import io.camunda.zeebe.spring.client.annotation.processor.AnnotationProcessorConfiguration;
+import io.camunda.zeebe.spring.client.annotation.value.factory.ReadAnnotationValueConfiguration;
+import io.camunda.zeebe.spring.client.jobhandling.DefaultCommandExceptionHandlingStrategy;
+import io.camunda.zeebe.spring.client.jobhandling.JobWorkerManager;
 import io.camunda.zeebe.spring.client.jobhandling.SpringSecretProvider;
-import io.grpc.ServerCredentials;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.env.Environment;
 
-import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 

--- a/client/spring-zeebe/src/main/java/io/camunda/zeebe/spring/client/AbstractZeebeBaseClientSpringConfiguration.java
+++ b/client/spring-zeebe/src/main/java/io/camunda/zeebe/spring/client/AbstractZeebeBaseClientSpringConfiguration.java
@@ -1,6 +1,7 @@
 package io.camunda.zeebe.spring.client;
 
 import io.camunda.connector.api.secret.SecretStore;
+import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.api.worker.BackoffSupplier;
 import io.camunda.zeebe.client.impl.worker.ExponentialBackoffBuilderImpl;
 import io.camunda.zeebe.spring.client.annotation.value.factory.ReadAnnotationValueConfiguration;
@@ -9,10 +10,12 @@ import io.camunda.zeebe.spring.client.jobhandling.DefaultCommandExceptionHandlin
 import io.camunda.zeebe.spring.client.annotation.processor.AnnotationProcessorConfiguration;
 import io.camunda.zeebe.spring.client.jobhandling.SpringSecretProvider;
 import io.grpc.ServerCredentials;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.env.Environment;
 
+import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -38,9 +41,11 @@ public abstract class AbstractZeebeBaseClientSpringConfiguration {
       new SpringSecretProvider(env));
   }
 
-    @Bean
-  public JobWorkerManager jobWorkerManager(final DefaultCommandExceptionHandlingStrategy commandExceptionHandlingStrategy, SecretStore secretStore) {
-    return new JobWorkerManager(commandExceptionHandlingStrategy, secretStore);
+  @Bean
+  public JobWorkerManager jobWorkerManager(final DefaultCommandExceptionHandlingStrategy commandExceptionHandlingStrategy,
+                                           SecretStore secretStore,
+                                           @Autowired(required = false) JsonMapper jsonMapper) {
+    return new JobWorkerManager(commandExceptionHandlingStrategy, secretStore, jsonMapper);
   }
 
   @Bean

--- a/client/spring-zeebe/src/main/java/io/camunda/zeebe/spring/client/jobhandling/JobWorkerManager.java
+++ b/client/spring-zeebe/src/main/java/io/camunda/zeebe/spring/client/jobhandling/JobWorkerManager.java
@@ -4,6 +4,7 @@ import io.camunda.connector.api.outbound.OutboundConnectorFunction;
 import io.camunda.connector.api.secret.SecretProvider;
 import io.camunda.connector.api.secret.SecretStore;
 import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.api.worker.JobHandler;
 import io.camunda.zeebe.client.api.worker.JobWorker;
 import io.camunda.zeebe.client.api.worker.JobWorkerBuilderStep1;
@@ -26,24 +27,28 @@ public class JobWorkerManager {
 
   private List<JobWorker> openedWorkers = new ArrayList<>();
   private List<ZeebeWorkerValue> workerValues = new ArrayList<>();
+  private JsonMapper jsonMapper;
 
-  public JobWorkerManager(DefaultCommandExceptionHandlingStrategy commandExceptionHandlingStrategy, SecretStore secretStore) {
+  public JobWorkerManager(DefaultCommandExceptionHandlingStrategy commandExceptionHandlingStrategy,
+                          SecretStore secretStore,
+                          JsonMapper jsonMapper) {
     this.commandExceptionHandlingStrategy = commandExceptionHandlingStrategy;
     this.secretStore = secretStore;
+    this.jsonMapper = jsonMapper;
   }
 
   public JobWorker openWorker(ZeebeClient client, ZeebeWorkerValue zeebeWorkerValue) {
     return openWorker(
       client,
       zeebeWorkerValue,
-      new JobHandlerInvokingSpringBeans(zeebeWorkerValue, commandExceptionHandlingStrategy));
+      new JobHandlerInvokingSpringBeans(zeebeWorkerValue, commandExceptionHandlingStrategy, jsonMapper));
   }
 
   public JobWorker openWorker(ZeebeClient client, ZeebeWorkerValue zeebeWorkerValue, OutboundConnectorFunction function) {
     return openWorker(
       client,
       zeebeWorkerValue,
-      new JobHandlerInvokingSpringBeans(zeebeWorkerValue, commandExceptionHandlingStrategy, secretStore, function));
+      new JobHandlerInvokingSpringBeans(zeebeWorkerValue, commandExceptionHandlingStrategy, secretStore, function, jsonMapper));
   }
 
   public JobWorker openWorker(ZeebeClient client, ZeebeWorkerValue zeebeWorkerValue, JobHandler handler) {

--- a/client/spring-zeebe/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientProperties.java
+++ b/client/spring-zeebe/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientProperties.java
@@ -24,15 +24,6 @@ public interface ZeebeClientProperties extends ZeebeClientConfiguration {
   @Deprecated
   List<ClientInterceptor> getInterceptors();
 
-  /**
-   * This method and configuration is deprecated in the Spring environment and shall not be used.
-   * Declare beans on type {@link JsonMapper} in your Spring context and they will be used automatically.
-   *
-   * @deprecated
-   */
-  @Deprecated
-  JsonMapper getJsonMapper();
-
   default boolean isAutoStartup() {
     return true;
   }

--- a/test/testcontainer/src/test/java/io/camunda/zeebe/spring/client/jobhandling/SmokeTest.java
+++ b/test/testcontainer/src/test/java/io/camunda/zeebe/spring/client/jobhandling/SmokeTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.testcontainers.shaded.com.fasterxml.jackson.core.JsonProcessingException;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -23,9 +22,12 @@ import java.util.Map;
 import static io.camunda.zeebe.process.test.assertions.BpmnAssert.assertThat;
 import static io.camunda.zeebe.spring.test.ZeebeTestThreadSupport.waitForProcessInstanceCompleted;
 import static org.junit.Assert.assertTrue;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@SpringBootTest(classes = {SmokeTest.class})
+@SpringBootTest(classes = {SmokeTest.class},
+  properties = { "zeebe.client.worker.default-type=DefaultType" })
 @ZeebeSpringTest
 public class SmokeTest {
 


### PR DESCRIPTION
Fixes the deserialization of complex types when annotating a worker job method with @ZeebeVariable by using the `JsonMapper` bean when exists in the context, falling back to a plain `ObjectMapper` otherwise

Supersede #236 