### PR TITLE
Add zeebe client for test early in context

### DIFF
--- a/test/common/src/main/java/io/camunda/zeebe/spring/test/EngineUtils.java
+++ b/test/common/src/main/java/io/camunda/zeebe/spring/test/EngineUtils.java
@@ -1,0 +1,17 @@
+package io.camunda.zeebe.spring.test;
+
+import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
+import io.camunda.zeebe.process.test.assertions.BpmnAssert;
+import io.camunda.zeebe.process.test.filters.RecordStream;
+
+public class EngineUtils {
+
+  private EngineUtils() {}
+
+  public static void initZeebeEngine(final ZeebeTestEngine zeebeTestEngine) {
+    BpmnAssert.initRecordStream(
+      RecordStream.of(zeebeTestEngine.getRecordStreamSource()));
+
+    ZeebeTestThreadSupport.setEngineForCurrentThread(zeebeTestEngine);
+  }
+}

--- a/test/common/src/main/java/io/camunda/zeebe/spring/test/proxy/TestProxyConfiguration.java
+++ b/test/common/src/main/java/io/camunda/zeebe/spring/test/proxy/TestProxyConfiguration.java
@@ -1,7 +1,11 @@
 package io.camunda.zeebe.spring.test.proxy;
 
 import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.ZeebeClientBuilder;
+import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
+import io.camunda.zeebe.spring.client.annotation.processor.ZeebeAnnotationProcessorRegistry;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
 
