### PR TITLE
feat(connectors): add endpoint to retrieve active inbound connectors

### DIFF
--- a/connector-runtime/src/main/java/io/camunda/connector/runtime/inbound/lifecycle/ActiveInboundConnectorResponse.java
+++ b/connector-runtime/src/main/java/io/camunda/connector/runtime/inbound/lifecycle/ActiveInboundConnectorResponse.java
@@ -1,0 +1,57 @@
+package io.camunda.connector.runtime.inbound.lifecycle;
+
+import java.util.Map;
+import java.util.Objects;
+
+public class ActiveInboundConnectorResponse {
+  private final String bpmnProcessId;
+  private final String type;
+  private final Map<String, Object> data;
+
+  public ActiveInboundConnectorResponse(
+    final String bpmnProcessId, final String type, final Map<String, Object> data) {
+
+    this.bpmnProcessId = bpmnProcessId;
+    this.type = type;
+    this.data = data;
+  }
+
+  public String getBpmnProcessId() {
+    return bpmnProcessId;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public Map<String, Object> getData() {
+    return data;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ActiveInboundConnectorResponse that = (ActiveInboundConnectorResponse) o;
+    return Objects.equals(bpmnProcessId, that.bpmnProcessId) && Objects.equals(
+      type, that.type) && Objects.equals(data, that.data);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(bpmnProcessId, type, data);
+  }
+
+  @Override
+  public String toString() {
+    return "InboundConnectorResponse{" +
+      "bpmnProcessId='" + bpmnProcessId + '\'' +
+      ", type='" + type + '\'' +
+      ", data=" + data +
+      '}';
+  }
+}

--- a/connector-runtime/src/main/java/io/camunda/connector/runtime/inbound/lifecycle/InboundConnectorManager.java
+++ b/connector-runtime/src/main/java/io/camunda/connector/runtime/inbound/lifecycle/InboundConnectorManager.java
@@ -82,6 +82,10 @@ public class InboundConnectorManager {
     }
   }
 
