### PR TITLE
feat: workaround for grpc issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,11 +59,11 @@
 
   <dependencyManagement>
     <dependencies>
-      <!-- Breaking changes, overwrite BOM until upstream is fixed-->
+      <!-- Overwrite BOM until upstream is fixed-->
       <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-bom</artifactId>
-        <version>4.1.100.Final</version>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-bom</artifactId>
+        <version>1.59.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
As described in this issue https://github.com/camunda-community-hub/spring-zeebe/issues/536, overriding the io.grpc to the fixed version till SpringBoot patch is released