### PR TITLE
Fix missing ScheduledExecutorService during startup

### DIFF
--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientProdAutoConfiguration.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientProdAutoConfiguration.java
@@ -38,6 +38,7 @@ public class ZeebeClientProdAutoConfiguration {
   public ZeebeClientProdAutoConfiguration(ZeebeClientConfigurationProperties configurationProperties, ZeebeClientExecutorService zeebeClientExecutorService, JsonMapper jsonMapper) {
     this.configurationProperties = configurationProperties;
     configurationProperties.setJsonMapper(jsonMapper); // Replace JsonMapper proxy (because of lazy) with real bean
+    configurationProperties.setScheduledExecutorService(zeebeClientExecutorService.get());
     configurationProperties.applyOverrides(); // make sure environment variables and other legacy config options are taken into account (duplicate, also done by  qPostConstruct, whatever)
     this.zeebeClientExecutorService = zeebeClientExecutorService;
   }


### PR DESCRIPTION
## Problem
Related to https://github.com/camunda-community-hub/spring-zeebe/issues/483. On application startup, Spring tries to read the value of [scheduledExecutorService](https://github.com/camunda-community-hub/spring-zeebe/blob/233ebd35322a37ffe886b4d52e56aff182d0049d/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java#L273-L274). It then finds it as `null` so [autowiring](https://github.com/camunda-community-hub/spring-zeebe/blob/472e9e402a7e7712742e95e491cf1ad6d0002805/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java#L86-L87) is initiated but there is no bean available so it throws 

```
NoSuchBeanDefinitionException: No qualifying bean of type 'java.util.concurrent.ScheduledExecutorService' available: Optional dependency not present for lazy injection point
```

## Fix

Set the `ZeebeClientConfigurationProperties.scheduledExecutorService` in `ZeebeClientProdAutoConfiguration` so that when the value is read [here](https://github.com/camunda-community-hub/spring-zeebe/blob/472e9e402a7e7712742e95e491cf1ad6d0002805/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientProdAutoConfiguration.java#L50), it is not null and continues with startup.

We can also see the `scheduledExecutorService` is now assigned a value in this screenshot (was `null` previously)

<img width="2072" alt="Screenshot 2023-10-09 at 9 48 51 PM" src="https://github.com/camunda-community-hub/spring-zeebe/assets/133918079/3ae08b2d-85cf-4014-8c13-93e5e70c29cb">


## Observation

What is the intent of`@Autowiring` [here](https://github.com/camunda-community-hub/spring-zeebe/blob/472e9e402a7e7712742e95e491cf1ad6d0002805/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java#L86-L87)? It seems the custom executor is wrapped in another class therefore the actual executor cant be accessed thru Autowiring.

If there is indeed a bean of that class found then its only purpose will be for showing the name in the logs when the zeebe client configuration is printed. Can that be removed unless I'm missing anything?