### PR TITLE
Update to current artifact, replacing the deprecated coordindates

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Add the following Maven dependency to your Spring Boot Starter project:
 
 ```xml
 <dependency>
-  <groupId>io.camunda</groupId>
-  <artifactId>spring-zeebe-starter</artifactId>
-  <version>8.2.1</version>
+  <groupId>io.camunda.spring</groupId>
+  <artifactId>spring-boot-starter-camunda</artifactId>
+  <version>8.2.3</version>
 </dependency>
 ```
 


### PR DESCRIPTION
Please double check: this documentation seems out-dated because the artifact was moved to `io.camunda.spring:spring-boot-starter-camunda`