### PR TITLE
chore(connectors): rm connectors runtime util

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,11 +78,6 @@
       </dependency>
       <dependency>
         <groupId>io.camunda.connector</groupId>
-        <artifactId>connector-runtime-util</artifactId>
-        <version>${connector.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.camunda.connector</groupId>
         <artifactId>connector-validation</artifactId>
         <version>${connector.version}</version>
       </dependency>

--- a/spring-client-zeebe/pom.xml
+++ b/spring-client-zeebe/pom.xml
@@ -19,10 +19,6 @@
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-client-java</artifactId>
     </dependency>
-    <dependency>
-      <groupId>io.camunda.connector</groupId>
-      <artifactId>connector-runtime-util</artifactId>
-    </dependency>
 
     <dependency>
       <groupId>commons-beanutils</groupId>


### PR DESCRIPTION
This module was removed from the Connnector SDK.

It is no longer required in Spring Zeebe either, since the Connector runtime was moved to another project.