### PR TITLE
chore(operate-client): introduced retry mechanism on create

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
 
     <spring-boot.version>2.7.7</spring-boot.version>
     <commons-beanutils.version>1.9.4</commons-beanutils.version>
+    <resilience4j.version>2.0.2</resilience4j.version>
 
     <plugin.version.javadoc>3.1.1</plugin.version.javadoc>
     <!-- disable jdk8 javadoc checks on release build -->
@@ -149,6 +150,11 @@
         <groupId>commons-beanutils</groupId>
         <artifactId>commons-beanutils</artifactId>
         <version>${commons-beanutils.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.resilience4j</groupId>
+        <artifactId>resilience4j-retry</artifactId>
+        <version>${resilience4j.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/spring-boot-starter-camunda/pom.xml
+++ b/spring-boot-starter-camunda/pom.xml
@@ -43,6 +43,10 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>io.github.resilience4j</groupId>
+      <artifactId>resilience4j-retry</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/OperateClientProdAutoConfiguration.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/OperateClientProdAutoConfiguration.java
@@ -4,22 +4,48 @@ import io.camunda.operate.CamundaOperateClient;
 import io.camunda.operate.exception.OperateException;
 import io.camunda.zeebe.spring.client.properties.OperateClientConfigurationProperties;
 import io.camunda.zeebe.spring.client.testsupport.SpringZeebeTestContext;
+import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.retry.RetryConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+
+import java.lang.invoke.MethodHandles;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.function.Supplier;
 
 @ConditionalOnProperty(prefix = "operate.client", name = "enabled", havingValue = "true",  matchIfMissing = false)
 @ConditionalOnMissingBean(SpringZeebeTestContext.class)
 @EnableConfigurationProperties(OperateClientConfigurationProperties.class)
 public class OperateClientProdAutoConfiguration {
 
+  private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
   @Bean
-  public CamundaOperateClient camundaOperateClient(OperateClientConfigurationProperties props) throws OperateException {
+  public CamundaOperateClient camundaOperateClient(OperateClientConfigurationProperties props) {
     String operateUrl = props.getOperateUrl();
-    return new CamundaOperateClient.Builder()
-      .operateUrl(operateUrl)
-      .authentication(props.getAuthentication(operateUrl))
+
+    // Giving 2 minutes for Operate to start-up
+    RetryConfig config = RetryConfig.custom()
+      .maxAttempts(24)
+      .waitDuration(Duration.of(5, ChronoUnit.SECONDS))
       .build();
+    Retry retry = Retry.of("camundaOperateClient", config);
+
+    return retry.executeSupplier(() -> {
+      try {
+        return new CamundaOperateClient.Builder()
+          .operateUrl(operateUrl)
+          .authentication(props.getAuthentication(operateUrl))
+          .build();
+      } catch (OperateException e) {
+        LOG.warn("An attempt to connect to Operate failed: " + e);
+        throw new RuntimeException(e);
+      }
+    });
   }
 }


### PR DESCRIPTION
## Description

Currently, if the operate failed to start-up before connectors, the whole Spring Zeebe runtime crashes.
This happens in 100% of cases when launching with `camunda-platform`.

Output logs on startup:

```
2023-04-06 13:02:29.662  WARN 17490 --- [           main] s.c.c.OperateClientProdAutoConfiguration : An attempt to connect to Operate failed: io.camunda.operate.exception.OperateException: org.apache.hc.client5.http.HttpHostConnectException: Connect to http://localhost:8081 [localhost/127.0.0.1, localhost/0:0:0:0:0:0:0:1] failed: Connection refused
2023-04-06 13:02:34.677  WARN 17490 --- [           main] s.c.c.OperateClientProdAutoConfiguration : An attempt to connect to Operate failed: io.camunda.operate.exception.OperateException: org.apache.hc.client5.http.HttpHostConnectException: Connect to http://localhost:8081 [localhost/127.0.0.1, localhost/0:0:0:0:0:0:0:1] failed: Connection refused
2023-04-06 13:02:39.692  WARN 17490 --- [           main] s.c.c.OperateClientProdAutoConfiguration : An attempt to connect to Operate failed: io.camunda.operate.exception.OperateException: org.apache.hc.client5.http.HttpHostConnectException: Connect to http://localhost:8081 [localhost/127.0.0.1, localhost/0:0:0:0:0:0:0:1] failed: Connection refused
2023-04-06 13:02:44.706  WARN 17490 --- [           main] s.c.c.OperateClientProdAutoConfiguration : An attempt to connect to Operate failed: io.camunda.operate.exception.OperateException: org.apache.hc.client5.http.HttpHostConnectException: Connect to http://localhost:8081 [localhost/127.0.0.1, localhost/0:0:0:0:0:0:0:1] failed: Connection refused
2023-04-06 13:02:49.733  WARN 17490 --- [           main] s.c.c.OperateClientProdAutoConfiguration : An attempt to connect to Operate failed: io.camunda.operate.exception.OperateException: org.apache.hc.client5.http.HttpHostConnectException: Connect to http://localhost:8081 [localhost/127.0.0.1, localhost/0:0:0:0:0:0:0:1] failed: Connection refused
2023-04-06 13:02:54.749  WARN 17490 --- [           main] s.c.c.OperateClientProdAutoConfiguration : An attempt to connect to Operate failed: io.camunda.operate.exception.OperateException: org.apache.hc.client5.http.HttpHostConnectException: Connect to http://localhost:8081 [localhost/127.0.0.1, localhost/0:0:0:0:0:0:0:1] failed: Connection refused
2023-04-06 13:02:59.761  WARN 17490 --- [           main] s.c.c.OperateClientProdAutoConfiguration : An attempt to connect to Operate failed: io.camunda.operate.exception.OperateException: org.apache.hc.client5.http.HttpHostConnectException: Connect to http://localhost:8081 [localhost/127.0.0.1, localhost/0:0:0:0:0:0:0:1] failed: Connection refused
2023-04-06 13:03:04.776  WARN 17490 --- [           main] s.c.c.OperateClientProdAutoConfiguration : An attempt to connect to Operate failed: io.camunda.operate.exception.OperateException: org.apache.hc.client5.http.HttpHostConnectException: Connect to http://localhost:8081 [localhost/127.0.0.1, localhost/0:0:0:0:0:0:0:1] failed: Connection refused
```