### PR TITLE
Adding instruction for new compiler flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,39 @@ Although Spring Zeebe has a transitive dependency to the [Zeebe Java Client](htt
 </dependency>
 ```
 
+The following compiler flag `-parameters` is required for Spring-Zeebe versions higher than 8.3.1:
+
+If using Maven in your `pom.xml`
+```xml
+<build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compilerArgs>
+            <arg>-parameters</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+```
+
+If using Gradle 
+
+```xml
+tasks.withType(JavaCompile) {
+    options.compilerArgs << '-parameters'
+}
+```
+
+If using Intellij:
+
+```agsl
+Settings > Build, Execution, Deployment > Compiler > Java Compiler
+```
+
 
 ## Configuring Camunda Platform 8 SaaS Connection
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Although Spring Zeebe has a transitive dependency to the [Zeebe Java Client](htt
 </dependency>
 ```
 
-The following compiler flag `-parameters` is required for Spring-Zeebe versions higher than 8.3.1:
+Note that if you are using [@Variables](https://github.com/camunda-community-hub/spring-zeebe#using-variable), compiler flag `-parameters` is required for Spring-Zeebe versions higher than 8.3.1:
 
 If using Maven:
 ```xml

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Although Spring Zeebe has a transitive dependency to the [Zeebe Java Client](htt
 
 The following compiler flag `-parameters` is required for Spring-Zeebe versions higher than 8.3.1:
 
-If using Maven in your `pom.xml`
+If using Maven:
 ```xml
 <build>
     <plugins>
@@ -89,7 +89,7 @@ If using Maven in your `pom.xml`
   </build>
 ```
 
-If using Gradle 
+If using Gradle:
 
 ```xml
 tasks.withType(JavaCompile) {
@@ -102,7 +102,6 @@ If using Intellij:
 ```agsl
 Settings > Build, Execution, Deployment > Compiler > Java Compiler
 ```
-
 
 ## Configuring Camunda Platform 8 SaaS Connection
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Although Spring Zeebe has a transitive dependency to the [Zeebe Java Client](htt
 </dependency>
 ```
 
-Note that if you are using [@Variables](https://github.com/camunda-community-hub/spring-zeebe#using-variable), compiler flag `-parameters` is required for Spring-Zeebe versions higher than 8.3.1:
+Note that if you are using [@Variables](https://github.com/camunda-community-hub/spring-zeebe#using-variable), compiler flag `-parameters` is required for Spring-Zeebe versions higher than 8.3.1.
 
 If using Maven:
 ```xml


### PR DESCRIPTION
Updating the readme to reflect usage of new compiler flag for new versions of Spring-Zeebe related to this PR https://github.com/camunda-community-hub/spring-zeebe/pull/512

This is the first time i'm aware of the `-parameters` flag but it seems its common based on a[ quick github search](https://github.com/search?q=%3Carg%3E-parameters%3C%2Farg%3E+&type=code)