### PR TITLE
Adds JavaDocs to @JobWorker

### DIFF
--- a/client/spring-zeebe/src/main/java/io/camunda/zeebe/spring/client/annotation/JobWorker.java
+++ b/client/spring-zeebe/src/main/java/io/camunda/zeebe/spring/client/annotation/JobWorker.java
@@ -11,14 +11,49 @@ public @interface JobWorker {
 
   String name() default ""; // set to empty string which leads to default from ZeebeClientBuilderImpl being used in ZeebeWorkerAnnotationProcessor
 
+  /**
+   * Set the time (in milliseconds) for how long a job is exclusively assigned for this worker.
+   * In this time, the job can not be assigned by other workers to ensure that only one worker work on the job.
+   * When the time is over then the job can be assigned again by this or other worker if it's not completed yet.
+   * If no timeout is set, then the default is used from the configuration.
+   */
   long timeout() default -1L;
 
+  /**
+   * Set the maximum number of jobs which will be exclusively activated for this worker at the same time.
+   * This is used to control the backpressure of the worker. When the maximum is reached then the worker will stop activating new jobs
+   * in order to not overwhelm the client and give other workers the chance to work on the jobs.
+   * The worker will try to activate new jobs again when jobs are completed (or marked as failed).
+   * If no maximum is set then the default, from the ZeebeClientConfiguration, is used.
+   * <br/><br/>
+   * Considerations:
+   * A greater value can avoid situations in which the client waits idle for the broker to provide more jobs. This can improve the worker's throughput.
+   * The memory used by the worker is linear with respect to this value.
+   * The job's timeout starts to run down as soon as the broker pushes the job.
+   * Keep in mind that the following must hold to ensure fluent job handling:
+   * <pre>time spent in queue + time job handler needs until job completion < job timeout</pre>
+   */
   int maxJobsActive() default -1;
 
+  /**
+   * Set the request timeout (in seconds) for activate job request used to poll for new job.
+   * If no request timeout is set then the default is used from the {@link io.camunda.zeebe.client.ZeebeClientConfiguration ZeebeClientConfiguration}
+   */
   long requestTimeout() default -1L;
 
+  /**
+   * Set the maximal interval (in milliseconds) between polling for new jobs.
+   * A job worker will automatically try to always activate new jobs after completing jobs.
+   * If no jobs can be activated after completing the worker will periodically poll for new jobs.
+   * If no poll interval is set then the default is used from the {@link io.camunda.zeebe.client.ZeebeClientConfiguration ZeebeClientConfiguration}
+   */
   long pollInterval() default -1L;
 
+  /**
+   * Set a list of variable names which should be fetch on job activation.
+   * The jobs which are activated by this worker will only contain variables from this list.
+   * This can be used to limit the number of variables of the activated jobs.
+   */
   String[] fetchVariables() default {};
 
   /**


### PR DESCRIPTION
Added docs to `@JobWorker` as this is one of the primary interfaces to create workers and they lack important info such as unit of measurement for timeouts.

Most of the wording has been inherited from `io.camunda.zeebe.client.api.worker.JobWorkerBuilderStep1`.

Please double check the UoM for `requestTimeout` (the only one in seconds as opposed to milliseconds). This has been inferred by looking at `JobWorkerManager.java#L77`.