### PR TITLE
fix: `ZeebeClientConfigurationProperties` doesn't work with Spring Boot 3

### DIFF
--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java
@@ -74,7 +74,8 @@ public class ZeebeClientConfigurationProperties implements ZeebeClientConfigurat
   @Autowired(required = false)
   private List<ClientInterceptor> interceptors;
 
-  public ZeebeClientConfigurationProperties(@Autowired org.springframework.core.env.Environment environment) {
+  @Autowired
+  public ZeebeClientConfigurationProperties(org.springframework.core.env.Environment environment) {
     this.environment = environment;
   }
 


### PR DESCRIPTION
### Description

Moved `@Autowired` to the constructor level to comply with the [changes in Spring Boot 3](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0.0-M2-Release-Notes#improved-constructorbinding-detection).
See also the related issue for more context.

### Related issues
closes #382 