+  public Map<String, Set<InboundConnectorProperties>> getActiveConnectorsByBpmnId() {
+    return activeConnectorsByBpmnId;
+  }
+
   private void handleLatestBpmnVersion(String bpmnId, List<InboundConnectorProperties> connectors) {
     var alreadyActiveConnectors = activeConnectorsByBpmnId.get(bpmnId);
     if (alreadyActiveConnectors != null) {

--- a/connector-runtime/src/main/java/io/camunda/connector/runtime/inbound/lifecycle/InboundConnectorRestController.java
+++ b/connector-runtime/src/main/java/io/camunda/connector/runtime/inbound/lifecycle/InboundConnectorRestController.java
@@ -1,0 +1,71 @@
+package io.camunda.connector.runtime.inbound.lifecycle;
+
+import io.camunda.connector.impl.inbound.InboundConnectorProperties;
+import io.camunda.connector.runtime.inbound.webhook.WebhookConnectorProperties;
+import io.camunda.connector.runtime.inbound.webhook.WebhookConnectorRegistry;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class InboundConnectorRestController {
+
+  private final InboundConnectorManager inboundManager;
+
+  public InboundConnectorRestController(InboundConnectorManager inboundManager) {
+    this.inboundManager = inboundManager;
+  }
+
+  @GetMapping("/inbound")
+  public List<ActiveInboundConnectorResponse> getActiveInboundConnectors(
+    @RequestParam(required = false) String type,
+    @RequestParam(required = false) String bpmnProcessId) {
+
+    var activeConnectors = inboundManager.getActiveConnectorsByBpmnId();
+    var filteredByBpmnProcessId = filterByBpmnProcessId(activeConnectors, bpmnProcessId);
+    var filteredByType = filterByType(filteredByBpmnProcessId, type);
+
+    // TODO: replace this with a general solution
+    // e.g. consider an optional method in InboundConnectorExecutable that returns data to be shown in Modeler
+    return filteredByType.stream()
+      .map(
+        properties ->
+          new ActiveInboundConnectorResponse(
+            properties.getBpmnProcessId(), properties.getType(), extractData(properties)))
+      .collect(Collectors.toList());
+  }
+
+  private List<InboundConnectorProperties> filterByBpmnProcessId(
+    Map<String, Set<InboundConnectorProperties>> connectors, String bpmnProcessId) {
+    if (bpmnProcessId != null) {
+      return new ArrayList<>(connectors.get(bpmnProcessId));
+    }
+    return connectors.values().stream()
+      .flatMap(Collection::stream)
+      .collect(Collectors.toList());
+  }
+
+  private List<InboundConnectorProperties> filterByType(
+    List<InboundConnectorProperties> properties, String type) {
+    if (type == null) {
+      return properties;
+    }
+    return properties.stream()
+      .filter(props -> type.equals(props.getType()))
+      .collect(Collectors.toList());
+  }
+
+  private Map<String, Object> extractData(InboundConnectorProperties properties) {
+    if (WebhookConnectorRegistry.TYPE_WEBHOOK.equals(properties.getType())) {
+      WebhookConnectorProperties webhookProps = new WebhookConnectorProperties(properties);
+      return Map.of("path", webhookProps.getContext());
+    }
+    return null;
+  }
+}

--- a/connector-runtime/src/main/java/io/camunda/connector/runtime/inbound/lifecycle/InboundConnectorRestController.java
+++ b/connector-runtime/src/main/java/io/camunda/connector/runtime/inbound/lifecycle/InboundConnectorRestController.java
@@ -29,7 +29,7 @@ public class InboundConnectorRestController {
 
     var activeConnectors = inboundManager.getActiveConnectorsByBpmnId();
     var filteredByBpmnProcessId = filterByBpmnProcessId(activeConnectors, bpmnProcessId);
-    var filteredByType = filterByType(filteredByBpmnProcessId, type);
+    var filteredByType = filterByConnectorType(filteredByBpmnProcessId, type);
 
     // TODO: replace this with a general solution
     // e.g. consider an optional method in InboundConnectorExecutable that returns data to be shown in Modeler
@@ -37,7 +37,7 @@ public class InboundConnectorRestController {
       .map(
         properties ->
           new ActiveInboundConnectorResponse(
-            properties.getBpmnProcessId(), properties.getType(), extractData(properties)))
+            properties.getBpmnProcessId(), properties.getType(), extractPublicConnectorData(properties)))
       .collect(Collectors.toList());
   }
 
@@ -51,7 +51,7 @@ public class InboundConnectorRestController {
       .collect(Collectors.toList());
   }
 
-  private List<InboundConnectorProperties> filterByType(
+  private List<InboundConnectorProperties> filterByConnectorType(
     List<InboundConnectorProperties> properties, String type) {
     if (type == null) {
       return properties;
@@ -61,7 +61,7 @@ public class InboundConnectorRestController {
       .collect(Collectors.toList());
   }
 
-  private Map<String, Object> extractData(InboundConnectorProperties properties) {
+  private Map<String, Object> extractPublicConnectorData(InboundConnectorProperties properties) {
     if (WebhookConnectorRegistry.TYPE_WEBHOOK.equals(properties.getType())) {
       WebhookConnectorProperties webhookProps = new WebhookConnectorProperties(properties);
       return Map.of("path", webhookProps.getContext());


### PR DESCRIPTION
Adds an endpoint to retrieve all active inbound connectors.

**Sample response structure:**
```
[
  {
    "bpmnProcessId": "8b1a3ac7-2edd-4d54-9c65-aa983c65edd8",
    "type": "io.camunda:webhook:1",
    "data": {
      "path": "my-inbound-connector-path"
    },
    {
    "bpmnProcessId": "8b1a3ac7-2edd-4d54-9c65-aa983c65edd8",
    "type": "io.camunda:webhook:1",
    "data": {
      "path": "my-other-inbound-connector-path"
    }
  }
]
```

**Current limitations:**
In Spring Zeebe runtime, we only know about the internals of the Webhook Connector. The Runtime can't possibly know what data should be displayed in the Modeler for generic inbound connectors (e.g. various subscriptions).

We will need to evolve this into a more robust and generic solution, that would allow Connector developers to indicate what information about the inbound connector execution should be displayed in the Modeler.

related to #342 