### PR TITLE
Correct variable for target branch

### DIFF
--- a/.github/workflows/mvn-release.yml
+++ b/.github/workflows/mvn-release.yml
@@ -43,7 +43,7 @@ jobs:
           maven-gpg-passphrase: ${{ secrets.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}
           maven-auto-release-after-close: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ github.ref_name }}
+          branch: ${{ github.event.release.target_commitish }}
         id: release
 
       - if: github.event.release


### PR DESCRIPTION
The current [publish](https://github.com/camunda-community-hub/spring-zeebe/actions/runs/7136216896/job/19434323615) is failing for 8.3. because its using a tag instead of a branch name

According to [this](https://stackoverflow.com/questions/63468238/how-to-get-target-branch-in-github-actions-on-release) we should use this to reference the target branch to update the next iteration version 