### PR TITLE
@JobWorker: Pass custom args to business method

### DIFF
--- a/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/bean/MethodInfo.java
+++ b/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/bean/MethodInfo.java
@@ -19,10 +19,10 @@ public class MethodInfo implements BeanInfo {
 
   private static LocalVariableTableParameterNameDiscoverer parameterNameDiscoverer = new LocalVariableTableParameterNameDiscoverer();
 
-  private ClassInfo classInfo;
-  private Method method;
+  protected ClassInfo classInfo;
+  protected Method method;
 
-  private MethodInfo(ClassInfo classInfo, Method method) {
+  protected MethodInfo(ClassInfo classInfo, Method method) {
     this.classInfo = classInfo;
     this.method = method;
   }

--- a/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/bean/MethodInfo.java
+++ b/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/bean/MethodInfo.java
@@ -27,6 +27,11 @@ public class MethodInfo implements BeanInfo {
     this.method = method;
   }
 
+  protected MethodInfo(MethodInfo original) {
+    this.classInfo = original.classInfo;
+    this.method = original.method;
+  }
+
   @Override
   public Object getBean() {
     return classInfo.getBean();


### PR DESCRIPTION
As mentioned in issue #426 we want to hide some aspects needed for each of the service-tasks. One thing we do is do pass entity loaded from a repository to the business method.

This PR is about some minor adoptions to leverage `ZeebeWorkerValueCustomizer` this purpose by injecting a custom `MethodInfo` which is aware of the new parameters. For this some minor adopts of `MethodInfo` is needed to make the class extendable.

We tested this within the last month and it works fine. We would be glad to see this merged 😄 .