### PR TITLE
Handle multiple Set-Cookie during Simple Authentication

### DIFF
--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SimpleAuthentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SimpleAuthentication.java
@@ -4,6 +4,7 @@ import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.entity.UrlEncodedFormEntity;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.NameValuePair;
 import org.apache.hc.core5.http.message.BasicNameValuePair;
 import org.slf4j.Logger;
@@ -57,7 +58,16 @@ public class SimpleAuthentication implements Authentication {
 
       CloseableHttpClient client = HttpClient.getInstance();
       CloseableHttpResponse response = client.execute(httpPost);
-      String cookie = response.getHeader("Set-Cookie").getValue();
+      Header[] cookieHeaders = response.getHeaders("Set-Cookie");
+      String cookie = null;
+      for (Header cookieHeader : cookieHeaders) {
+        if (cookieHeader.getValue().startsWith("OPERATE-SESSION")) {
+          cookie = response.getHeader("Set-Cookie").getValue();
+        }
+      }
+      if (cookie == null) {
+        throw new RuntimeException("Unable to authenticate due to missing Set-Cookie");
+      }
       tokens.put(product, cookie);
     } catch (Exception e) {
       LOG.error("Authenticating for " + product + " failed due to " + e);


### PR DESCRIPTION
There can be instances where multiple `Set-Cookie` headers are returned. We need to pick the one that says `Operate-Session`.

Unit tests to follow and as of now, it was hard-coded for `Operate-Session` since only Operate module is supported.

![image](https://github.com/camunda-community-hub/spring-zeebe/assets/133918079/398b68e8-2604-40ef-9eae-d112dbd57397)

We can see from above that cookies that start from `Operate-Session` is picked.
