### PR TITLE
chore: Upgrade dependencies for multi-tenancy alpha support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,14 +20,13 @@
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
 
-    <zeebe.version>8.2.8</zeebe.version>
-
-    <connector.version>0.8.1</connector.version>
-    <version.operate-client>8.2.0</version.operate-client>
+    <zeebe.version>8.3.0-alpha4</zeebe.version>
+    <operate-client.version>8.3.0-alpha5</operate-client.version>
 
     <spring-boot.version>2.7.7</spring-boot.version>
     <commons-beanutils.version>1.9.4</commons-beanutils.version>
     <resilience4j.version>2.1.0</resilience4j.version>
+    <jackson.version>2.15.2</jackson.version>
 
     <plugin.version.javadoc>3.1.1</plugin.version.javadoc>
     <!-- disable jdk8 javadoc checks on release build -->
@@ -74,12 +73,7 @@
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>camunda-operate-client-java</artifactId>
-        <version>${version.operate-client}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.camunda.connector</groupId>
-        <artifactId>connector-validation</artifactId>
-        <version>${connector.version}</version>
+        <version>${operate-client.version}</version>
       </dependency>
       <dependency>
         <groupId>io.camunda</groupId>
@@ -91,7 +85,6 @@
         <artifactId>zeebe-process-test-extension-testcontainer</artifactId>
         <version>${zeebe.version}</version>
       </dependency>
-
       <dependency>
         <groupId>io.camunda.spring</groupId>
         <artifactId>spring-client-annotations</artifactId>
@@ -127,16 +120,25 @@
         <artifactId>spring-boot-starter-camunda-test-testcontainer</artifactId>
         <version>${project.version}</version>
       </dependency>
-
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-core</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-annotations</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
       <dependency>
         <groupId>org.awaitility</groupId>
         <artifactId>awaitility</artifactId>
         <version>4.2.0</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.module</groupId>
-        <artifactId>jackson-module-kotlin</artifactId>
-        <version>${kotlin-jackson.version}</version>
       </dependency>
       <dependency>
         <groupId>commons-beanutils</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
 
-    <zeebe.version>8.3.0-SNAPSHOT</zeebe.version>
+    <zeebe.version>8.3.0-rc1</zeebe.version>
     <operate-client.version>8.3.0-alpha5</operate-client.version>
 
     <spring-boot.version>2.7.7</spring-boot.version>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,6 @@
     <artifactId>community-hub-release-parent</artifactId>
     <version>1.4.3</version>
   </parent>
-
   <groupId>io.camunda.spring</groupId>
   <artifactId>spring-client-root</artifactId>
   <version>8.2.5-SNAPSHOT</version>
@@ -20,7 +19,7 @@
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
 
-    <zeebe.version>8.3.0-alpha4</zeebe.version>
+    <zeebe.version>8.3.0-SNAPSHOT</zeebe.version>
     <operate-client.version>8.3.0-alpha5</operate-client.version>
 
     <spring-boot.version>2.7.7</spring-boot.version>

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/ExecutorServiceConfiguration.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/ExecutorServiceConfiguration.java
@@ -33,6 +33,8 @@ public class ExecutorServiceConfiguration {
         threadPool, "zeebe_client_thread_pool", Collections.emptyList());
       threadPoolMetrics.bindTo(meterRegistry);
     }
+    configurationProperties.setScheduledExecutorService(threadPool);
+    configurationProperties.setOwnsJobWorkerExecutor(true);
     return new ZeebeClientExecutorService(threadPool);
   }
 }

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientAllAutoConfiguration.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientAllAutoConfiguration.java
@@ -1,8 +1,12 @@
 package io.camunda.zeebe.spring.client.configuration;
 
+import io.camunda.zeebe.client.ClientProperties;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.api.worker.BackoffSupplier;
+import io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl;
 import io.camunda.zeebe.client.impl.worker.ExponentialBackoffBuilderImpl;
+import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebePropertiesImpl;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeProperties;
 import io.camunda.zeebe.spring.client.annotation.customizer.ZeebeWorkerValueCustomizer;
 import io.camunda.zeebe.spring.client.annotation.processor.AnnotationProcessorConfiguration;
 import io.camunda.zeebe.spring.client.jobhandling.CommandExceptionHandlingStrategy;
