### PR TITLE
fix(connectors): handle disable webhook correctly, return 404

### DIFF
--- a/connector-runtime/src/main/java/io/camunda/connector/runtime/inbound/webhook/WebhookConnectorRegistry.java
+++ b/connector-runtime/src/main/java/io/camunda/connector/runtime/inbound/webhook/WebhookConnectorRegistry.java
@@ -23,7 +23,8 @@ public class WebhookConnectorRegistry {
     new HashMap<>();
 
   public boolean containsContextPath(String context) {
-    return activeEndpointsByContext.containsKey(context);
+    return activeEndpointsByContext.containsKey(context) &&
+      !activeEndpointsByContext.get(context).isEmpty();
   }
 
   public List<InboundConnectorContext> getWebhookConnectorByContextPath(String context) {

--- a/connector-runtime/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerPlainJavaTests.java
+++ b/connector-runtime/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerPlainJavaTests.java
@@ -18,6 +18,7 @@
 package io.camunda.connector.runtime.inbound;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -129,6 +130,24 @@ public class WebhookControllerPlainJavaTests {
     Collection<InboundConnectorContext> connectors2 =
         webhook.getWebhookConnectorByContextPath("myPath2");
     assertEquals(0, connectors2.size()); // No one - as it was disabled
+  }
+
+  @Test
+  public void webhookDeactivation_shouldReturnNotFound() {
+    WebhookConnectorRegistry webhook = new WebhookConnectorRegistry();
+
+    // given
+    var processA1 = new InboundConnectorContextBuilder()
+      .properties(webhookProperties("processA", 1, "myPath"))
+      .secret(CONNECTOR_SECRET_NAME, CONNECTOR_SECRET_VALUE)
+      .build();
+
+    //when
+    webhook.activateEndpoint(processA1);
+    webhook.deactivateEndpoint(processA1.getProperties());
+
+    // then
+    assertFalse(webhook.containsContextPath("myPath"));
   }
 
   private static long nextProcessDefinitionKey = 0L;


### PR DESCRIPTION
Adds another check to webhook `containsContextPath` method, so that webhook endpoint consistently returns 404 in both cases:
- if webhook has not been activated
- if webhook was deactivated by deploying a new process definition without connector

closes #370 