### PR TITLE
fix(metrics): include jobType tag in counter key

### DIFF
--- a/client/spring-zeebe-starter/src/main/java/io/camunda/zeebe/spring/client/actuator/MicrometerMetricsRecorder.java
+++ b/client/spring-zeebe-starter/src/main/java/io/camunda/zeebe/spring/client/actuator/MicrometerMetricsRecorder.java
@@ -28,7 +28,7 @@ public class MicrometerMetricsRecorder implements MetricsRecorder {
 
   @Override
   public void increase(String metricName, String action, String jobType) {
-    String key = metricName + "#" + action;
+    String key = metricName + "#" + action + '#' + jobType;
     if (!counters.containsKey(key)) {
       counters.put(key, newCounter(metricName, action, jobType));
     }


### PR DESCRIPTION
Provides fix of the `camunda_connector_outbound_invocations_total` metric (and subsequently of the similar metric for inbound). See related issue for context.

closes #299 