@@ -25,6 +29,10 @@ public class ZeebeClientAllAutoConfiguration {
 
   private final ZeebeClientConfigurationProperties configurationProperties;
   public ZeebeClientAllAutoConfiguration(ZeebeClientConfigurationProperties configurationProperties) {
+    // TODO Remove workaround as soon as https://github.com/camunda/zeebe/issues/14176 is fixed
+    if(configurationProperties.getWorker().getDefaultName() == null) {
+      configurationProperties.getWorker().setDefaultName(ClientProperties.DEFAULT_JOB_WORKER_NAME);
+    }
     this.configurationProperties = configurationProperties;
   }
 

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java
@@ -47,6 +47,10 @@ public class ZeebeClientConfigurationProperties implements ZeebeClientConfigurat
    */
   private String connectionMode;
 
+  private String defaultTenantId = DEFAULT.getDefaultTenantId();
+
+  private List<String> defaultJobWorkerTenantIds = DEFAULT.getDefaultJobWorkerTenantIds();
+
   private boolean applyEnvironmentVariableOverrides = false; // the default is NOT to overwrite anything by environment variables in a Spring Boot world - it is unintuitive
 
   private boolean enabled = true;
@@ -82,6 +86,8 @@ public class ZeebeClientConfigurationProperties implements ZeebeClientConfigurat
   private ScheduledExecutorService scheduledExecutorService;
 
   private boolean ownsJobWorkerExecutor;
+
+  private boolean defaultJobWorkerStreamEnabled = DEFAULT.getDefaultJobWorkerStreamEnabled();
 
   @Autowired
   public ZeebeClientConfigurationProperties(org.springframework.core.env.Environment environment) {
@@ -121,6 +127,10 @@ public class ZeebeClientConfigurationProperties implements ZeebeClientConfigurat
       }
       if (worker.defaultName == null && environment.containsProperty(ClientProperties.DEFAULT_JOB_WORKER_NAME)) {
         worker.defaultName = environment.getProperty(ClientProperties.DEFAULT_JOB_WORKER_NAME);
+      }
+      // Support environment based default tenant id override if value is client default fallback
+      if ((defaultTenantId == null || defaultTenantId.equals(DEFAULT.getDefaultTenantId())) && environment.containsProperty(ClientProperties.DEFAULT_TENANT_ID)) {
+        defaultTenantId = environment.getProperty(ClientProperties.DEFAULT_TENANT_ID);
       }
     }
   }
@@ -641,6 +651,21 @@ public class ZeebeClientConfigurationProperties implements ZeebeClientConfigurat
     } else {
       return broker.getGatewayAddress();
     }
+  }
+
+  @Override
+  public String getDefaultTenantId() {
+    return defaultTenantId;
+  }
+
+  @Override
+  public List<String> getDefaultJobWorkerTenantIds() {
+    return defaultJobWorkerTenantIds;
+  }
+
+  @Override
+  public boolean getDefaultJobWorkerStreamEnabled() {
+    return defaultJobWorkerStreamEnabled;
   }
 
   public String getConnectionMode() {

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java
@@ -534,7 +534,7 @@ public class ZeebeClientConfigurationProperties implements ZeebeClientConfigurat
 
   public static class Message {
     private Duration timeToLive = DEFAULT.getDefaultMessageTimeToLive();
-    private int maxMessageSize;
+    private int maxMessageSize = DEFAULT.getMaxMessageSize();
 
     public Duration getTimeToLive() {
       return timeToLive;

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.springframework.util.StringUtils.hasText;
 
@@ -75,6 +76,12 @@ public class ZeebeClientConfigurationProperties implements ZeebeClientConfigurat
   @Lazy
   @Autowired(required = false)
   private List<ClientInterceptor> interceptors;
+
+  @Lazy
+  @Autowired(required = false)
+  private ScheduledExecutorService scheduledExecutorService;
+
+  private boolean ownsJobWorkerExecutor;
 
   @Autowired
   public ZeebeClientConfigurationProperties(org.springframework.core.env.Environment environment) {
@@ -196,6 +203,24 @@ public class ZeebeClientConfigurationProperties implements ZeebeClientConfigurat
     this.applyEnvironmentVariableOverrides = applyEnvironmentVariableOverrides;
   }
 
+  public void setScheduledExecutorService(ScheduledExecutorService scheduledExecutorService) {
+    this.scheduledExecutorService = scheduledExecutorService;
+  }
+
+  public void setOwnsJobWorkerExecutor(boolean ownsJobWorkerExecutor) {
+    this.ownsJobWorkerExecutor = ownsJobWorkerExecutor;
+  }
+
+  @Override
+  public ScheduledExecutorService jobWorkerExecutor() {
+    return scheduledExecutorService;
+  }
+
+  @Override
+  public boolean ownsJobWorkerExecutor() {
+    return ownsJobWorkerExecutor;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -227,6 +252,8 @@ public class ZeebeClientConfigurationProperties implements ZeebeClientConfigurat
       ", job=" + job +
       ", interceptors=" + interceptors +
       ", requestTimeout=" + requestTimeout +
+      ", scheduledExecutorService=" + scheduledExecutorService +
+      ", ownsJobWorkerExecutor=" + ownsJobWorkerExecutor +
       '}';
   }
 

--- a/spring-client-zeebe/src/test/java/io/camunda/zeebe/spring/client/processor/DeploymentPostProcessorTest.java
+++ b/spring-client-zeebe/src/test/java/io/camunda/zeebe/spring/client/processor/DeploymentPostProcessorTest.java
@@ -173,6 +173,11 @@ public class DeploymentPostProcessorTest {
       public String getResourceName() {
         return "TestProcess";
       }
+
+      @Override
+      public String getTenantId() {
+        return "TestTenantId";
+      }
     };
   }
 }


### PR DESCRIPTION
This upgrades the dependencies for the zeebe and operate clients to the latest alpha versions to allow the connectors component to make use of multi-tenancy. This also includes an update of the jackson dependency as the previous pom did not provide an up-to-date version that was compatible with the zeebe client.