### PR TITLE
Adding compiler flag in example

### DIFF
--- a/example/pom.xml
+++ b/example/pom.xml
@@ -34,6 +34,17 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+          <compilerArgs>
+            <arg>-parameters</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
Adding `-parameters` flag in `example` module. This was missed in previous [PR](https://github.com/camunda-community-hub/spring-zeebe/pull/512)