### PR TITLE
Use Java 21 for publish artifacts

### DIFF
--- a/.github/workflows/mvn-release.yml
+++ b/.github/workflows/mvn-release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Java environment
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: zulu
           cache: maven
           gpg-private-key: ${{ secrets.MAVEN_CENTRAL_GPG_SIGNING_KEY_SEC }}


### PR DESCRIPTION
Using Java 21 since Zeebe 8.4 uses that JDK version