### PR TITLE
feat: use dynamic prefix for product

### DIFF
--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SimpleAuthentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SimpleAuthentication.java
@@ -59,8 +59,9 @@ public class SimpleAuthentication implements Authentication {
       CloseableHttpResponse response = client.execute(httpPost);
       Header[] cookieHeaders = response.getHeaders("Set-Cookie");
       String cookie = null;
+      String cookiePrefix = product.toString().toUpperCase() + "-SESSION";
       for (Header cookieHeader : cookieHeaders) {
-        if (cookieHeader.getValue().startsWith("OPERATE-SESSION")) {
+        if (cookieHeader.getValue().startsWith(cookiePrefix)) {
           cookie = response.getHeader("Set-Cookie").getValue();
         }
       }


### PR DESCRIPTION
Fixes the [issue](https://github.com/camunda-community-hub/spring-zeebe/issues/589) by using dynamic cookie header prefix per product