### PR TITLE
feat: correct the way we override dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,8 +64,8 @@
         <groupId>io.grpc</groupId>
         <artifactId>grpc-bom</artifactId>
         <version>1.60.0</version>
-        <type>pom</type>
         <scope>import</scope>
+        <type>pom</type>
       </dependency>
 
       <dependency>
@@ -176,6 +176,37 @@
   </dependencyManagement>
 
   <!-- no dependencies allowed here, specify in submodules! -->
+  <!-- Remove this override dependencies once SpringBoot 3.2 or Zeebe 8.3.x has released a fix -->
+  <dependencies>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-stub</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-netty</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-util</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-protobuf</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-protobuf-lite</artifactId>
+    </dependency>
+  </dependencies>
 
   <build>
     <defaultGoal>clean install</defaultGoal>


### PR DESCRIPTION
I was incorrectly using the dependency management. It turns out, we need to specify the dependencies so that it actually overrides the version.

We should not be specifying dependencies in the root pom of the project. But this will be an exception since the other approach would be to duplicate the dependencies on two modules `spring-boot-starter-camunda` and `spring-boot-starter-camunda-test` which is not clean