### PR TITLE
Update Spring Boot dependency to 3.1.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <zeebe.version>8.3.0</zeebe.version>
     <operate-client.version>8.3.0</operate-client.version>
 
-    <spring-boot.version>2.7.7</spring-boot.version>
+    <spring-boot.version>3.1.4</spring-boot.version>
     <commons-beanutils.version>1.9.4</commons-beanutils.version>
     <resilience4j.version>2.1.0</resilience4j.version>
     <jackson.version>2.15.2</jackson.version>

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java
@@ -17,7 +17,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.context.annotation.Lazy;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 import java.lang.invoke.MethodHandles;
 import java.time.Duration;
 import java.util.ArrayList;


### PR DESCRIPTION
Fixes https://github.com/camunda-community-hub/spring-zeebe/pull/473 and https://github.com/camunda-community-hub/spring-zeebe/issues/470

SpringBoot 3 requires the use of `jakarta` packages instead of `javax`