### PR TITLE
Use Authentication for ZeebeClient

### DIFF
--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/ExecutorServiceConfiguration.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/ExecutorServiceConfiguration.java
@@ -6,11 +6,9 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.MeterBinder;
 import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
 import java.util.Collections;
 import java.util.concurrent.Executors;
@@ -33,7 +31,6 @@ public class ExecutorServiceConfiguration {
         threadPool, "zeebe_client_thread_pool", Collections.emptyList());
       threadPoolMetrics.bindTo(meterRegistry);
     }
-    configurationProperties.setScheduledExecutorService(threadPool);
     configurationProperties.setOwnsJobWorkerExecutor(true);
     return new ZeebeClientExecutorService(threadPool);
   }

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientConfiguration.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientConfiguration.java
@@ -1,0 +1,198 @@
+package io.camunda.zeebe.spring.client.configuration;
+
+import io.camunda.common.auth.Authentication;
+import io.camunda.common.auth.DefaultNoopAuthentication;
+import io.camunda.common.auth.Product;
+import io.camunda.zeebe.client.CredentialsProvider;
+import io.camunda.zeebe.client.api.JsonMapper;
+import io.camunda.zeebe.client.impl.oauth.OAuthCredentialsProviderBuilder;
+import io.camunda.zeebe.client.impl.util.Environment;
+import io.camunda.zeebe.spring.client.jobhandling.ZeebeClientExecutorService;
+import io.camunda.zeebe.spring.client.properties.ZeebeClientConfigurationProperties;
+import io.grpc.ClientInterceptor;
+import io.grpc.Metadata;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static org.springframework.util.StringUtils.hasText;
+
+public class ZeebeClientConfiguration implements io.camunda.zeebe.client.ZeebeClientConfiguration {
+
+  @Autowired
+  private ZeebeClientConfigurationProperties properties;
+
+  @Autowired
+  private Authentication authentication;
+
+  @Lazy // Must be lazy, otherwise we get circular dependencies on beans
+  @Autowired
+  private JsonMapper jsonMapper;
+
+  @Lazy
+  @Autowired(required = false)
+  private List<ClientInterceptor> interceptors;
+
+  @Lazy
+  @Autowired
+  private ZeebeClientExecutorService zeebeClientExecutorService;
+
+  @PostConstruct
+  public void applyLegacy() {
+    // make sure environment variables and other legacy config options are taken into account (duplicate, also done by  qPostConstruct, whatever)
+    properties.applyOverrides();
+  }
+
+  @Override
+  public String getGatewayAddress() {
+    return properties.getGatewayAddress();
+  }
+
+  @Override
+  public String getDefaultTenantId() {
+    return properties.getDefaultTenantId();
+  }
+
+  @Override
+  public List<String> getDefaultJobWorkerTenantIds() {
+    return properties.getDefaultJobWorkerTenantIds();
+  }
+
+  @Override
+  public int getNumJobWorkerExecutionThreads() {
+    return properties.getNumJobWorkerExecutionThreads();
+  }
+
+  @Override
+  public int getDefaultJobWorkerMaxJobsActive() {
+    return properties.getDefaultJobWorkerMaxJobsActive();
+  }
+
+  @Override
+  public String getDefaultJobWorkerName() {
+    return properties.getDefaultJobWorkerName();
+  }
+
+  @Override
+  public Duration getDefaultJobTimeout() {
+    return properties.getDefaultJobTimeout();
+  }
+
+  @Override
+  public Duration getDefaultJobPollInterval() {
+    return properties.getDefaultJobPollInterval();
+  }
+
+  @Override
+  public Duration getDefaultMessageTimeToLive() {
+    return properties.getDefaultMessageTimeToLive();
+  }
+
+  @Override
+  public Duration getDefaultRequestTimeout() {
+    return properties.getDefaultRequestTimeout();
+  }
+
+  @Override
+  public boolean isPlaintextConnectionEnabled() {
+    return properties.isPlaintextConnectionEnabled();
+  }
+
+  @Override
+  public String getCaCertificatePath() {
+    return properties.getCaCertificatePath();
+  }
+
+  @Override
+  public CredentialsProvider getCredentialsProvider() {
+    if (!(authentication instanceof DefaultNoopAuthentication)) {
+      return new CredentialsProvider() {
+        @Override
+        public void applyCredentials(Metadata headers) throws IOException {
+          final var authHeader = authentication.getTokenHeader(Product.ZEEBE);
+          final var authHeaderKey = Metadata.Key.of(authHeader.getKey(), Metadata.ASCII_STRING_MARSHALLER);
+          headers.put(authHeaderKey, authHeader.getValue());
+        }
+
+        @Override
+        public boolean shouldRetryRequest(Throwable throwable) {
+          return ((StatusRuntimeException) throwable).getStatus() == Status.DEADLINE_EXCEEDED;
+        }
+      };
+    }
+    if (hasText(properties.getCloud().getClientId()) && hasText(properties.getCloud().getClientSecret())) {
+//        log.debug("Client ID and secret are configured. Creating OAuthCredientialsProvider with: {}", this);
+      return CredentialsProvider.newCredentialsProviderBuilder()
+        .clientId(properties.getCloud().getClientId())
+        .clientSecret(properties.getCloud().getClientSecret())
+        .audience(properties.getCloud().getAudience())
+        .scope(properties.getCloud().getScope())
+        .authorizationServerUrl(properties.getCloud().getAuthUrl())
+        .credentialsCachePath(properties.getCloud().getCredentialsCachePath())
+        .build();
+    }
+    if (Environment.system().get("ZEEBE_CLIENT_ID") != null && Environment.system().get("ZEEBE_CLIENT_SECRET") != null) {
+      // Copied from ZeebeClientBuilderImpl
+      OAuthCredentialsProviderBuilder builder = CredentialsProvider.newCredentialsProviderBuilder();
+      int separatorIndex = properties.getBroker().getGatewayAddress().lastIndexOf(58); //":"
+      if (separatorIndex > 0) {
+        builder.audience(properties.getBroker().getGatewayAddress().substring(0, separatorIndex));
+      }
+      return builder.build();
+    }
+    return null;
+  }
+
+  @Override
+  public Duration getKeepAlive() {
+    return properties.getKeepAlive();
+  }
+
+  @Override
+  public List<ClientInterceptor> getInterceptors() {
+    return interceptors;
+  }
+
+  @Override
+  public JsonMapper getJsonMapper() {
+    return jsonMapper;
+  }
+
+  @Override
+  public String getOverrideAuthority() {
+    return properties.getOverrideAuthority();
+  }
+
+  @Override
+  public int getMaxMessageSize() {
+    return properties.getMaxMessageSize();
+  }
+
+  @Override
+  public ScheduledExecutorService jobWorkerExecutor() {
+    return zeebeClientExecutorService.get();
+  }
+
+  @Override
+  public boolean ownsJobWorkerExecutor() {
+    return properties.ownsJobWorkerExecutor();
+  }
+
+  @Override
+  public boolean getDefaultJobWorkerStreamEnabled() {
+    return properties.getDefaultJobWorkerStreamEnabled();
+  }
+
+  @Override
+  public boolean useDefaultRetryPolicy() {
+    return properties.useDefaultRetryPolicy();
+  }
+
+}

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientStarterAutoConfigurationCustomJsonMapperTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientStarterAutoConfigurationCustomJsonMapperTest.java
@@ -15,6 +15,7 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.util.AopTestUtils;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.Duration;
@@ -99,9 +100,10 @@ public class ZeebeClientStarterAutoConfigurationCustomJsonMapperTest {
     //ZeebeClientBuilder builder = autoConfiguration.builder(jsonMapper, Collections.emptyList());
     //assertThat(builder).isNotNull();
 
-    ZeebeClient client = applicationContext.getBean(ZeebeClient.class) ;
-    assertThat(client.getConfiguration().getJsonMapper()).isSameAs(jsonMapper);
-    assertThat(client.getConfiguration().getJsonMapper()).isSameAs(applicationContext.getBean("overridingJsonMapper"));
+    ZeebeClient client = applicationContext.getBean(ZeebeClient.class);
+    final var clientJsonMapper = AopTestUtils.getUltimateTargetObject(client.getConfiguration().getJsonMapper());
+    assertThat(clientJsonMapper).isSameAs(jsonMapper);
+    assertThat(clientJsonMapper).isSameAs(applicationContext.getBean("overridingJsonMapper"));
     assertThat(client.getConfiguration().getGatewayAddress()).isEqualTo("localhost12345");
     assertThat(client.getConfiguration().getDefaultRequestTimeout()).isEqualTo(Duration.ofSeconds(99));
     assertThat(client.getConfiguration().getCaCertificatePath()).isEqualTo("aPath");

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/properties/ZeebeClientSpringConfigurationPropertiesTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/properties/ZeebeClientSpringConfigurationPropertiesTest.java
@@ -1,9 +1,5 @@
 package io.camunda.zeebe.spring.client.properties;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.time.Duration;
-
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
 import org.junit.jupiter.api.Test;
@@ -15,6 +11,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(SpringExtension.class)
 @TestPropertySource(
@@ -108,19 +108,7 @@ public class ZeebeClientSpringConfigurationPropertiesTest {
   }
 
   @Test
-  public void getCredentialsProvider() throws Exception {
-    assertThat(properties.getCredentialsProvider()).isNull();
-  }
-
-  @Test
   void shouldFooWorkerDisabled() {
     assertThat(properties.getWorker().getOverride().get("foo").getEnabled()).isFalse();
-  }
-
-  @Test
-  void getJsonMapper() {
-    assertThat(jsonMapper).isNotNull();
-    assertThat(properties.getJsonMapper()).isNotNull();
-    assertThat(properties.getJsonMapper()).isSameAs(properties.getJsonMapper());
   }
 }


### PR DESCRIPTION
As mentioned in #558 we want to use spring-zeebe to connect to a self-managed cluster having tenants enabled. This also requires to enable Identity based authentication (see https://github.com/camunda/camunda-platform#multi-tenancy).

I used the current main-branch (https://github.com/camunda-community-hub/spring-zeebe/commit/17e1fc4d9109a46c8952f380755fa18b459e396b) to test this, but failed due to two lacks in implementation:

1. At https://github.com/camunda-community-hub/spring-zeebe/blob/17e1fc4d9109a46c8952f380755fa18b459e396b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/CommonClientConfiguration.java#L41 it is tested for `getCloud() != null` but there is always an object given.
2. At https://github.com/camunda-community-hub/spring-zeebe/blob/17e1fc4d9109a46c8952f380755fa18b459e396b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java#L766 the new authentication classes (like https://github.com/camunda-community-hub/spring-zeebe/blob/17e1fc4d9109a46c8952f380755fa18b459e396b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SelfManagedAuthentication.java#L23) are not used for Zeebe-client authentication.

In this pull-request I resolved this by
1. Fixing CommonClientConfiguration
2. Detaching io.camunda.zeebe.client.ZeebeClientConfiguration and ZeebeClientConfigurationProperties
3. Using any other authentication than DefaultNoopAuthentication as CredentialsProvider for the ZeebeClient

With this in place I'm able to start self-managed C8 and use it with tenants enabled:

1. local C8 started like this: https://github.com/camunda/camunda-platform#multi-tenancy
2. Configured Zeebe-API to allow default-tenant
3. Use Spring config:
application.yaml:
```yaml
logging:
  level:
    io.camunda.zeebe.client.impl.ZeebeCallCredentials: ERROR

zeebe:
  client:
    broker:
      gateway-address: 127.0.0.1:26500
    security:
       plaintext: true

common:
  keycloak:
    url: http://localhost:18080
    realm: camunda-platform
  client-id: zeebe
  client-secret: zecret
```



