### PR TITLE
DynamicJobWorkerRegistrar to dynamically or programmatically register Job Workers

### DIFF
--- a/client/spring-zeebe/src/main/java/io/camunda/zeebe/spring/client/event/TaskReceivedEvent.java
+++ b/client/spring-zeebe/src/main/java/io/camunda/zeebe/spring/client/event/TaskReceivedEvent.java
@@ -1,0 +1,74 @@
+package io.camunda.zeebe.spring.client.event;
+
+import org.springframework.context.ApplicationEvent;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * A Camunda agnostic TaskReceivedEvent which is handed to the Dynamically registered listeners.
+ * @author Sai.
+ */
+public class TaskReceivedEvent extends ApplicationEvent {
+  private final String key;
+  private final String processId;
+  private final String processVersion;
+  private final String elementId;
+  private final String worker;
+  private final Map<String, Object> variables;
+  private final Map<String, String> headers;
+
+  public TaskReceivedEvent(String key, String processId, String processVersion,
+                           String elementId, String worker, Map<String, Object> variables, Map<String, String> headers) {
+    super(key);
+    this.key = key;
+    this.processId = processId;
+    this.elementId = elementId;
+    this.worker = worker;
+    this.variables = variables;
+    this.headers = headers;
+    this.processVersion = processVersion;
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  public String getProcessId() {
+    return processId;
+  }
+
+  public String getProcessVersion() {
+    return processVersion;
+  }
+
+  public String getElementId() {
+    return elementId;
+  }
+
+  public String getWorker() {
+    return worker;
+  }
+
+  public Map<String, Object> getVariables() {
+    return new HashMap<>(variables);
+  }
+
+  public Map<String, String> getHeaders() {
+    return new HashMap<>(headers);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    TaskReceivedEvent that = (TaskReceivedEvent) o;
+    return Objects.equals(key, that.key) && Objects.equals(processId, that.processId) && Objects.equals(processVersion, that.processVersion) && Objects.equals(elementId, that.elementId) && Objects.equals(worker, that.worker) && Objects.equals(variables, that.variables) && Objects.equals(headers, that.headers);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(key, processId, processVersion, elementId, worker, variables, headers);
+  }
+}

--- a/client/spring-zeebe/src/main/java/io/camunda/zeebe/spring/client/jobhandling/DynamicJobWorkerRegistrar.java
+++ b/client/spring-zeebe/src/main/java/io/camunda/zeebe/spring/client/jobhandling/DynamicJobWorkerRegistrar.java
@@ -1,0 +1,110 @@
+package io.camunda.zeebe.spring.client.jobhandling;
+
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.response.ActivatedJob;
+import io.camunda.zeebe.client.api.worker.JobHandler;
+import io.camunda.zeebe.spring.client.event.TaskReceivedEvent;
+import org.springframework.context.ApplicationContext;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * For clients who don't wish to use @JobWorker annotation and may want to dynamically (programmatically) register workers based on logic etc.
+ *
+ * @author Sai.
+ */
+public class DynamicJobWorkerRegistrar {
+
+  /**
+   * Application context that's already in scope.
+   */
+  private final ApplicationContext applicationContext;
+  private String jobType;
+  private String jobName;
+  private Consumer<TaskReceivedEvent> taskReceiver;
+  private boolean emitSpringEvent;
+  private JobHandler mockJobHandler;
+
+  private DynamicJobWorkerRegistrar(ApplicationContext applicationContext) {
+    this.applicationContext = applicationContext;
+  }
+
+  public static DynamicJobWorkerRegistrar newInstance(final ApplicationContext applicationContext) {
+    Objects.requireNonNull(applicationContext, "Application context is null. It is required to be injected correctly.");
+    return new DynamicJobWorkerRegistrar(applicationContext);
+  }
+
+  public DynamicJobWorkerRegistrar withJobType(final String jobType) {
+    this.jobType = jobType;
+    return this;
+  }
+
+  public DynamicJobWorkerRegistrar withJobName(final String jobName) {
+    this.jobName = jobName;
+    return this;
+  }
+
+  public DynamicJobWorkerRegistrar withHandler(final Consumer<TaskReceivedEvent> taskReceiver) {
+    Objects.requireNonNull(taskReceiver, "TaskReceiver cannot ne bull. A non null value is required.");
+    this.taskReceiver = taskReceiver;
+    return this;
+  }
+
+  public DynamicJobWorkerRegistrar emitSpringApplicationEvent(final boolean emitSpringEvent) {
+    this.emitSpringEvent = emitSpringEvent;
+    return this;
+  }
+
+  // Used only for unit testing.
+  JobHandler mockJobHandler(final ActivatedJob mockJob) {
+    this.mockJobHandler = (a, b) -> handle(mockJob);
+    return this.mockJobHandler;
+  }
+
+  public void build() {
+    ZeebeClient zeebeClient = applicationContext.getBean(ZeebeClient.class);
+    Objects.requireNonNull(jobType, "JobType must be a non null value.");
+    Objects.requireNonNull(jobName, "JobName must be a non null value.");
+    Objects.requireNonNull(zeebeClient, "Zeebe client is null. It is required to be injected correctly.");
+    if (!emitSpringEvent && taskReceiver == null) {
+      throw new IllegalArgumentException("Either emitSpringEvent should be set to true or a handler must be supplied to handle the Task.");
+    } else if (emitSpringEvent && taskReceiver != null) {
+      throw new IllegalArgumentException("Only one of emitSpringEvent should be set to true or a handler must be supplied to handle the Task.");
+    } else {
+      try {
+        JobHandler jobHandler = mockJobHandler == null ? (client, job) -> handle(job) : mockJobHandler;
+        zeebeClient.newWorker()
+          .jobType(this.jobType)
+          .handler(jobHandler)
+          .name(jobName)
+          .open();
+      } catch (Exception ex) {
+        throw new RuntimeException(ex);
+      }
+    }
+  }
+
+  private void handle(final ActivatedJob job) {
+    TaskReceivedEvent taskReceivedEvent = getTaskReceivedEvent(job);
+    if (emitSpringEvent) {
+      applicationContext.publishEvent(taskReceivedEvent);
+    } else {
+      taskReceiver.accept(taskReceivedEvent);
+    }
+  }
+
+  private TaskReceivedEvent getTaskReceivedEvent(final ActivatedJob job) {
+    return new TaskReceivedEvent(
+      job.getKey() + "",
+      job.getBpmnProcessId(),
+      job.getProcessDefinitionVersion() + "",
+      job.getElementId(),
+      job.getWorker(),
+      job.getVariablesAsMap(),
+      job.getCustomHeaders()
+    );
+  }
+
+
+}

--- a/client/spring-zeebe/src/test/java/io/camunda/zeebe/spring/client/jobhandling/DynamicJobWorkerRegistrarTest.java
+++ b/client/spring-zeebe/src/test/java/io/camunda/zeebe/spring/client/jobhandling/DynamicJobWorkerRegistrarTest.java
@@ -1,0 +1,118 @@
+package io.camunda.zeebe.spring.client.jobhandling;
+
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.worker.JobHandler;
+import io.camunda.zeebe.client.api.worker.JobWorker;
+import io.camunda.zeebe.client.api.worker.JobWorkerBuilderStep1;
+import io.camunda.zeebe.spring.client.event.TaskReceivedEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationContext;
+
+import java.util.function.Consumer;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class DynamicJobWorkerRegistrarTest {
+
+  @Mock
+  private ApplicationContext applicationContext;
+
+  @Mock
+  private ZeebeClient zeebeClient;
+
+  @Mock
+  private JobWorkerBuilderStep1 jobWorkerBuilderStep1;
+
+  @Mock
+  private JobWorkerBuilderStep1.JobWorkerBuilderStep2 jobWorkerBuilderStep2;
+
+  @Mock
+  private JobWorkerBuilderStep1.JobWorkerBuilderStep3 jobWorkerBuilderStep3;
+
+  @Mock
+  private JobWorker jobWorker;
+
+  @DisplayName("Should build with a task handler supplied")
+  @Test
+  void build_with_task_handler() throws Exception {
+    final String jobType = "job-type-1";
+    final String jobName = "job-name-1";
+    final Consumer<TaskReceivedEvent> taskHandler = event -> {
+      MockJob mockJob = new MockJob();
+      assertThat(event, is(notNullValue()));
+      assertThat(event.getVariables(), equalTo(mockJob.getVariablesAsMap()));
+      assertThat(event.getElementId(), equalTo(mockJob.getElementId()));
+      assertThat(event.getProcessVersion(), equalTo(mockJob.getProcessDefinitionVersion() + ""));
+      assertThat(event.getHeaders(), equalTo(mockJob.getCustomHeaders()));
+      assertThat(event.getKey(), equalTo(mockJob.getKey() + ""));
+      assertThat(event.getProcessId(), equalTo(mockJob.getBpmnProcessId() + ""));
+    };
+    when(applicationContext.getBean(ZeebeClient.class)).thenReturn(zeebeClient);
+    when(zeebeClient.newWorker()).thenReturn(jobWorkerBuilderStep1);
+    when(jobWorkerBuilderStep1.jobType(jobType)).thenReturn(jobWorkerBuilderStep2);
+    when(jobWorkerBuilderStep2.handler(any())).thenReturn(jobWorkerBuilderStep3);
+    when(jobWorkerBuilderStep3.name(jobName)).thenReturn(jobWorkerBuilderStep3);
+    when(jobWorkerBuilderStep3.open()).thenReturn(jobWorker);
+    DynamicJobWorkerRegistrar dynamicJobWorkerRegistrar = DynamicJobWorkerRegistrar.newInstance(applicationContext);
+    final JobHandler mockJobHandler = dynamicJobWorkerRegistrar.mockJobHandler(new MockJob());
+    dynamicJobWorkerRegistrar.withJobType(jobType);
+    dynamicJobWorkerRegistrar.withJobName(jobName);
+    dynamicJobWorkerRegistrar.withHandler(taskHandler);
+    dynamicJobWorkerRegistrar.build();
+    mockJobHandler.handle(null, new MockJob());
+  }
+
+  @DisplayName("Should build with spring event publisher supplied")
+  @Test
+  void build_with_spring_event_publisher() throws Exception {
+    final String jobType = "job-type-1";
+    final String jobName = "job-name-1";
+    when(applicationContext.getBean(ZeebeClient.class)).thenReturn(zeebeClient);
+    when(zeebeClient.newWorker()).thenReturn(jobWorkerBuilderStep1);
+    when(jobWorkerBuilderStep1.jobType(jobType)).thenReturn(jobWorkerBuilderStep2);
+    when(jobWorkerBuilderStep2.handler(any())).thenReturn(jobWorkerBuilderStep3);
+    when(jobWorkerBuilderStep3.name(jobName)).thenReturn(jobWorkerBuilderStep3);
+    when(jobWorkerBuilderStep3.open()).thenReturn(jobWorker);
+    DynamicJobWorkerRegistrar dynamicJobWorkerRegistrar = DynamicJobWorkerRegistrar.newInstance(applicationContext);
+    final MockJob mockJob = new MockJob();
+    final JobHandler mockJobHandler = dynamicJobWorkerRegistrar.mockJobHandler(mockJob);
+    dynamicJobWorkerRegistrar.withJobType(jobType);
+    dynamicJobWorkerRegistrar.withJobName(jobName);
+    dynamicJobWorkerRegistrar.emitSpringApplicationEvent(true);
+    dynamicJobWorkerRegistrar.build();
+    mockJobHandler.handle(null, mockJob);
+    verify(applicationContext, times(1)).publishEvent(new TaskReceivedEvent(mockJob.getKey() + "",
+      mockJob.getBpmnProcessId(),
+      mockJob.getProcessDefinitionVersion() + "",
+      mockJob.getElementId(),
+      mockJob.getWorker(),
+      mockJob.getVariablesAsMap(),
+      mockJob.getCustomHeaders()));
+  }
+
+  @DisplayName("Should build with spring event publisher supplied")
+  @Test
+  void fail_when_both_spring_Event_and_task_handlers_are_supplied() {
+    final String jobType = "job-type-1";
+    final String jobName = "job-name-1";
+    when(applicationContext.getBean(ZeebeClient.class)).thenReturn(zeebeClient);
+    DynamicJobWorkerRegistrar dynamicJobWorkerRegistrar = DynamicJobWorkerRegistrar.newInstance(applicationContext);
+    assertThrows(IllegalArgumentException.class,
+      () -> {
+        dynamicJobWorkerRegistrar.withJobType(jobType)
+          .withHandler(t -> System.out.println(" My task handler "))
+          .withJobName(jobName)
+          .emitSpringApplicationEvent(true);
+        dynamicJobWorkerRegistrar.build();
+      });
+  }
+}

--- a/client/spring-zeebe/src/test/java/io/camunda/zeebe/spring/client/jobhandling/MockJob.java
+++ b/client/spring-zeebe/src/test/java/io/camunda/zeebe/spring/client/jobhandling/MockJob.java
@@ -1,0 +1,93 @@
+package io.camunda.zeebe.spring.client.jobhandling;
+
+import io.camunda.zeebe.client.api.response.ActivatedJob;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class MockJob implements ActivatedJob {
+
+  @Override
+  public long getKey() {
+    return 0;
+  }
+
+  @Override
+  public String getType() {
+    return "Type";
+  }
+
+  @Override
+  public long getProcessInstanceKey() {
+    return 0;
+  }
+
+  @Override
+  public String getBpmnProcessId() {
+    return "BpmnProcessId";
+  }
+
+  @Override
+  public int getProcessDefinitionVersion() {
+    return 0;
+  }
+
+  @Override
+  public long getProcessDefinitionKey() {
+    return 0;
+  }
+
+  @Override
+  public String getElementId() {
+    return "ElementId";
+  }
+
+  @Override
+  public long getElementInstanceKey() {
+    return 0;
+  }
+
+  @Override
+  public Map<String, String> getCustomHeaders() {
+    return new HashMap<String, String>() {{
+      put("header1", "value1");
+    }};
+  }
+
+  @Override
+  public String getWorker() {
+    return "Worker";
+  }
+
+  @Override
+  public int getRetries() {
+    return 0;
+  }
+
+  @Override
+  public long getDeadline() {
+    return 0;
+  }
+
+  @Override
+  public String getVariables() {
+    return "";
+  }
+
+  @Override
+  public Map<String, Object> getVariablesAsMap() {
+    return new HashMap<String, Object>() {{
+      put("variable1", "value1");
+    }};
+  }
+
+  @Override
+  public <T> T getVariablesAsType(Class<T> variableType) {
+    return null;
+  }
+
+  @Override
+  public String toJson() {
+    return null;
+  }
+}


### PR DESCRIPTION
An alternative to @JobWorker annotation for a more programmatic worker registration:

```
DynamicJobWorkerRegistrar.newInstance(applicationContext)
                    .withJobName("boo")
                    .withJobType("boo")
                    .withHandler(taskReceivedEvent -> {
                        System.out.println(" ==> Received: " + taskReceivedEvent.getVariables());
                    }).build();
```

Or

```
DynamicJobWorkerRegistrar.newInstance(applicationContext)
                    .withJobName("boo")
                    .withJobType("boo")
                    .emitSpringApplicationEvent(true)
.build();

// In this case, this will emit TaskReceivedEvent as a Spring application Event and can be consumed by standard spring application event listeners.
```
