### PR TITLE
Updated README.md to match #275

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,15 +78,7 @@ zeebe.client.connection-mode=ADDRESS
 
 ## Connect to Zeebe
 
-Add the `@EnableZeebeClient` annotation to your Spring Boot Application:
-
-```java
-@SpringBootApplication
-@EnableZeebeClient
-public class MySpringBootApplication {
-```
-
-Now you can inject the ZeebeClient and work with it, e.g. to create new workflow instances:
+You can inject the ZeebeClient and work with it, e.g. to create new workflow instances:
 
 ```java
 @Autowired


### PR DESCRIPTION
Deleted unnecessary advice to use `@EnableZeebeClient` for enabling the ZeebeClient.
The annotation is deprecated after implementation of #275.