### PR TITLE
chore: exclude commons-collections dependency

### DIFF
--- a/spring-client-zeebe/pom.xml
+++ b/spring-client-zeebe/pom.xml
@@ -23,6 +23,12 @@
     <dependency>
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-collections</groupId>
+          <artifactId>commons-collections</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
According to this [issue](https://github.com/camunda-community-hub/spring-zeebe/issues/414) we have [vulnerable](https://devhub.checkmarx.com/cve-details/Cx78f40514-81ff/) transitive dependency `commons-collections` under `spring-client-zeebe`.

Things we know:
- Updating to latest Spring Boot 3 won't solve the issue since its not a dependency of SB3
- Inspected the [code](https://github.com/camunda-community-hub/spring-zeebe/blob/405ddeae5dba13863d9b1910670b40e923661b9c/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/bean/CopyNotNullBeanUtilsBean.java#L3-L3) and looks like we are not using any functionality of `commons-collections` (it gets imported as part of commons-beanutils). There are no known reference for commons-collections in the repo

We have few options:
- update to latest version of `commons-beanutils`, but this library has been out of date in a while and there is a breaking change from commons-collections3 to commons-collections4 and using it is not straightforward (diff group id, diff package names)
- exclude the dependency

To address the CVE, I'm going for excluding the dependency since its not used. Here is the before and after

**Before:**

<img src="https://github.com/camunda-community-hub/spring-zeebe/assets/133918079/f465498a-cbc9-4076-b5cd-26caeb422bf7"  width="50%" height="50%">


**After:**

<img src="https://github.com/camunda-community-hub/spring-zeebe/assets/133918079/87b0e55a-9f21-485f-b882-0bddb5bfaad9"  width="50%" height="50%">