@@ -10,8 +14,17 @@ import java.lang.reflect.Proxy;
 public class TestProxyConfiguration {
 
   @Bean
-  public ZeebeClientProxy zeebeClientProxy() {
-    return new ZeebeClientProxy();
+  public ZeebeClientProxy zeebeClientProxy(final ZeebeTestEngine zeebeTestEngine,
+                                           @Autowired(required = false) final JsonMapper jsonMapper,
+                                           final ZeebeAnnotationProcessorRegistry zeebeAnnotationProcessorRegistry) {
+    final ZeebeClientProxy zeebeClientProxy = new ZeebeClientProxy();
+    final ZeebeClientBuilder zeebeClientBuilder = ZeebeClient.newClientBuilder().gatewayAddress(zeebeTestEngine.getGatewayAddress()).usePlaintext();
+    if (jsonMapper != null) {
+      zeebeClientBuilder.withJsonMapper(jsonMapper);
+    }
+    final ZeebeClient zeebeClient = zeebeClientBuilder.build();
+    zeebeClientProxy.swapZeebeClient(zeebeClient);
+    return zeebeClientProxy;
   }
 
   @Bean
@@ -21,11 +34,6 @@ public class TestProxyConfiguration {
       this.getClass().getClassLoader(),
       new Class[] { ZeebeClient.class },
       zeebeClientProxy);
-  }
-
-  @Bean
-  public ZeebeTestEngineProxy zeebeTestEngineProxy() {
-    return new ZeebeTestEngineProxy();
   }
 
   @Bean

--- a/test/common/src/main/java/io/camunda/zeebe/spring/test/proxy/ZeebeClientProxy.java
+++ b/test/common/src/main/java/io/camunda/zeebe/spring/test/proxy/ZeebeClientProxy.java
@@ -23,6 +23,10 @@ public class ZeebeClientProxy extends AbstractInvocationHandler  {
     this.delegate = null;
   }
 
+  public ZeebeClient getCurrentZeebeClient() {
+    return delegate;
+  }
+
   @Override
   protected Object handleInvocation(Object proxy, Method method, @Nullable Object[] args) throws Throwable {
     if (delegate==null) {

--- a/test/common/src/main/java/io/camunda/zeebe/spring/test/proxy/ZeebeTestEngineProxy.java
+++ b/test/common/src/main/java/io/camunda/zeebe/spring/test/proxy/ZeebeTestEngineProxy.java
@@ -13,17 +13,21 @@ import java.util.Arrays;
  * Dynamic proxy to delegate to a {@link ZeebeTestEngine} which allows to swap the {@link ZeebeTestEngine} object under the hood.
  * This is used in test environments, where the while ZeebeEngine is re-initialized for every test case
  */
-public class ZeebeTestEngineProxy extends AbstractInvocationHandler {
+public class ZeebeTestEngineProxy<T extends ZeebeTestEngine> extends AbstractInvocationHandler {
 
-  private ZeebeTestEngine delegate;
+  private T delegate;
 
-  public void swapZeebeEngine(ZeebeTestEngine client) {
+  public void swapZeebeEngine(T client) {
     this.delegate = client;
   }
 
   public void removeZeebeEngine() {
   this.delegate = null;
 }
+
+  public T getCurrentEngine() {
+    return delegate;
+  }
 
   @Override
   protected Object handleInvocation(Object proxy, Method method, @Nullable Object[] args) throws Throwable {

--- a/test/embedded/src/main/java/io/camunda/zeebe/spring/test/EmbeddedZeebeEngineConfiguration.java
+++ b/test/embedded/src/main/java/io/camunda/zeebe/spring/test/EmbeddedZeebeEngineConfiguration.java
@@ -1,0 +1,34 @@
+package io.camunda.zeebe.spring.test;
+
+import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
+import io.camunda.zeebe.process.test.engine.EngineFactory;
+import io.camunda.zeebe.spring.test.proxy.ZeebeTestEngineProxy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.util.TestSocketUtils;
+
+import java.lang.invoke.MethodHandles;
+
+@TestConfiguration
+public class EmbeddedZeebeEngineConfiguration {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  @Bean
+  public ZeebeTestEngineProxy<ZeebeTestEngine> zeebeTestEngineProxy() {
+    return initNewEngineProxy();
+  }
+
+  public ZeebeTestEngineProxy<ZeebeTestEngine> initNewEngineProxy() {
+    int randomPort = TestSocketUtils.findAvailableTcpPort(); // https://github.com/spring-projects/spring-framework/issues/28210
+    LOGGER.info("Create Zeebe in-memory engine for test run on random port: " + randomPort + "...");
+    final ZeebeTestEngine engine = EngineFactory.create(randomPort);
+    EngineUtils.initZeebeEngine(engine);
+    engine.start();
+    final ZeebeTestEngineProxy<ZeebeTestEngine> zeebeTestEngineZeebeTestEngineProxy = new ZeebeTestEngineProxy<>();
+    zeebeTestEngineZeebeTestEngineProxy.swapZeebeEngine(engine);
+    return zeebeTestEngineZeebeTestEngineProxy;
+  }
+}

--- a/test/embedded/src/main/java/io/camunda/zeebe/spring/test/ZeebeSpringTest.java
+++ b/test/embedded/src/main/java/io/camunda/zeebe/spring/test/ZeebeSpringTest.java
@@ -1,6 +1,7 @@
 package io.camunda.zeebe.spring.test;
 
 import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestExecutionListeners;
 
 import java.lang.annotation.ElementType;
@@ -16,9 +17,11 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 // this creates the engine and the client
-@Import({ZeebeTestClientSpringConfiguration.class})
+@Import({EmbeddedZeebeEngineConfiguration.class ,ZeebeTestClientSpringConfiguration.class})
 // this listener hooks up into test execution
 @TestExecutionListeners(listeners = ZeebeTestExecutionListener.class, mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
+// I have a strange things without this annotation (i.e. NPE because there is no Zeebe Client in proxy)
+@DirtiesContext
 public @interface ZeebeSpringTest {
 
 }

--- a/test/testcontainer/src/main/java/io/camunda/zeebe/spring/test/TestContainerZeebeEngineConfiguration.java
+++ b/test/testcontainer/src/main/java/io/camunda/zeebe/spring/test/TestContainerZeebeEngineConfiguration.java
@@ -1,0 +1,27 @@
+package io.camunda.zeebe.spring.test;
+
+import io.camunda.zeebe.process.test.extension.testcontainer.ContainerProperties;
+import io.camunda.zeebe.process.test.extension.testcontainer.ContainerizedEngine;
+import io.camunda.zeebe.process.test.extension.testcontainer.EngineContainer;
+import io.camunda.zeebe.spring.test.proxy.ZeebeTestEngineProxy;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class TestContainerZeebeEngineConfiguration {
+
+  @Bean
+  public ZeebeTestEngineProxy<ContainerizedEngine> zeebeTestEngineProxy() {
+    final ZeebeTestEngineProxy<ContainerizedEngine> zeebeTestEngineProxy = new ZeebeTestEngineProxy<>();
+    final EngineContainer container = EngineContainer.getContainer();
+    container.start();
+    final ContainerizedEngine containerizedEngine = new ContainerizedEngine(
+      container.getHost(),
+      container.getMappedPort(ContainerProperties.getContainerPort()),
+      container.getMappedPort(ContainerProperties.getGatewayPort()));
+    containerizedEngine.start();
+    EngineUtils.initZeebeEngine(containerizedEngine);
+    zeebeTestEngineProxy.swapZeebeEngine(containerizedEngine);
+    return zeebeTestEngineProxy;
+  }
+}

--- a/test/testcontainer/src/main/java/io/camunda/zeebe/spring/test/ZeebeSpringTest.java
+++ b/test/testcontainer/src/main/java/io/camunda/zeebe/spring/test/ZeebeSpringTest.java
@@ -1,6 +1,7 @@
 package io.camunda.zeebe.spring.test;
 
 import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestExecutionListeners;
 
 import java.lang.annotation.ElementType;
@@ -19,6 +20,8 @@ import java.lang.annotation.Target;
 @Import({TestContainerZeebeEngineConfiguration.class, ZeebeTestClientSpringConfiguration.class})
 // this listener hooks up into test execution
 @TestExecutionListeners(listeners = ZeebeTestExecutionListener.class, mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
+// I have a strange things without this annotation (i.e. NPE because there is no Zeebe Client in proxy)
+@DirtiesContext
 public @interface ZeebeSpringTest {
 
 }

--- a/test/testcontainer/src/main/java/io/camunda/zeebe/spring/test/ZeebeSpringTest.java
+++ b/test/testcontainer/src/main/java/io/camunda/zeebe/spring/test/ZeebeSpringTest.java
@@ -16,7 +16,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 // this creates the engine and the client
-@Import({ZeebeTestClientSpringConfiguration.class})
+@Import({TestContainerZeebeEngineConfiguration.class, ZeebeTestClientSpringConfiguration.class})
 // this listener hooks up into test execution
 @TestExecutionListeners(listeners = ZeebeTestExecutionListener.class, mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
 public @interface ZeebeSpringTest {

--- a/test/testcontainer/src/main/java/io/camunda/zeebe/spring/test/ZeebeTestExecutionListener.java
+++ b/test/testcontainer/src/main/java/io/camunda/zeebe/spring/test/ZeebeTestExecutionListener.java
@@ -1,16 +1,19 @@
 package io.camunda.zeebe.spring.test;
 
-import io.camunda.zeebe.process.test.extension.testcontainer.ContainerProperties;
+import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.process.test.extension.testcontainer.ContainerizedEngine;
-import io.camunda.zeebe.process.test.extension.testcontainer.EngineContainer;
+import io.camunda.zeebe.spring.client.annotation.processor.ZeebeAnnotationProcessorRegistry;
+import io.camunda.zeebe.spring.test.proxy.ZeebeTestEngineProxy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.Ordered;
+import org.springframework.core.ResolvableType;
 import org.springframework.lang.NonNull;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.TestExecutionListener;
 
 import java.lang.invoke.MethodHandles;
+import java.util.Optional;
 
 /**
  * Test execution listener binding the Zeebe engine to current test context.
@@ -24,25 +27,26 @@ public class ZeebeTestExecutionListener extends AbstractZeebeTestExecutionListen
   public void beforeTestClass(@NonNull TestContext testContext) {
     LOGGER.info("Creating Zeebe Testcontainer...");
 
-    final EngineContainer container = EngineContainer.getContainer();
-    container.start();
-    containerizedEngine = new ContainerizedEngine(
-        container.getHost(),
-        container.getMappedPort(ContainerProperties.getContainerPort()),
-        container.getMappedPort(ContainerProperties.getGatewayPort()));
+    final String[] beanNamesForType = testContext.getApplicationContext().getBeanNamesForType(ResolvableType.forClassWithGenerics(ZeebeTestEngineProxy.class, ContainerizedEngine.class));
+    containerizedEngine = ((ZeebeTestEngineProxy<ContainerizedEngine>) testContext.getApplicationContext().getBean(beanNamesForType[0])).getCurrentEngine();
 
     LOGGER.info("...finished creating Zeebe Testcontainer");
   }
 
   public void beforeTestMethod(@NonNull TestContext testContext) {
     LOGGER.info("Create Zeebe Testcontainer engine");
-    containerizedEngine.start();
-    setupWithZeebeEngine(testContext, containerizedEngine);
+    if (Optional.ofNullable(testContext.getAttribute("NOT_STARTED")).map(o -> (Boolean) o).orElse(false)) {
+      containerizedEngine.start();
+      setupWithZeebeEngine(testContext, containerizedEngine);
+    }
+    // TODO: Play nicely with this. It probably should be somewhere in the parent class
+    testContext.getApplicationContext().getBean(ZeebeAnnotationProcessorRegistry.class).startAll(testContext.getApplicationContext().getBean(ZeebeClient.class));
   }
 
   public void afterTestMethod(@NonNull TestContext testContext) {
     cleanup(testContext, containerizedEngine);
     containerizedEngine.reset();
+    testContext.setAttribute("NOT_STARTED", Boolean.TRUE);
   }
 
   @Override


### PR DESCRIPTION
I've decided that `ZeebeClient` should be firstly initialized in a Spring context. So, it requires that `ZeebeEngine` should be initialized before it as well.

Closes #313 