### PR TITLE
feat(inbound): add parsing for x-www-form-urlencoded content type

### DIFF
--- a/connector-runtime/src/main/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestController.java
+++ b/connector-runtime/src/main/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestController.java
@@ -76,7 +76,7 @@ public class InboundWebhookRestController {
   public ResponseEntity<WebhookResponse> inbound(
       @PathVariable String context,
       @RequestBody(required = false) byte[] bodyAsByteArray, // raw form required to calculate HMAC
-      @RequestHeader Map<String, String> headers)
+      @RequestHeader Map<String, String> headers, @RequestHeader(value = "Content-type", required = false) String contentType)
       throws IOException {
 
     LOG.debug("Received inbound hook on {}", context);
@@ -89,9 +89,8 @@ public class InboundWebhookRestController {
 
     // TODO(nikku): what context do we expose?
     // TODO(igpetrov): handling exceptions? Throw or fail? Maybe spring controller advice?
-    boolean isURLFormContentType = Optional.ofNullable(headers)
-      .map(headersValue -> headersValue.entrySet().stream()
-        .anyMatch(header -> header.getValue().equalsIgnoreCase("application/x-www-form-urlencoded")))
+    boolean isURLFormContentType = Optional.ofNullable(contentType)
+      .map(contentHeaderType -> contentHeaderType.equalsIgnoreCase("application/x-www-form-urlencoded"))
       .orElse(false);
 
     Map<String, String> bodyAsMap;

--- a/connector-runtime/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerPlainJavaTests.java
+++ b/connector-runtime/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerPlainJavaTests.java
@@ -79,7 +79,7 @@ public class WebhookControllerPlainJavaTests {
     webhook.activateEndpoint(webhookB);
 
     ResponseEntity<WebhookResponse> responseEntity =
-        controller.inbound("myPath", "{}".getBytes(), new HashMap<>());
+        controller.inbound("myPath", "{}".getBytes(), new HashMap<>(), "application/json");
 
     assertEquals(200, responseEntity.getStatusCode().value());
     assertTrue(responseEntity.getBody().getUnauthorizedConnectors().isEmpty());

--- a/connector-runtime/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerTestZeebeTests.java
+++ b/connector-runtime/src/test/java/io/camunda/connector/runtime/inbound/WebhookControllerTestZeebeTests.java
@@ -95,7 +95,7 @@ class WebhookControllerTestZeebeTests {
     webhook.activateEndpoint(webhookB);
 
     ResponseEntity<WebhookResponse> responseEntity =
-        controller.inbound("myPath", "{}".getBytes(), new HashMap<>());
+        controller.inbound("myPath", "{}".getBytes(), new HashMap<>(), "application/json");
 
     assertEquals(200, responseEntity.getStatusCode().value());
     assertTrue(responseEntity.getBody().getUnauthorizedConnectors().isEmpty());

--- a/connector-runtime/src/test/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestControllerTest.java
+++ b/connector-runtime/src/test/java/io/camunda/connector/runtime/inbound/webhook/InboundWebhookRestControllerTest.java
@@ -91,7 +91,7 @@ class InboundWebhookRestControllerTest {
     when(feelEngine.evaluate(eq(variablesMapping), any(Map.class))).thenReturn(Map.of());
 
     ResponseEntity<WebhookResponse> response =
-        controller.inbound(DEFAULT_CONTEXT, DEFAULT_REQUEST_BODY, DEFAULT_HEADERS);
+        controller.inbound(DEFAULT_CONTEXT, DEFAULT_REQUEST_BODY, DEFAULT_HEADERS, "application/json");
 
     verify(connectorContext).replaceSecrets(props);
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -125,7 +125,7 @@ class InboundWebhookRestControllerTest {
       .thenReturn(List.of(connectorContext));
 
     ResponseEntity<WebhookResponse> response =
-      controller.inbound(DEFAULT_CONTEXT, FORM_URL_REQUEST_BODY.getBytes(), HEADERS);
+      controller.inbound(DEFAULT_CONTEXT, FORM_URL_REQUEST_BODY.getBytes(), HEADERS, "application/x-www-form-urlencoded");
 
     verify(connectorContext).replaceSecrets(props);
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -141,7 +141,7 @@ class InboundWebhookRestControllerTest {
     when(registry.containsContextPath(DEFAULT_CONTEXT)).thenReturn(false);
     assertThrows(
         ResponseStatusException.class,
-        () -> controller.inbound(DEFAULT_CONTEXT, DEFAULT_REQUEST_BODY, DEFAULT_HEADERS));
+        () -> controller.inbound(DEFAULT_CONTEXT, DEFAULT_REQUEST_BODY, DEFAULT_HEADERS, "application/json"));
   }
 
   @Test
@@ -171,7 +171,7 @@ class InboundWebhookRestControllerTest {
       .thenReturn(List.of(connectorContext));
 
     ResponseEntity<WebhookResponse> response =
-        controller.inbound(DEFAULT_CONTEXT, DEFAULT_REQUEST_BODY, DEFAULT_HEADERS);
+        controller.inbound(DEFAULT_CONTEXT, DEFAULT_REQUEST_BODY, DEFAULT_HEADERS, "application/json");
 
     verify(connectorContext).replaceSecrets(props);
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -212,7 +212,7 @@ class InboundWebhookRestControllerTest {
     when(feelEngine.evaluate(anyString(), any(Map.class))).thenReturn(false);
 
     ResponseEntity<WebhookResponse> response =
-        controller.inbound(DEFAULT_CONTEXT, DEFAULT_REQUEST_BODY, DEFAULT_HEADERS);
+        controller.inbound(DEFAULT_CONTEXT, DEFAULT_REQUEST_BODY, DEFAULT_HEADERS, "application/json");
 
     verify(connectorContext).replaceSecrets(props);
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -255,7 +255,7 @@ class InboundWebhookRestControllerTest {
         .thenThrow(new RuntimeException(exceptionMessage));
 
     ResponseEntity<WebhookResponse> response =
-        controller.inbound(DEFAULT_CONTEXT, DEFAULT_REQUEST_BODY, DEFAULT_HEADERS);
+        controller.inbound(DEFAULT_CONTEXT, DEFAULT_REQUEST_BODY, DEFAULT_HEADERS, "application/json");
 
     verify(connectorContext).replaceSecrets(props);
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -294,7 +294,7 @@ class InboundWebhookRestControllerTest {
       .thenReturn(List.of(connectorContext));
 
     ResponseEntity<WebhookResponse> response =
-      controller.inbound(DEFAULT_CONTEXT, null, DEFAULT_HEADERS);
+      controller.inbound(DEFAULT_CONTEXT, null, DEFAULT_HEADERS, "application/json");
 
     verify(connectorContext).replaceSecrets(props);
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -332,7 +332,7 @@ class InboundWebhookRestControllerTest {
       .thenReturn(List.of(connectorContext));
 
     ResponseEntity<WebhookResponse> response =
-      controller.inbound(DEFAULT_CONTEXT, null, DEFAULT_HEADERS);
+      controller.inbound(DEFAULT_CONTEXT, null, DEFAULT_HEADERS, "application/json");
 
     verify(connectorContext).replaceSecrets(props);
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);


### PR DESCRIPTION
Add parsing for x-www-form-urlencoded content type in InboundWebhookRestController.
Can be merged only in new repository, because: https://github.com/camunda-community-hub/spring-zeebe/pull/418#issuecomment-1523501401

Blocked by https://github.com/camunda/connectors-bundle/pull/493