### PR TITLE
Add token reset and throw exception instead of swallowing

### DIFF
--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/Authentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/Authentication.java
@@ -7,4 +7,6 @@ public interface Authentication {
   Authentication build();
 
   Map.Entry<String, String> getTokenHeader(Product product);
+
+  void resetToken(Product product);
 }

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/DefaultNoopAuthentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/DefaultNoopAuthentication.java
@@ -1,5 +1,6 @@
 package io.camunda.common.auth;
 
+import io.camunda.common.exception.SdkException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,10 +15,17 @@ public class DefaultNoopAuthentication implements Authentication {
 
   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
+  private final String errorMessage = "Unable to determine authentication. Please check your configuration";
+
   @Override
   public Authentication build() {
-    LOG.error("Unable to determine authentication. Please check your configuration");
+    LOG.error(errorMessage);
     return this;
+  }
+
+  @Override
+  public void resetToken(Product product) {
+    throw new SdkException(errorMessage);
   }
 
   @Override

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SaaSAuthentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SaaSAuthentication.java
@@ -49,8 +49,7 @@ public class SaaSAuthentication extends JwtAuthentication {
 
   @Override
   public void resetToken(Product product) {
-    JwtCredential jwtCredential = jwtConfig.getProduct(product);
-    retrieveToken(product, jwtCredential);
+    tokens.remove(product);
   }
 
   private String retrieveToken(Product product, JwtCredential jwtCredential) {

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SaaSAuthentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SaaSAuthentication.java
@@ -47,6 +47,12 @@ public class SaaSAuthentication extends JwtAuthentication {
     return this;
   }
 
+  @Override
+  public void resetToken(Product product) {
+    JwtCredential jwtCredential = jwtConfig.getProduct(product);
+    retrieveToken(product, jwtCredential);
+  }
+
   private String retrieveToken(Product product, JwtCredential jwtCredential) {
     try {
       HttpPost httpPost = new HttpPost(jwtCredential.getAuthUrl());

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SelfManagedAuthentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SelfManagedAuthentication.java
@@ -77,9 +77,7 @@ public class SelfManagedAuthentication extends JwtAuthentication {
 
   @Override
   public void resetToken(Product product) {
-    JwtCredential jwtCredential = jwtConfig.getProduct(product);
     tokens.remove(product);
-    retrieveToken(product, jwtCredential);
   }
 
   private String retrieveToken(Product product, JwtCredential jwtCredential) {

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SelfManagedAuthentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SelfManagedAuthentication.java
@@ -78,6 +78,7 @@ public class SelfManagedAuthentication extends JwtAuthentication {
   @Override
   public void resetToken(Product product) {
     JwtCredential jwtCredential = jwtConfig.getProduct(product);
+    tokens.remove(product);
     retrieveToken(product, jwtCredential);
   }
 

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SimpleAuthentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SimpleAuthentication.java
@@ -44,7 +44,6 @@ public class SimpleAuthentication implements Authentication {
   @Override
   public Authentication build() {
     authUrl = simpleUrl+"/api/login";
-    //simpleConfig.getMap().forEach(this::retrieveToken);
     return this;
   }
 
@@ -88,5 +87,11 @@ public class SimpleAuthentication implements Authentication {
     }
 
     return new AbstractMap.SimpleEntry<>("Cookie", token);
+  }
+
+  @Override
+  public void resetToken(Product product) {
+    SimpleCredential simpleCredential = simpleConfig.getProduct(product);
+    retrieveToken(product, simpleCredential);
   }
 }

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SimpleAuthentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SimpleAuthentication.java
@@ -91,7 +91,6 @@ public class SimpleAuthentication implements Authentication {
 
   @Override
   public void resetToken(Product product) {
-    SimpleCredential simpleCredential = simpleConfig.getProduct(product);
-    retrieveToken(product, simpleCredential);
+    tokens.remove(product);
   }
 }

--- a/camunda-sdk-java/java-common/src/test/java/io/camunda/common/http/DefaultHttpClientTest.java
+++ b/camunda-sdk-java/java-common/src/test/java/io/camunda/common/http/DefaultHttpClientTest.java
@@ -46,6 +46,7 @@ public class DefaultHttpClientTest {
 
     // when
     when(chClient.execute(any(HttpGet.class))).thenReturn(response);
+    when(response.getCode()).thenReturn(200);
     when(authentication.getTokenHeader(any())).thenReturn(new AbstractMap.SimpleEntry<>("key", "value"));
     when(response.getEntity().getContent()).thenReturn(new ByteArrayInputStream("{\"name\" : \"test-name\"}".getBytes()));
     MyResponseClass parsedResponse = defaultHttpClient.get(MyResponseClass.class, "123");
@@ -67,6 +68,7 @@ public class DefaultHttpClientTest {
 
     // when
     when(chClient.execute(any(HttpPost.class))).thenReturn(response);
+    when(response.getCode()).thenReturn(200);
     when(authentication.getTokenHeader(any())).thenReturn(new AbstractMap.SimpleEntry<>("key", "value"));
     when(response.getEntity().getContent()).thenReturn(new ByteArrayInputStream("[{\"name\" : \"test-name\"}]".getBytes()));
     List parsedResponse = defaultHttpClient.post(List.class, MyResponseClass.class, TypeToken.of(MyResponseClass.class), "dummy");
@@ -87,6 +89,7 @@ public class DefaultHttpClientTest {
 
     // when
     when(chClient.execute(any(HttpDelete.class))).thenReturn(response);
+    when(response.getCode()).thenReturn(200);
     when(authentication.getTokenHeader(any())).thenReturn(new AbstractMap.SimpleEntry<>("key", "value"));
     when(response.getEntity().getContent()).thenReturn(new ByteArrayInputStream("{\"name\" : \"test-name\"}".getBytes()));
     MyResponseClass parsedResponse = defaultHttpClient.delete(MyResponseClass.class, MySelectorClass.class, 123L);


### PR DESCRIPTION
- Add token reset for authentication failures
- Throw exceptions instead of swallowing

TODOs:
- Refactor the duplicate code introduced
- Handle automatic retry of existing request if authentication has expired
- Make code unit testable to add unit tests and mock authentication process