### PR TITLE
Rework Zeebe client configuration & add thread pool metrics

### DIFF
--- a/client/spring-zeebe-starter/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java
+++ b/client/spring-zeebe-starter/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java
@@ -63,7 +63,9 @@ public class ZeebeClientConfigurationProperties implements ZeebeClientProperties
    * TODO: Think about how to support this in Spring Boot and potentially even remove it from the ZeebeClientProperties
    * interface upstream
    */
-  private ArrayList<ClientInterceptor> interceptors = new ArrayList<>();
+  @Lazy
+  @Autowired(required = false)
+  private List<ClientInterceptor> interceptors;
 
   private Duration requestTimeout = DEFAULT.getDefaultRequestTimeout();
 
@@ -113,10 +115,6 @@ public class ZeebeClientConfigurationProperties implements ZeebeClientProperties
 
   public void setJob(Job job) {
     this.job = job;
-  }
-
-  public void setInterceptors(ArrayList<ClientInterceptor> interceptors) {
-    this.interceptors = interceptors;
   }
 
   public Duration getRequestTimeout() {

--- a/client/spring-zeebe-starter/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientStarterAutoConfigurationCustomJsonMapperTest.java
+++ b/client/spring-zeebe-starter/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientStarterAutoConfigurationCustomJsonMapperTest.java
@@ -3,8 +3,6 @@ package io.camunda.zeebe.spring.client.config;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.ZeebeClientBuilder;
-import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,8 +15,6 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import java.time.Duration;
-import java.util.Collections;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -97,23 +93,6 @@ public class ZeebeClientStarterAutoConfigurationCustomJsonMapperTest {
     assertThat(((ObjectMapper)objectMapper).getDeserializationConfig()).isNotNull();
     assertThat(((ObjectMapper)objectMapper).getDeserializationConfig().isEnabled(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES)).isTrue();
     assertThat(((ObjectMapper)objectMapper).getDeserializationConfig().isEnabled(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)).isTrue();
-  }
-
-  @Test
-  void testBuilder() {
-    ZeebeClientBuilder builder = autoConfiguration.builder(jsonMapper, Collections.emptyList());
-
-    assertThat(builder).isNotNull();
-
-    ZeebeClient client = builder.build();
-    assertThat(client.getConfiguration().getJsonMapper()).isSameAs(jsonMapper);
-    assertThat(client.getConfiguration().getJsonMapper()).isSameAs(applicationContext.getBean("overridingJsonMapper"));
-    assertThat(client.getConfiguration().getGatewayAddress()).isEqualTo("localhost12345");
-    assertThat(client.getConfiguration().getDefaultRequestTimeout()).isEqualTo(Duration.ofSeconds(99));
-    assertThat(client.getConfiguration().getCaCertificatePath()).isEqualTo("aPath");
-    assertThat(client.getConfiguration().isPlaintextConnectionEnabled()).isTrue();
-    assertThat(client.getConfiguration().getDefaultJobWorkerMaxJobsActive()).isEqualTo(99);
-    assertThat(client.getConfiguration().getDefaultJobPollInterval()).isEqualTo(Duration.ofSeconds(99));
   }
 
   private static class JsonMapper {

--- a/client/spring-zeebe-starter/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientStarterAutoConfigurationTest.java
+++ b/client/spring-zeebe-starter/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientStarterAutoConfigurationTest.java
@@ -3,7 +3,6 @@ package io.camunda.zeebe.spring.client.config;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.ZeebeClientBuilder;
 import io.camunda.zeebe.client.api.JsonMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,10 +14,6 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import java.time.Duration;
-import java.time.ZoneOffset;
-import java.util.Collections;
-import java.util.Date;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -79,21 +74,5 @@ public class ZeebeClientStarterAutoConfigurationTest {
     assertThat(((ObjectMapper)objectMapper).getDeserializationConfig()).isNotNull();
     assertThat(((ObjectMapper)objectMapper).getDeserializationConfig().isEnabled(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES)).isFalse();
     assertThat(((ObjectMapper)objectMapper).getDeserializationConfig().isEnabled(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)).isFalse();
-  }
-
-  @Test
-  void testBuilder() {
-    ZeebeClientBuilder builder = autoConfiguration.builder(jsonMapper, Collections.emptyList());
-
-    assertThat(builder).isNotNull();
-
-    ZeebeClient client = builder.build();
-    assertThat(client.getConfiguration().getJsonMapper()).isSameAs(jsonMapper);
-    assertThat(client.getConfiguration().getGatewayAddress()).isEqualTo("localhost12345");
-    assertThat(client.getConfiguration().getDefaultRequestTimeout()).isEqualTo(Duration.ofSeconds(99));
-    assertThat(client.getConfiguration().getCaCertificatePath()).isEqualTo("aPath");
-    assertThat(client.getConfiguration().isPlaintextConnectionEnabled()).isTrue();
-    assertThat(client.getConfiguration().getDefaultJobWorkerMaxJobsActive()).isEqualTo(99);
-    assertThat(client.getConfiguration().getDefaultJobPollInterval()).isEqualTo(Duration.ofSeconds(99));
   }
 }

--- a/client/spring-zeebe/src/main/java/io/camunda/zeebe/spring/client/ZeebeClientSpringConfiguration.java
+++ b/client/spring-zeebe/src/main/java/io/camunda/zeebe/spring/client/ZeebeClientSpringConfiguration.java
@@ -1,18 +1,10 @@
 package io.camunda.zeebe.spring.client;
 
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.ZeebeClientBuilder;
 import io.camunda.zeebe.spring.client.lifecycle.ZeebeClientLifecycle;
 import io.camunda.zeebe.spring.client.lifecycle.ZeebeClientObjectFactory;
 import io.camunda.zeebe.spring.client.annotation.processor.ZeebeAnnotationProcessorRegistry;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Conditional;
-
-import java.lang.invoke.MethodHandles;
 
 /**
  * Pulled in by @EnableZeebeClient as configuration.
@@ -23,22 +15,8 @@ import java.lang.invoke.MethodHandles;
  */
 public class ZeebeClientSpringConfiguration extends AbstractZeebeBaseClientSpringConfiguration {
 
-  private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-
   @Bean
   public ZeebeClientLifecycle zeebeClientLifecycle(final ZeebeClientObjectFactory factory, final ZeebeAnnotationProcessorRegistry proxy, final ApplicationEventPublisher publisher) {
     return new ZeebeClientLifecycle(factory, proxy, publisher);
   }
-
-  @Bean
-  public ZeebeClientObjectFactory zeebeClientObjectFactory(ZeebeClientBuilder zeebeClientBuilder) {
-    return new ZeebeClientObjectFactory() {
-      @Override
-      public ZeebeClient getObject() throws BeansException {
-        LOG.info("Creating ZeebeClient using ZeebeClientBuilder [" + zeebeClientBuilder + "]");
-        return zeebeClientBuilder.build();
-      }
-    };
-  }
-
 }

--- a/client/spring-zeebe/src/main/java/io/camunda/zeebe/spring/client/lifecycle/ZeebeClientObjectFactoryImpl.java
+++ b/client/spring-zeebe/src/main/java/io/camunda/zeebe/spring/client/lifecycle/ZeebeClientObjectFactoryImpl.java
@@ -1,0 +1,73 @@
+package io.camunda.zeebe.spring.client.lifecycle;
+
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.ZeebeClientBuilder;
+import io.camunda.zeebe.client.ZeebeClientConfiguration;
+import io.camunda.zeebe.client.impl.ZeebeClientImpl;
+import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
+import io.grpc.ManagedChannel;
+import java.lang.invoke.MethodHandles;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.lang.NonNull;
+
+/**
+ * Default {@link ZeebeClientObjectFactory} implementations
+ */
+public abstract class ZeebeClientObjectFactoryImpl implements ZeebeClientObjectFactory {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  /**
+   * Creates {@link ZeebeClient} instances based on {@link ZeebeClientBuilder},
+   * delegating object creation to its {@link ZeebeClientBuilder#build()} method.
+   */
+  public static class FromBuilder extends ZeebeClientObjectFactoryImpl {
+    private final ZeebeClientBuilder builder;
+
+    public FromBuilder(ZeebeClientBuilder builder) {
+      this.builder = builder;
+    }
+
+    @Override
+    @NonNull
+    public ZeebeClient getObject() throws BeansException {
+      LOG.info("Creating ZeebeClient using ZeebeClientBuilder [" + builder + "]");
+      return builder.build();
+    }
+  }
+
+  /**
+   * Creates {@link ZeebeClient} instances based on {@link ZeebeClientConfiguration}.
+   * <p>
+   * This implementation provides more flexibility compared to {@link FromConfiguration} implementation,
+   * because it also allows to use a custom thread pool.
+   */
+  public static class FromConfiguration extends ZeebeClientObjectFactoryImpl {
+    private final ZeebeClientConfiguration configuration;
+    private final Supplier<ScheduledExecutorService> threadPoolSupplier;
+
+    /**
+     * @param configuration Zeebe client configuration
+     * @param threadPoolSupplier Function to create a {@link ScheduledExecutorService} that will be used by Zeebe client.
+     *                           ExecutorService lifecycle is managed by the underlying {@link ZeebeClientImpl}.
+     */
+    public FromConfiguration(ZeebeClientConfiguration configuration, Supplier<ScheduledExecutorService> threadPoolSupplier) {
+      this.configuration = configuration;
+      this.threadPoolSupplier = threadPoolSupplier;
+    }
+
+    @Override
+    @NonNull
+    public ZeebeClient getObject() throws BeansException {
+      LOG.info("Creating ZeebeClient using ZeebeClientConfiguration [" + configuration + "]");
+
+      ManagedChannel managedChannel = ZeebeClientImpl.buildChannel(configuration);
+      GatewayStub gatewayStub = ZeebeClientImpl.buildGatewayStub(managedChannel, configuration);
+      return new ZeebeClientImpl(configuration, managedChannel, gatewayStub, threadPoolSupplier.get());
+    }
+  }
+}


### PR DESCRIPTION
### 1. Create Zeebe Client using `ZeebeClientConfiguration` (instead of `ZeebeClientBuilder`)

To introduce thread pool metrics, first and foremost we need to have access to the `ScheduledExecutorService` used by Zeebe Client.
This is impossible if we only use `ZeebeClientBuilder`, since it doesn't allow us to configure the executor service.
`ZeebeClientImpl` class, on the other hand, allows us to create an instance with a custom executor service.

I also noticed that `ZeebeClientConfigurationProperties` implements `ZeebeClientConfiguration`, which can be directly used to create a client object. This also allows us to avoid re-wrapping all our properties in a Builder.

**Concern** - backward compatibility is an issue in this specific scenario (though it doesn't seem likely):
* Someone has `spring-zeebe` in the classpath, but doesn't use the spring boot starter, and also relies on the existing mechanism by providing a custom `ZeebeClientBuilder` bean in context. 

### 2. Thread pool metrics

* On creation of `ScheduledExecutorService`, `ExecutorServiceMetrics` instance is created
* New metrics become available:
  * executor_completed_tasks_total
  * executor_pool_size_threads
  * executor_active_threads
  * executor_queued_tasks
 
<img width="856" alt="Screenshot 2022-12-27 at 17 27 04" src="https://user-images.githubusercontent.com/38818382/209694197-8fe00520-91e3-42c3-86c3-0dafda805ae5.png">

related to #305, camunda/team-connectors#288

**P.S.** This still needs some polishing and new tests, I will provide those if we agree on the chosen approach.


