### PR TITLE
Prepare for Spring Boot 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ This project allows to leverage Zeebe (the orchestration engine that comes as pa
 
 ## Version Compatibility
 
-| Spring Zeebe version | Camunda Platform (Zeebe Java Client) version | Bundled Spring Boot version | Compatible Spring Boot versions |
-|----------------------| ------------------------ |-----------------------------|
+| Spring Zeebe version | Camunda Platform version | Bundled Spring Boot version | Compatible Spring Boot versions |
+|----------------------| ------------------------ |-----------------------------| ----------------------------|
 | >= 8.1.15            | 8.1.x                    | 2.7.7  | >= 2.7.6, 3.0.x  |
 | < 8.1.14             | 8.1.x                    | 2.7.5  | = 2.7.x (no 3.0.x)            |
 

--- a/README.md
+++ b/README.md
@@ -9,11 +9,10 @@ This project allows to leverage Zeebe (the orchestration engine that comes as pa
 
 ## Version Compatibility
 
-| Spring Zeebe version | Camunda Platform (Zeebe Java Client) version | Spring Boot version |
-| -------------------- | ------------------------ | ----------------- |
-| 8.1.x                | 8.1.x                    | 2.7.x             |
-
-We are **not** yet supporting Spring Boot 3.x, see [#289](https://github.com/camunda-community-hub/spring-zeebe/issues/289).
+| Spring Zeebe version | Camunda Platform (Zeebe Java Client) version | Spring Boot version       |
+|----------------------| ------------------------ |---------------------------|
+| >= 8.1.15            | 8.1.x                    | >= 2.7.6 (including 3.0.x) |
+| < 8.1.14             | 8.1.x                    | 2.7.x (no 3.0.x)          |
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ This project allows to leverage Zeebe (the orchestration engine that comes as pa
 
 ## Version Compatibility
 
-| Spring Zeebe version | Camunda Platform (Zeebe Java Client) version | Spring Boot version       |
-|----------------------| ------------------------ |---------------------------|
-| >= 8.1.15            | 8.1.x                    | >= 2.7.6 (including 3.0.x) |
-| < 8.1.14             | 8.1.x                    | 2.7.x (no 3.0.x)          |
+| Spring Zeebe version | Camunda Platform (Zeebe Java Client) version | Bundled Spring Boot version | Compatible Spring Boot versions |
+|----------------------| ------------------------ |-----------------------------|
+| >= 8.1.15            | 8.1.x                    | 2.7.7  | >= 2.7.6, 3.0.x  |
+| < 8.1.14             | 8.1.x                    | 2.7.5  | = 2.7.x (no 3.0.x)            |
 
 ## Examples
 

--- a/client/spring-zeebe-starter/src/main/resources/META-INF/spring.factories
+++ b/client/spring-zeebe-starter/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  io.camunda.zeebe.spring.client.config.ZeebeClientStarterAutoConfiguration

--- a/client/spring-zeebe-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/client/spring-zeebe-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+io.camunda.zeebe.spring.client.config.ZeebeClientStarterAutoConfiguration

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <connector.version>0.4.0</connector.version>
     <version.operate-client>1.3.8</version.operate-client>
 
-    <spring-boot.version>2.7.5</spring-boot.version>
+    <spring-boot.version>2.7.7</spring-boot.version>
     <commons-beanutils.version>1.9.4</commons-beanutils.version>
 
     <plugin.version.javadoc>3.1.1</plugin.version.javadoc>

--- a/test/embedded/src/main/java/io/camunda/zeebe/spring/test/ZeebeTestExecutionListener.java
+++ b/test/embedded/src/main/java/io/camunda/zeebe/spring/test/ZeebeTestExecutionListener.java
@@ -8,7 +8,7 @@ import org.springframework.core.Ordered;
 import org.springframework.lang.NonNull;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.TestExecutionListener;
-import org.springframework.util.SocketUtils;
+import org.springframework.test.util.TestSocketUtils;
 
 import java.lang.invoke.MethodHandles;
 
@@ -22,7 +22,7 @@ public class ZeebeTestExecutionListener extends AbstractZeebeTestExecutionListen
   private ZeebeTestEngine zeebeEngine;
 
   public void beforeTestMethod(@NonNull TestContext testContext) {
-    int randomPort = SocketUtils.findAvailableTcpPort(); // can be replaced with TestSocketUtils once available: https://github.com/spring-projects/spring-framework/issues/28210
+    int randomPort = TestSocketUtils.findAvailableTcpPort(); // can be replaced with TestSocketUtils once available: https://github.com/spring-projects/spring-framework/pull/29132
 
     LOGGER.info("Create Zeebe in-memory engine for test run on random port: " + randomPort + "...");
     zeebeEngine = EngineFactory.create(randomPort);


### PR DESCRIPTION
See #289 - Spring Zeebe now works with Spring >= 2.7.6 (also including 3.0.x)