### PR TITLE
Fix self managed basic auth

### DIFF
--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/CommonClientConfiguration.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/CommonClientConfiguration.java
@@ -53,12 +53,11 @@ public class CommonClientConfiguration {
           .build();
       } else if (zeebeClientConfigurationProperties.getBroker().getGatewayAddress() != null || zeebeSelfManagedProperties.getGatewayAddress() != null) {
         // figure out if Self-Managed JWT or Self-Managed Basic
-        JwtConfig jwtConfig = configureJwtConfig();
-        IdentityConfig identityConfig = configureIdentities(jwtConfig);
-
         // Operate Client props take first priority
         if (operateClientConfigurationProperties != null) {
           if (hasText(operateClientConfigurationProperties.getKeycloakUrl()) || hasText(operateClientConfigurationProperties.getKeycloakTokenUrl())) {
+            JwtConfig jwtConfig = configureJwtConfig();
+            IdentityConfig identityConfig = configureIdentities(jwtConfig);
             return SelfManagedAuthentication.builder()
               .jwtConfig(jwtConfig)
               .identityConfig(identityConfig)
@@ -77,6 +76,8 @@ public class CommonClientConfiguration {
         // Identity props take second priority
         if (identityConfigurationFromProperties != null) {
           if (hasText(identityConfigurationFromProperties.getClientId())) {
+            JwtConfig jwtConfig = configureJwtConfig();
+            IdentityConfig identityConfig = configureIdentities(jwtConfig);
             return SelfManagedAuthentication.builder()
               .jwtConfig(jwtConfig)
               .identityConfig(identityConfig)
@@ -87,11 +88,15 @@ public class CommonClientConfiguration {
         // Fallback to common props
         if (commonConfigurationProperties != null) {
           if (commonConfigurationProperties.getKeycloak().getUrl() != null) {
+            JwtConfig jwtConfig = configureJwtConfig();
+            IdentityConfig identityConfig = configureIdentities(jwtConfig);
             return SelfManagedAuthentication.builder()
               .jwtConfig(jwtConfig)
               .identityConfig(identityConfig)
               .build();
           } else if (commonConfigurationProperties.getKeycloak().getTokenUrl() != null) {
+            JwtConfig jwtConfig = configureJwtConfig();
+            IdentityConfig identityConfig = configureIdentities(jwtConfig);
             return SelfManagedAuthentication.builder()
               .jwtConfig(jwtConfig)
               .identityConfig(identityConfig)

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedBasicWithZeebeCredentialsTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedBasicWithZeebeCredentialsTest.java
@@ -24,13 +24,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 @TestPropertySource(
   properties = {
     "zeebe.client.broker.gatewayAddress=localhost12345",
+    "zeebe.authorization.server.url=http://zeebe-authorization-server",
+    "zeebe.client.id=client-id",
+    "zeebe.client.secret=client-secret",
+    "zeebe.token.audience=sample-audience",
     "camunda.operate.client.url=http://localhost:8081",
     "camunda.operate.client.username=username",
     "camunda.operate.client.password=password"
   }
 )
-@ContextConfiguration(classes = OperateSelfManagedBasicTest.TestConfig.class)
-public class OperateSelfManagedBasicTest {
+@ContextConfiguration(classes = OperateSelfManagedBasicWithZeebeCredentialsTest.TestConfig.class)
+public class OperateSelfManagedBasicWithZeebeCredentialsTest {
 
   @ImportAutoConfiguration({CommonClientConfiguration.class, OperateClientConfiguration.class, IdentityAutoConfiguration.class})
   @EnableConfigurationProperties(ZeebeClientConfigurationProperties.class)


### PR DESCRIPTION
There was a regression during refactoring for Identity SDK integration. The JWT was moved to a higher scope but it fails since its being evaluated first before checking if its a basic mode.

Changes:
- move the configuring jwts to their respective local scopes inside different conditions
- refactor and add more tests to avoid false positive