### PR TITLE
feat(connectors): bump connector-sdk

### DIFF
--- a/connector-runtime/src/main/java/io/camunda/connector/runtime/inbound/lifecycle/InboundConnectorManager.java
+++ b/connector-runtime/src/main/java/io/camunda/connector/runtime/inbound/lifecycle/InboundConnectorManager.java
@@ -123,6 +123,7 @@ public class InboundConnectorManager {
         "Inbound connector failed at correlation point " + newProperties.getCorrelationPointId(),
         throwable);
       // TODO: store error for user's convenience
+      // (see https://github.com/camunda-community-hub/spring-zeebe/issues/401)
       deactivateConnector(newProperties);
     };
 

--- a/connector-runtime/src/main/java/io/camunda/connector/runtime/inbound/lifecycle/InboundConnectorManager.java
+++ b/connector-runtime/src/main/java/io/camunda/connector/runtime/inbound/lifecycle/InboundConnectorManager.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -117,10 +118,18 @@ public class InboundConnectorManager {
   private void activateConnector(InboundConnectorProperties newProperties) {
 
     InboundConnectorExecutable executable = connectorFactory.getInstance(newProperties.getType());
+    Consumer<Throwable> cancellationCallback = throwable -> {
+      LOG.error(
+        "Inbound connector failed at correlation point " + newProperties.getCorrelationPointId(),
+        throwable);
+      // TODO: store error for user's convenience
+      deactivateConnector(newProperties);
+    };
 
     try {
       executable.activate(
-        new InboundConnectorContextImpl(secretProvider, newProperties, correlationHandler));
+        new InboundConnectorContextImpl(
+          secretProvider, newProperties, correlationHandler, cancellationCallback));
 
       activeConnectorsByCorrelationPointId.put(newProperties.getCorrelationPointId(), executable);
       activeConnectorsByBpmnId.compute(

--- a/connector-runtime/src/main/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestController.java
+++ b/connector-runtime/src/main/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestController.java
@@ -112,7 +112,7 @@ public class InboundWebhookRestController {
             response.addUnactivatedConnector(connectorProperties);
           } else {
             Map<String, Object> variables = extractVariables(connectorProperties, webhookContext);
-            InboundConnectorResult result = connectorContext.correlate(variables);
+            InboundConnectorResult<?> result = connectorContext.correlate(variables);
 
             LOG.debug(
                 "Webhook {} created process instance {}",
@@ -155,6 +155,7 @@ public class InboundWebhookRestController {
     return validator.isRequestValid();
   }
 
+  @Deprecated
   private Map<String, Object> extractVariables(
           WebhookConnectorProperties connectorProperties, Map<String, Object> context) {
 
@@ -162,10 +163,15 @@ public class InboundWebhookRestController {
     if (variableMapping == null) {
       return context;
     }
+    // Variable mapping is now supported on the Connector SDK level (see InboundConnectorProperties).
+    // We still support the old property for backwards compatibility.
+    LOG.warn("Usage of deprecated property `inbound.variableMapping`. "
+      + "Use `resultVariable` and `resultExpression` properties instead.");
+
     return feelEngine.evaluate(variableMapping, context);
-    //      throw fail("Failed to extract variables", connectorProperties, exception);
   }
 
+  @Deprecated
   private boolean activationConditionTriggered(
           WebhookConnectorProperties connectorProperties, Map<String, Object> context) {
 
@@ -174,8 +180,10 @@ public class InboundWebhookRestController {
     if (activationCondition == null || activationCondition.trim().length()==0) {
       return true;
     }
+    // Activation condition is now supported on the Connector SDK level (see InboundConnectorProperties).
+    // We still support the old property for backwards compatibility.
+    LOG.warn("Usage of deprecated property `inbound.activationCondition`. Use `activationCondition` instead.");
     Object shouldActivate = feelEngine.evaluate(activationCondition, context);
     return Boolean.TRUE.equals(shouldActivate);
-    //      throw fail("Failed to check activation", connectorProperties, exception);
   }
 }

--- a/connector-runtime/src/main/java/io/camunda/connector/runtime/inbound/webhook/WebhookConnectorProperties.java
+++ b/connector-runtime/src/main/java/io/camunda/connector/runtime/inbound/webhook/WebhookConnectorProperties.java
@@ -16,8 +16,8 @@
 package io.camunda.connector.runtime.inbound.webhook;
 
 import io.camunda.connector.api.annotation.Secret;
-import io.camunda.connector.api.inbound.ProcessCorrelationPoint;
 import io.camunda.connector.impl.inbound.InboundConnectorProperties;
+import io.camunda.connector.impl.inbound.ProcessCorrelationPoint;
 import io.camunda.connector.runtime.inbound.signature.HMACSwitchCustomerChoice;
 import java.util.Objects;
 

--- a/connector-runtime/src/main/resources/application.properties
+++ b/connector-runtime/src/main/resources/application.properties
@@ -3,6 +3,7 @@ camunda.connector.polling.enabled=false
 camunda.connector.polling.interval=5000
 
 camunda.connector.webhook.enabled=false
+spring.main.web-application-type=none
 
 operate.client.enabled=true
 

--- a/connector-runtime/src/main/resources/application.properties
+++ b/connector-runtime/src/main/resources/application.properties
@@ -3,7 +3,6 @@ camunda.connector.polling.enabled=false
 camunda.connector.polling.interval=5000
 
 camunda.connector.webhook.enabled=false
-spring.main.web-application-type=none
 
 operate.client.enabled=true
 

--- a/connector-runtime/src/test/java/io/camunda/connector/runtime/inbound/TestInboundConnector.java
+++ b/connector-runtime/src/test/java/io/camunda/connector/runtime/inbound/TestInboundConnector.java
@@ -7,13 +7,22 @@ import io.camunda.connector.api.inbound.InboundConnectorExecutable;
 @InboundConnector(name = "TEST_INBOUND", type = "io.camunda:test-inbound:1")
 public class TestInboundConnector implements InboundConnectorExecutable {
 
+  private InboundConnectorContext context;
+
   @Override
   public void activate(InboundConnectorContext context) {
-
+    this.context = context;
   }
 
   @Override
   public void deactivate() {
 
+  }
+
+  public InboundConnectorContext getProvidedContext() {
+    if (context == null) {
+      throw new IllegalStateException("Connector has not been activated yet. No context available.");
+    }
+    return context;
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <zeebe.version>8.1.5</zeebe.version>
 
-    <connector.version>0.7.0</connector.version>
+    <connector.version>0.8.0-alpha2</connector.version>
     <version.operate-client>8.1.7.2</version.operate-client>
 
     <spring-boot.version>2.7.7</spring-boot.version>

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/OperateClientProdAutoConfiguration.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/OperateClientProdAutoConfiguration.java
@@ -8,7 +8,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
 @ConditionalOnProperty(prefix = "operate.client", name = "enabled", havingValue = "true",  matchIfMissing = false)
 @ConditionalOnMissingBean(SpringZeebeTestContext.class)


### PR DESCRIPTION
Adjustments to Connector runtime to support the [changes in the Connector SDK](https://github.com/camunda/connector-sdk/pull/411):

- Variable mapping and activation condition check are now handled centrally in the SDK (added deprecation warning to legacy checks in webhook connector)
- Adjustments to support slightly changed APIs
- Cancellation callback handling (initial simple implementation, just deregisters the connector without storing the error). Will be improved as a follow up: #401 