### PR TITLE
feat: support keycloakTokenUrl for Self-Managed

### DIFF
--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SelfManagedAuthentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SelfManagedAuthentication.java
@@ -29,6 +29,7 @@ public class SelfManagedAuthentication extends JwtAuthentication {
   // TODO: Check with Identity about upcoming IDPs to abstract this
   private String keycloakRealm = "camunda-platform";
   private String keycloakUrl;
+  private String keycloakTokenUrl;
   private JwtConfig jwtConfig;
   private Map<Product, String> tokens;
 
@@ -51,13 +52,21 @@ public class SelfManagedAuthentication extends JwtAuthentication {
     this.keycloakUrl = keycloakUrl;
   }
 
+  public void setKeycloakTokenUrl(String keycloakTokenUrl) {
+    this.keycloakTokenUrl = keycloakTokenUrl;
+  }
+
   public void setJwtConfig(JwtConfig jwtConfig) {
     this.jwtConfig = jwtConfig;
   }
 
   @Override
   public Authentication build() {
-    authUrl = keycloakUrl+"/auth/realms/"+keycloakRealm+"/protocol/openid-connect/token";
+    if (keycloakTokenUrl != null) {
+      authUrl = keycloakTokenUrl;
+    } else {
+      authUrl = keycloakUrl+"/auth/realms/"+keycloakRealm+"/protocol/openid-connect/token";
+    }
     return this;
   }
 

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SelfManagedAuthenticationBuilder.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SelfManagedAuthenticationBuilder.java
@@ -25,6 +25,13 @@ public class SelfManagedAuthenticationBuilder {
     return this;
   }
 
+  public SelfManagedAuthenticationBuilder keycloakTokenUrl(String keycloakTokenUrl) {
+    if (keycloakTokenUrl != null) {
+      selfManagedAuthentication.setKeycloakTokenUrl(keycloakTokenUrl);
+    }
+    return this;
+  }
+
   public Authentication build() {
     return selfManagedAuthentication.build();
   }

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/CommonClientConfiguration.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/CommonClientConfiguration.java
@@ -50,7 +50,12 @@ public class CommonClientConfiguration {
               .keycloakUrl(operateClientConfigurationProperties.getKeycloakUrl())
               .keycloakRealm(operateClientConfigurationProperties.getKeycloakRealm())
               .build();
-          } else if (operateClientConfigurationProperties.getUsername() != null && operateClientConfigurationProperties.getPassword() != null) {
+          } else if (operateClientConfigurationProperties.getKeycloakTokenUrl() != null)  {
+            return SelfManagedAuthentication.builder()
+              .jwtConfig(configureJwtConfig())
+              .keycloakTokenUrl(operateClientConfigurationProperties.getKeycloakTokenUrl())
+              .build();
+          }  else if (operateClientConfigurationProperties.getUsername() != null && operateClientConfigurationProperties.getPassword() != null) {
             SimpleConfig simpleConfig = new SimpleConfig();
             SimpleCredential simpleCredential = new SimpleCredential(operateClientConfigurationProperties.getUsername(), operateClientConfigurationProperties.getPassword());
             simpleConfig.addProduct(Product.OPERATE, simpleCredential);
@@ -67,6 +72,11 @@ public class CommonClientConfiguration {
               .jwtConfig(configureJwtConfig())
               .keycloakUrl(commonConfigurationProperties.getKeycloak().getUrl())
               .keycloakRealm(commonConfigurationProperties.getKeycloak().getRealm())
+              .build();
+          } else if (commonConfigurationProperties.getKeycloak().getTokenUrl() != null) {
+            return SelfManagedAuthentication.builder()
+              .jwtConfig(configureJwtConfig())
+              .keycloakTokenUrl(commonConfigurationProperties.getKeycloak().getTokenUrl())
               .build();
           } else if (commonConfigurationProperties.getUsername() != null && commonConfigurationProperties.getPassword() != null) {
             SimpleConfig simpleConfig = new SimpleConfig();
@@ -125,8 +135,8 @@ public class CommonClientConfiguration {
         jwtConfig.addProduct(Product.OPERATE, new JwtCredential(
           commonConfigurationProperties.getClientId(),
           commonConfigurationProperties.getClientSecret(),
-          operateAuthUrl,
-          operateAudience)
+          operateAudience,
+          operateAuthUrl)
         );
       } else if (zeebeClientConfigurationProperties.getCloud().getClientId() != null && zeebeClientConfigurationProperties.getCloud().getClientSecret() != null) {
         jwtConfig.addProduct(Product.OPERATE, new JwtCredential(zeebeClientConfigurationProperties.getCloud().getClientId(), zeebeClientConfigurationProperties.getCloud().getClientSecret(), operateAudience, operateAuthUrl));

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/condition/OperateClientCondition.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/condition/OperateClientCondition.java
@@ -23,6 +23,9 @@ public class OperateClientCondition extends AnyNestedCondition {
   @ConditionalOnProperty(name = "camunda.operate.client.keycloak-url")
   static class KeycloakUrlCondition { }
 
+  @ConditionalOnProperty(name = "camunda.operate.client.keycloak-token-url")
+  static class KeycloakTokenUrlCondition { }
+
   @ConditionalOnProperty(name = "camunda.operate.client.url")
   static class UrlCondition { }
 

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/properties/OperateClientConfigurationProperties.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/properties/OperateClientConfigurationProperties.java
@@ -28,6 +28,8 @@ public class OperateClientConfigurationProperties {
   private String keycloakUrl;
   private String keycloakRealm = "camunda-platform";
 
+  private String keycloakTokenUrl;
+
   private String baseUrl;
 
   private String authUrl;
@@ -94,6 +96,14 @@ public class OperateClientConfigurationProperties {
 
   public void setKeycloakRealm(String keycloakRealm) {
     this.keycloakRealm = keycloakRealm;
+  }
+
+  public String getKeycloakTokenUrl() {
+    return keycloakTokenUrl;
+  }
+
+  public void setKeycloakTokenUrl(String keycloakTokenUrl) {
+    this.keycloakTokenUrl = keycloakTokenUrl;
   }
 
   public String getBaseUrl() {

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/properties/common/Keycloak.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/properties/common/Keycloak.java
@@ -4,6 +4,7 @@ public class Keycloak {
 
   private String url;
   private String realm;
+  private String tokenUrl;
 
   public String getUrl() {
     return url;
@@ -19,5 +20,13 @@ public class Keycloak {
 
   public void setRealm(String realm) {
     this.realm = realm;
+  }
+
+  public String getTokenUrl() {
+    return tokenUrl;
+  }
+
+  public void setTokenUrl(String tokenUrl) {
+    this.tokenUrl = tokenUrl;
   }
 }


### PR DESCRIPTION
Allows Self-Managed users to specify `keycloakTokenUrl` directly to allow customized keycloak instances