### PR TITLE
Fixes json mapper default naming

### DIFF
--- a/client/spring-zeebe-starter/src/main/java/io/camunda/zeebe/spring/client/config/ZeebeClientStarterAutoConfiguration.java
+++ b/client/spring-zeebe-starter/src/main/java/io/camunda/zeebe/spring/client/config/ZeebeClientStarterAutoConfiguration.java
@@ -49,7 +49,7 @@ public class ZeebeClientStarterAutoConfiguration {
       builder.usePlaintext();
     }
     if (jsonMapper==null) { // double security because of https://github.com/camunda-community-hub/spring-zeebe/issues/240
-      jsonMapper = jsonMapper();
+      jsonMapper = new ZeebeObjectMapper();
     }
     builder.withJsonMapper(jsonMapper);
     final List<ClientInterceptor> legacyInterceptors = configurationProperties.getInterceptors();
@@ -67,8 +67,17 @@ public class ZeebeClientStarterAutoConfiguration {
     return new PropertyBasedZeebeWorkerValueCustomizer(this.configurationProperties);
   }
 
-  @Bean
-  @ConditionalOnMissingBean(JsonMapper.class)
+  /**
+   * Registering a JsonMapper bean when there is none already exists in {@link org.springframework.beans.factory.BeanFactory}.
+   *
+   * NOTE: This method SHOULD NOT be explicitly called as it might lead to unexpected behaviour due to the
+   * {@link ConditionalOnMissingBean} annotation. i.e. Calling this method when another JsonMapper bean is defined in the context
+   * might throw {@link org.springframework.beans.factory.NoSuchBeanDefinitionException}
+   *
+   * @return a new JsonMapper bean if none already exists in {@link org.springframework.beans.factory.BeanFactory}
+   */
+  @Bean(name = "zeebeJsonMapper")
+  @ConditionalOnMissingBean
   public JsonMapper jsonMapper() {
     return new ZeebeObjectMapper();
   }

--- a/client/spring-zeebe-starter/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientStarterAutoConfigurationCustomJsonMapperTest.java
+++ b/client/spring-zeebe-starter/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientStarterAutoConfigurationCustomJsonMapperTest.java
@@ -107,6 +107,7 @@ public class ZeebeClientStarterAutoConfigurationCustomJsonMapperTest {
 
     ZeebeClient client = builder.build();
     assertThat(client.getConfiguration().getJsonMapper()).isSameAs(jsonMapper);
+    assertThat(client.getConfiguration().getJsonMapper()).isSameAs(applicationContext.getBean("overridingJsonMapper"));
     assertThat(client.getConfiguration().getGatewayAddress()).isEqualTo("localhost12345");
     assertThat(client.getConfiguration().getDefaultRequestTimeout()).isEqualTo(Duration.ofSeconds(99));
     assertThat(client.getConfiguration().getCaCertificatePath()).isEqualTo("aPath");

--- a/client/spring-zeebe-starter/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientStarterAutoConfigurationTest.java
+++ b/client/spring-zeebe-starter/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientStarterAutoConfigurationTest.java
@@ -5,11 +5,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.ZeebeClientBuilder;
 import io.camunda.zeebe.client.api.JsonMapper;
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections.ListUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
@@ -18,6 +17,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.Duration;
 import java.util.Collections;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -52,15 +52,20 @@ public class ZeebeClientStarterAutoConfigurationTest {
   private JsonMapper jsonMapper;
   @Autowired
   private ZeebeClientStarterAutoConfiguration autoConfiguration;
+  @Autowired
+  private ApplicationContext applicationContext;
 
   @Test
   void getJsonMapper() {
     assertThat(jsonMapper).isNotNull();
     assertThat(autoConfiguration).isNotNull();
-    assertThat(autoConfiguration.jsonMapper()).isSameAs(jsonMapper);
 
+    Map<String, JsonMapper> jsonMapperBeans = applicationContext.getBeansOfType(JsonMapper.class);
     Object objectMapper = ReflectionTestUtils.getField(jsonMapper, "objectMapper");
 
+    assertThat(jsonMapperBeans.size()).isEqualTo(1);
+    assertThat(jsonMapperBeans.containsKey("zeebeJsonMapper")).isTrue();
+    assertThat(jsonMapperBeans.get("zeebeJsonMapper")).isSameAs(jsonMapper);
     assertThat(objectMapper).isNotNull();
     assertThat(objectMapper).isInstanceOf(ObjectMapper.class);
     assertThat(((ObjectMapper)objectMapper).getDeserializationConfig()).isNotNull();


### PR DESCRIPTION
Changes the default jsonMapper bean name to avoid conflicting with other `jsonMapper` beans and autowire custom defined beans of type `JsonMapper`. Also adding some more test cases to catch similar issues in the future.
Should be fixing #240 