### PR TITLE
Enable Java Client / JobWorker Metrics

### DIFF
--- a/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/jobhandling/JobWorkerManager.java
+++ b/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/jobhandling/JobWorkerManager.java
@@ -70,7 +70,7 @@ public class JobWorkerManager {
       builder.fetchVariables(zeebeWorkerValue.getFetchVariables());
     }
 
-    // TODO: Check if this is the right place for enabling JobWorker metrics
+    // TODO: Check if this is the right place for enabling JobWorker metrics and connect to Meter Registry
     try {
       JobWorkerMetrics metrics = JobWorkerMetrics.micrometer().build();
       builder.metrics(metrics);

--- a/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/jobhandling/JobWorkerManager.java
+++ b/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/jobhandling/JobWorkerManager.java
@@ -5,6 +5,7 @@ import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.api.worker.JobHandler;
 import io.camunda.zeebe.client.api.worker.JobWorker;
 import io.camunda.zeebe.client.api.worker.JobWorkerBuilderStep1;
+import io.camunda.zeebe.client.api.worker.JobWorkerMetrics;
 import io.camunda.zeebe.spring.client.annotation.value.ZeebeWorkerValue;
 import io.camunda.zeebe.spring.client.metrics.MetricsRecorder;
 import org.slf4j.Logger;
@@ -67,6 +68,14 @@ public class JobWorkerManager {
     }
     if (zeebeWorkerValue.getFetchVariables() != null && zeebeWorkerValue.getFetchVariables().length > 0) {
       builder.fetchVariables(zeebeWorkerValue.getFetchVariables());
+    }
+
+    // TODO: Check if this is the right place for enabling JobWorker metrics
+    try {
+      JobWorkerMetrics metrics = JobWorkerMetrics.micrometer().build();
+      builder.metrics(metrics);
+    } catch (UnsupportedOperationException e) {
+      LOGGER.error("Unable to start JobWorker metrics");
     }
 
     JobWorker jobWorker = builder.open();

--- a/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/metrics/ZeebeClientMetricsBridge.java
+++ b/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/metrics/ZeebeClientMetricsBridge.java
@@ -1,0 +1,28 @@
+package io.camunda.zeebe.spring.client.metrics;
+
+import io.camunda.zeebe.client.api.worker.JobWorkerMetrics;
+
+/**
+ * Bridge between spring-zeebe metrics and zeebe-client metrics.
+ * One way flow where zeebe-client metrics get propagated to MetricRecorder format in Spring.
+ */
+public class ZeebeClientMetricsBridge implements JobWorkerMetrics {
+
+  private final MetricsRecorder metricsRecorder;
+  private final String jobType;
+
+  public ZeebeClientMetricsBridge(MetricsRecorder metricsRecorder, String jobType) {
+    this.metricsRecorder = metricsRecorder;
+    this.jobType = jobType;
+  }
+
+  @Override
+  public void jobActivated(int count) {
+    metricsRecorder.increase("zeebe.client.worker.job", "activated", jobType, count);
+  }
+
+  @Override
+  public void jobHandled(int count) {
+    metricsRecorder.increase("zeebe.client.worker.job", "handled", jobType, count);
+  }
+}


### PR DESCRIPTION
### Overview
Zeebe's java-client has JobWorker [metrics](https://github.com/camunda-community-hub/spring-zeebe/issues/472) and explicitly enabling it on `spring-zeebe`

Zeebe-client metrics gets translated towards Spring's `MetricRecorder` so that users will see consistent metrics in the format of `metric` and `action`.

### Changes
- enabled by default (can be disabled by config property if there is a need?)
- users will see 2 sets of metrics in the same format:
  - `camunda.job.invocations` (from spring)
  - `zeebe.client.worker.job` (from zeebe-client)
