### PR TITLE
Resolves #395 Add variables in ZeebeBpmnError

### DIFF
--- a/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/exception/ZeebeBpmnError.java
+++ b/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/exception/ZeebeBpmnError.java
@@ -1,5 +1,7 @@
 package io.camunda.zeebe.spring.client.exception;
 
+import java.util.Map;
+
 /**
  * Indicates an error in sense of BPMN occured, that should be handled by the BPMN process,
  * see https://docs.camunda.io/docs/reference/bpmn-processes/error-events/error-events/
@@ -8,11 +10,19 @@ public class ZeebeBpmnError extends RuntimeException {
 
   private String errorCode;
   private String errorMessage;
+  private Map<String, Object> variables;
 
   public ZeebeBpmnError(String errorCode, String errorMessage) {
     super("[" + errorCode + "] " + errorMessage);
     this.errorCode = errorCode;
     this.errorMessage = errorMessage;
+  }
+
+  public ZeebeBpmnError(String errorCode, String errorMessage, Map<String, Object> variables) {
+    super("[" + errorCode + "] " + errorMessage);
+    this.errorCode = errorCode;
+    this.errorMessage = errorMessage;
+    this.variables = variables;
   }
 
   public String getErrorMessage() {
@@ -21,5 +31,9 @@ public class ZeebeBpmnError extends RuntimeException {
 
   public String getErrorCode() {
     return errorCode;
+  }
+
+  public Map<String, Object> getVariables() {
+    return variables;
   }
 }

--- a/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/jobhandling/JobHandlerInvokingSpringBeans.java
+++ b/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/jobhandling/JobHandlerInvokingSpringBeans.java
@@ -137,7 +137,8 @@ public class JobHandlerInvokingSpringBeans implements JobHandler {
   private FinalCommandStep<Void> createThrowErrorCommand(JobClient jobClient, ActivatedJob job, ZeebeBpmnError bpmnError) {
     FinalCommandStep<Void> command = jobClient.newThrowErrorCommand(job.getKey()) // TODO: PR for taking a job only in command chain
       .errorCode(bpmnError.getErrorCode())
-      .errorMessage(bpmnError.getErrorMessage());
+      .errorMessage(bpmnError.getErrorMessage())
+      .variables(bpmnError.getVariables());
     return command;
   }
 


### PR DESCRIPTION
As mentioned in #395, `zeebe-client-java` already supports sending variables along with the ThrowErrorCommand. This adds the ability to optionally update context variables when throwing `ZeebeBpmnError`