### PR TITLE
bugfix OperateClientConfigurationProperties.java

### DIFF
--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/properties/OperateClientConfigurationProperties.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/properties/OperateClientConfigurationProperties.java
@@ -94,13 +94,13 @@ public class OperateClientConfigurationProperties {
       if (operateKeycloakUrl != null || operateKeycloakTokenUrl!=null) {
         if (clientId!=null && clientSecret !=null) {
           SelfManagedAuthentication authentication = new SelfManagedAuthentication(clientId, clientSecret);
-          if (operateKeycloakUrl!=null) {
+          if (operateKeycloakTokenUrl!=null && !operateKeycloakTokenUrl.equals("")) {
+            LOG.debug("Authenticating with Camunda Operate using Keycloak token url " + operateKeycloakTokenUrl);
+            return authentication.keycloakTokenUrl(operateKeycloakTokenUrl);
+          } else {
             LOG.debug("Authenticating with Camunda Operate using Keycloak on " + operateKeycloakUrl);
             return authentication.keycloakUrl(operateKeycloakUrl)
               .keycloakRealm(operateKeycloakRealm);
-          } else {
-            LOG.debug("Authenticating with Camunda Operate using Keycloak token url " + operateKeycloakTokenUrl);
-            return authentication.keycloakTokenUrl(operateKeycloakTokenUrl);
           }
         }
         


### PR DESCRIPTION
keycloak url is provided as a default from the helm charts and cannot easily be unset. So we should change the test order. If the keycloak token url is provided we use that, else we do the default.