### PR TITLE
feat: remove accidental 8.4 features

### DIFF
--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientConfiguration.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientConfiguration.java
@@ -138,7 +138,6 @@ public class ZeebeClientConfiguration implements io.camunda.zeebe.client.ZeebeCl
         .clientId(properties.getCloud().getClientId())
         .clientSecret(properties.getCloud().getClientSecret())
         .audience(properties.getCloud().getAudience())
-        .scope(properties.getCloud().getScope())
         .authorizationServerUrl(properties.getCloud().getAuthUrl())
         .credentialsCachePath(properties.getCloud().getCredentialsCachePath())
         .build();
@@ -194,10 +193,4 @@ public class ZeebeClientConfiguration implements io.camunda.zeebe.client.ZeebeCl
   public boolean getDefaultJobWorkerStreamEnabled() {
     return properties.getDefaultJobWorkerStreamEnabled();
   }
-
-  @Override
-  public boolean useDefaultRetryPolicy() {
-    return properties.useDefaultRetryPolicy();
-  }
-
 }


### PR DESCRIPTION
`scope` and other 8.4 was accidentally introduced in 8.3 (was supposed to be in 8.4). Undoing it.