### PR TITLE
chore: remove previously override netty bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,15 +59,6 @@
 
   <dependencyManagement>
     <dependencies>
-      <!-- Overwrite BOM until upstream is fixed-->
-      <dependency>
-        <groupId>io.grpc</groupId>
-        <artifactId>grpc-bom</artifactId>
-        <version>1.60.0</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>


### PR DESCRIPTION
Removing the override netty BOM since Zeebe 8.4.0 already has `1.60.0`