### PR TITLE
Enable Operator Client via authUrl or baseUrl

### DIFF
--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/CamundaOperateClientConfiguration.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/CamundaOperateClientConfiguration.java
@@ -8,6 +8,7 @@ import io.camunda.zeebe.spring.client.properties.CamundaOperateClientConfigurati
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
@@ -19,6 +20,7 @@ import java.lang.invoke.MethodHandles;
  */
 @Deprecated
 @Conditional(CamundaOperateClientCondition.class)
+@ConditionalOnProperty(prefix = "camunda.operate.client", name = "enabled", havingValue = "true",  matchIfMissing = true)
 @EnableConfigurationProperties(CamundaOperateClientConfigurationProperties.class)
 public class CamundaOperateClientConfiguration {
 

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/CommonClientConfiguration.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/CommonClientConfiguration.java
@@ -129,17 +129,31 @@ public class CommonClientConfiguration {
             operateAuthUrl,
             operateAudience)
           );
+        } else {
+          // TODO: Remove this in the future, new property scheme shouldn't depend on Zeebe
+          jwtConfig.addProduct(Product.OPERATE, new JwtCredential(
+            zeebeClientConfigurationProperties.getCloud().getClientId(),
+            zeebeClientConfigurationProperties.getCloud().getClientSecret(),
+            operateAudience, operateAuthUrl)
+          );
         }
       }
-    } else if (camundaOperateClientConfigurationProperties != null) {
+    }
+    if (camundaOperateClientConfigurationProperties != null) {
       // TODO: Remove this else if block when we deprecate camunda.[product].client.*
-      if (camundaOperateClientConfigurationProperties.getAuthUrl() != null) {
-        operateAuthUrl = camundaOperateClientConfigurationProperties.getAuthUrl();
+      if (camundaOperateClientConfigurationProperties.getEnabled()) {
+        if (camundaOperateClientConfigurationProperties.getAuthUrl() != null) {
+          operateAuthUrl = camundaOperateClientConfigurationProperties.getAuthUrl();
+        }
+        if (camundaOperateClientConfigurationProperties.getBaseUrl() != null) {
+          operateAudience = camundaOperateClientConfigurationProperties.getBaseUrl();
+        }
+        if (camundaOperateClientConfigurationProperties.getClientId() != null && camundaOperateClientConfigurationProperties.getClientSecret() != null) {
+          jwtConfig.addProduct(Product.OPERATE, new JwtCredential(camundaOperateClientConfigurationProperties.getClientId(), camundaOperateClientConfigurationProperties.getClientSecret(), operateAudience, operateAuthUrl));
+        } else {
+          jwtConfig.addProduct(Product.OPERATE, new JwtCredential(zeebeClientConfigurationProperties.getCloud().getClientId(), zeebeClientConfigurationProperties.getCloud().getClientSecret(), operateAudience, operateAuthUrl));
+        }
       }
-      if (camundaOperateClientConfigurationProperties.getBaseUrl() != null) {
-        operateAudience = camundaOperateClientConfigurationProperties.getBaseUrl();
-      }
-      jwtConfig.addProduct(Product.OPERATE, new JwtCredential(camundaOperateClientConfigurationProperties.getClientId(), camundaOperateClientConfigurationProperties.getClientSecret(), operateAudience, operateAuthUrl));
     }
     return jwtConfig;
   }

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/condition/CamundaOperateClientCondition.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/condition/CamundaOperateClientCondition.java
@@ -13,12 +13,14 @@ public class CamundaOperateClientCondition extends AnyNestedCondition {
   }
 
   @ConditionalOnProperty(name = "camunda.operate.client.client-id")
-  static class ClientIdCondition {
-
-  }
+  static class ClientIdCondition { }
 
   @ConditionalOnProperty(name = "camunda.operate.client.username")
-  static class UsernameCondition {
+  static class UsernameCondition { }
 
-  }
+  @ConditionalOnProperty(name = "camunda.operate.client.auth-url")
+  static class AuthUrlCondition { }
+
+  @ConditionalOnProperty(name = "camunda.operate.client.base-url")
+  static class BaseUrlCondition { }
 }

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/condition/OperateClientCondition.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/condition/OperateClientCondition.java
@@ -9,12 +9,14 @@ public class OperateClientCondition extends AnyNestedCondition {
   }
 
   @ConditionalOnProperty(name = "operate.client.client-id")
-  static class ClientIdCondition {
-
-  }
+  static class ClientIdCondition { }
 
   @ConditionalOnProperty(name = "operate.client.username")
-  static class UsernameCondition {
+  static class UsernameCondition { }
 
-  }
+  @ConditionalOnProperty(name = "operate.client.auth-url")
+  static class AuthUrlCondition { }
+
+  @ConditionalOnProperty(name = "operate.client.base-url")
+  static class BaseUrlCondition { }
 }

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/properties/CamundaOperateClientConfigurationProperties.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/properties/CamundaOperateClientConfigurationProperties.java
@@ -1,5 +1,6 @@
 package io.camunda.zeebe.spring.client.properties;
 
+import jakarta.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -26,7 +27,7 @@ public class CamundaOperateClientConfigurationProperties {
   private String clientSecret;
   private String username;
   private String password;
-  private Boolean enabled;
+  private Boolean enabled = false;
   private String url;
 
   private String keycloakUrl;
@@ -130,5 +131,16 @@ public class CamundaOperateClientConfigurationProperties {
     }
     throw new IllegalArgumentException(
       "In order to connect to Camunda Operate you need to specify either a SaaS clusterId or an Operate URL.");
+  }
+
+  @PostConstruct
+  private void applyFinalValues() {
+    if (this.getClientId() != null && this.getClientSecret() != null) {
+      this.setEnabled(true);
+    } else if (this.getUsername() != null && this.getPassword() != null) {
+      this.setEnabled(true);
+    } else if (this.getAuthUrl() != null || this.getBaseUrl() != null) {
+      this.setEnabled(true);
+    }
   }
 }

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/properties/OperateClientConfigurationProperties.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/properties/OperateClientConfigurationProperties.java
@@ -44,6 +44,8 @@ public class OperateClientConfigurationProperties extends Client {
         this.setEnabled(true);
       } else if (this.getUsername() != null && this.getPassword() != null) {
         this.setEnabled(true);
+      } else if (this.getAuthUrl() != null || this.getBaseUrl() != null) {
+        this.setEnabled(true);
       }
   }
 }


### PR DESCRIPTION
To enable operator client, users can set the `baseUrl` or `authUrl`. This will use the existing zeebe credentials present.

Both schemes below are valid.

```
# Old scheme
zeebe.client.cloud.region=xxx
zeebe.client.cloud.clusterId=xxx
zeebe.client.cloud.clientId=xxx
zeebe.client.cloud.baseUrl=xxx
camunda.operate.client.base-url=operate.camunda.io
camunda.operate.client.auth-url=https://login.cloud.camunda.io/oauth/token

# New scheme
zeebe.client.cloud.region=xxx
zeebe.client.cloud.clusterId=xxx
zeebe.client.cloud.clientId=xxx
zeebe.client.cloud.baseUrl=xxx
operate.client.base-url=operate.camunda.io
operate.client.auth-url=https://login.cloud.camunda.io/oauth/token
```

