### PR TITLE
chore(build): Add missing compiler arg

### DIFF
--- a/spring-boot-starter-camunda/pom.xml
+++ b/spring-boot-starter-camunda/pom.xml
@@ -68,5 +68,19 @@
         <filtering>true</filtering>
       </resource>
     </resources>
+
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+          <compilerArgs>
+            <arg>-parameters</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+    </plugins>
   </build>
 </project>


### PR DESCRIPTION
Add compiler flag to avoid https://github.com/camunda-community-hub/spring-zeebe/pull/514 when running tests for `spring-boot-starter-camunda`