### PR TITLE
chore(connector-runtime): add validation module by default

### DIFF
--- a/connector-runtime/pom.xml
+++ b/connector-runtime/pom.xml
@@ -19,6 +19,10 @@
       <artifactId>connector-runtime-util</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.camunda.connector</groupId>
+      <artifactId>connector-validation</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>spring-zeebe-starter</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,11 @@
         <version>${connector.version}</version>
       </dependency>
       <dependency>
+        <groupId>io.camunda.connector</groupId>
+        <artifactId>connector-validation</artifactId>
+        <version>${connector.version}</version>
+      </dependency>
+      <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-process-test-extension</artifactId>
         <version>${zeebe.version}</version>


### PR DESCRIPTION
Adds the validation module by default to the Connector runtime to provide this for Connectors. Connectors compile against the validation module with scope `provided` to avoid clashes on the final Connector runtime classpath.