### PR TITLE
Support multi-tenancy per worker

### DIFF
--- a/.github/workflows/mvn-build.yml
+++ b/.github/workflows/mvn-build.yml
@@ -20,4 +20,4 @@ jobs:
           java-version: '21'
           distribution: 'adopt'
       - name: Build with Maven
-        run: mvn --batch-mode --update-snapshots package
+        run: mvn verify -PcheckFormat -B

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ If you have additional information that can help us understand the behaviour of 
 
 If no issue already exists for the bug, please create a new one.
 
-When creating a bug report, please fill out the template. What really helps us are the steps for us to be able reproduce the problem in front of us. 
+When creating a bug report, please fill out the template. What really helps us are the steps for us to be able reproduce the problem in front of us.
 
 To generate these, start from nothing, and document the steps required to set up a project that shows the bug. If you create such a project as a new GitHub repo, you will have a Minimal Reproducible Example. We can then check out that project and see the bug in front of us immediately. This will increase the speed that we can address the issue. It will also help you isolate the actual issue, and sometimes to fix it.
 
@@ -45,9 +45,9 @@ If you have additional information that can help us understand the behaviour you
 
 If no issue already exists for the feature request, please create a new one.
 
-When creating a feature request, please fill out the template. What really helps us are both the motivation for the feature (what is your use-case and what you want to achieve), as well as what you would like the feature to be. Sometimes there is an existing way to accomplish what you want, and we may be able to recommend that. 
+When creating a feature request, please fill out the template. What really helps us are both the motivation for the feature (what is your use-case and what you want to achieve), as well as what you would like the feature to be. Sometimes there is an existing way to accomplish what you want, and we may be able to recommend that.
 
-If there is no existing way to do it, then understanding the use-case that motivates the feature request helps us to triage it, and also to design the feature implementation.  
+If there is no existing way to do it, then understanding the use-case that motivates the feature request helps us to triage it, and also to design the feature implementation.
 
 ## Fix to documentation
 
@@ -57,7 +57,7 @@ Please read the [Code Style Guidelines](#code-style-guidelines) and [Commit Mess
 
 ## Code contribution for an existing issue
 
-Maybe you patch an existing bug, or implement a requested feature for yourself - without waiting for us to get to it. You can contribute that to the codebase as a pull request. This way, you don't end up maintaining a separate fork. 
+Maybe you patch an existing bug, or implement a requested feature for yourself - without waiting for us to get to it. You can contribute that to the codebase as a pull request. This way, you don't end up maintaining a separate fork.
 
 See the section [Running a development version](#running-a-development-version) for instructions on how to use your fork locally to test your changes.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.camunda/spring-zeebe/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.camunda/spring-zeebe)
 [![Project Stats](https://www.openhub.net/p/spring-zeebe/widgets/project_thin_badge.gif)](https://www.openhub.net/p/spring-zeebe)
 
-Spring Zeebe will slowly evolve towards Camunda Spring SDK. 
+Spring Zeebe will slowly evolve towards Camunda Spring SDK.
 
 This project allows you to leverage Zeebe, Operate, Optimize, Tasklist, Console, and Modeler within your Spring or Spring Boot environment.
 
@@ -35,7 +35,7 @@ This project allows you to leverage Zeebe, Operate, Optimize, Tasklist, Console,
 
 ## Exciting news: Evolution of Spring-Zeebe into a Camunda Spring SDK
 
-This SDK will support all Camunda Products (Zeebe, Operate, Tasklist, etc) in a unified way. 
+This SDK will support all Camunda Products (Zeebe, Operate, Tasklist, etc) in a unified way.
 
 What to expect in the coming months:
 

--- a/camunda-sdk-java/java-client-operate/README.md
+++ b/camunda-sdk-java/java-client-operate/README.md
@@ -5,9 +5,9 @@
 This client is part of the Spring Zeebe project. If you intend to use it outside of this project, you can add a dependency to io.camunda.spring:java-client-operate
 ```xml
 <dependency>
-	<groupId>io.camunda.spring</groupId>
-	<artifactId>java-client-operate</artifactId>
-	<version>8.3.4</version>
+  <groupId>io.camunda.spring</groupId>
+  <artifactId>java-client-operate</artifactId>
+  <version>8.3.4</version>
 </dependency>
 ```
 

--- a/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/CamundaOperateClient.java
+++ b/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/CamundaOperateClient.java
@@ -6,7 +6,6 @@ import io.camunda.operate.model.*;
 import io.camunda.operate.search.SearchQuery;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
-
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.List;
@@ -26,9 +25,8 @@ public class CamundaOperateClient {
   public BpmnModelInstance getProcessDefinitionModel(Long key) throws OperateException {
     String xml = getProcessDefinitionXml(key);
     try {
-        InputStream processInputStream = new ByteArrayInputStream(
-          xml.getBytes());
-        return Bpmn.readModelFromStream(processInputStream);
+      InputStream processInputStream = new ByteArrayInputStream(xml.getBytes());
+      return Bpmn.readModelFromStream(processInputStream);
     } catch (Exception e) {
       throw new OperateException(e);
     }
@@ -38,36 +36,58 @@ public class CamundaOperateClient {
     return httpClient.getXml(ProcessDefinition.class, key);
   }
 
-  public List<ProcessDefinition> searchProcessDefinitions(SearchQuery query) throws OperateException {
+  public List<ProcessDefinition> searchProcessDefinitions(SearchQuery query)
+      throws OperateException {
     return searchProcessDefinitionResults(query).getItems();
   }
 
-  public SearchResult<ProcessDefinition> searchProcessDefinitionResults(SearchQuery query) throws OperateException {
-    return httpClient.post(SearchResult.class, ProcessDefinition.class, SearchResultTypeToken.searchResultProcessDefinition, query);
+  public SearchResult<ProcessDefinition> searchProcessDefinitionResults(SearchQuery query)
+      throws OperateException {
+    return httpClient.post(
+        SearchResult.class,
+        ProcessDefinition.class,
+        SearchResultTypeToken.searchResultProcessDefinition,
+        query);
   }
 
-  public List<DecisionDefinition> searchDecisionDefinitions(SearchQuery query) throws OperateException {
+  public List<DecisionDefinition> searchDecisionDefinitions(SearchQuery query)
+      throws OperateException {
     return searchDecisionDefinitionResults(query).getItems();
   }
 
-  public SearchResult<DecisionDefinition> searchDecisionDefinitionResults(SearchQuery query) throws OperateException {
-    return httpClient.post(SearchResult.class, DecisionDefinition.class, SearchResultTypeToken.searchResultDecisionDefinition, query);
+  public SearchResult<DecisionDefinition> searchDecisionDefinitionResults(SearchQuery query)
+      throws OperateException {
+    return httpClient.post(
+        SearchResult.class,
+        DecisionDefinition.class,
+        SearchResultTypeToken.searchResultDecisionDefinition,
+        query);
   }
 
   public List<DecisionInstance> searchDecisionInstances(SearchQuery query) throws OperateException {
     return searchDecisionInstanceResults(query).getItems();
   }
 
-  public SearchResult<DecisionInstance> searchDecisionInstanceResults(SearchQuery query) throws OperateException {
-    return httpClient.post(SearchResult.class, DecisionInstance.class, SearchResultTypeToken.searchResultDecisionInstance, query);
+  public SearchResult<DecisionInstance> searchDecisionInstanceResults(SearchQuery query)
+      throws OperateException {
+    return httpClient.post(
+        SearchResult.class,
+        DecisionInstance.class,
+        SearchResultTypeToken.searchResultDecisionInstance,
+        query);
   }
 
   public List<FlowNodeInstance> searchFlowNodeInstances(SearchQuery query) throws OperateException {
     return searchFlowNodeInstanceResults(query).getItems();
   }
 
-  public SearchResult<FlowNodeInstance> searchFlowNodeInstanceResults(SearchQuery query) throws OperateException {
-    return httpClient.post(SearchResult.class, FlowNodeInstance.class, SearchResultTypeToken.searchResultFlowNodeInstance, query);
+  public SearchResult<FlowNodeInstance> searchFlowNodeInstanceResults(SearchQuery query)
+      throws OperateException {
+    return httpClient.post(
+        SearchResult.class,
+        FlowNodeInstance.class,
+        SearchResultTypeToken.searchResultFlowNodeInstance,
+        query);
   }
 
   public List<Variable> searchVariables(SearchQuery query) throws OperateException {
@@ -75,23 +95,35 @@ public class CamundaOperateClient {
   }
 
   public SearchResult<Variable> searchVariableResults(SearchQuery query) throws OperateException {
-    return httpClient.post(SearchResult.class, Variable.class, SearchResultTypeToken.searchResultVariable, query);
+    return httpClient.post(
+        SearchResult.class, Variable.class, SearchResultTypeToken.searchResultVariable, query);
   }
 
   public List<ProcessInstance> searchProcessInstances(SearchQuery query) throws OperateException {
     return searchProcessInstanceResults(query).getItems();
   }
 
-  public SearchResult<ProcessInstance> searchProcessInstanceResults(SearchQuery query) throws OperateException {
-    return httpClient.post(SearchResult.class, ProcessInstance.class, SearchResultTypeToken.searchResultProcessInstance, query);
+  public SearchResult<ProcessInstance> searchProcessInstanceResults(SearchQuery query)
+      throws OperateException {
+    return httpClient.post(
+        SearchResult.class,
+        ProcessInstance.class,
+        SearchResultTypeToken.searchResultProcessInstance,
+        query);
   }
 
-  public List<DecisionRequirements> searchDecisionRequirements(SearchQuery query) throws OperateException {
+  public List<DecisionRequirements> searchDecisionRequirements(SearchQuery query)
+      throws OperateException {
     return searchDecisionRequirementsResults(query).getItems();
   }
 
-  public SearchResult<DecisionRequirements> searchDecisionRequirementsResults(SearchQuery query) throws OperateException {
-    return httpClient.post(SearchResult.class, DecisionRequirements.class, SearchResultTypeToken.searchResultDecisionRequirements, query);
+  public SearchResult<DecisionRequirements> searchDecisionRequirementsResults(SearchQuery query)
+      throws OperateException {
+    return httpClient.post(
+        SearchResult.class,
+        DecisionRequirements.class,
+        SearchResultTypeToken.searchResultDecisionRequirements,
+        query);
   }
 
   public List<Incident> searchIncidents(SearchQuery query) throws OperateException {
@@ -99,7 +131,8 @@ public class CamundaOperateClient {
   }
 
   public SearchResult<Incident> searchIncidentResults(SearchQuery query) throws OperateException {
-    return httpClient.post(SearchResult.class, Incident.class, SearchResultTypeToken.searchResultIncident, query);
+    return httpClient.post(
+        SearchResult.class, Incident.class, SearchResultTypeToken.searchResultIncident, query);
   }
 
   public ProcessInstance getProcessInstance(Long key) throws OperateException {
@@ -111,7 +144,8 @@ public class CamundaOperateClient {
   }
 
   public List<FlowNodeStatistics> getFlowNodeStatistics(Long key) throws OperateException {
-    return httpClient.get(List.class, FlowNodeStatistics.class, ListTypeToken.listFlowNodeStatistics, key);
+    return httpClient.get(
+        List.class, FlowNodeStatistics.class, ListTypeToken.listFlowNodeStatistics, key);
   }
 
   public List<String> getSequenceFlows(Long key) throws OperateException {

--- a/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/CamundaOperateClientBuilder.java
+++ b/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/CamundaOperateClientBuilder.java
@@ -5,7 +5,6 @@ import io.camunda.common.auth.Product;
 import io.camunda.common.http.DefaultHttpClient;
 import io.camunda.common.http.HttpClient;
 import io.camunda.operate.model.*;
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -15,7 +14,6 @@ public class CamundaOperateClientBuilder {
   private Authentication authentication;
   private String operateUrl;
   private HttpClient httpClient;
-
 
   public CamundaOperateClientBuilder authentication(Authentication authentication) {
     this.authentication = authentication;
@@ -42,12 +40,21 @@ public class CamundaOperateClientBuilder {
     map.put(DecisionDefinition.class, "/decision-definitions");
     map.put(DecisionRequirements.class, "/drd");
     map.put(DecisionInstance.class, "/decision-instances");
-    map.put(SearchResultTypeToken.searchResultProcessDefinition.getClass(), "/process-definitions/search");
-    map.put(SearchResultTypeToken.searchResultDecisionDefinition.getClass(), "/decision-definitions/search");
-    map.put(SearchResultTypeToken.searchResultDecisionInstance.getClass(), "/decision-instances/search");
-    map.put(SearchResultTypeToken.searchResultFlowNodeInstance.getClass(), "/flownode-instances/search");
+    map.put(
+        SearchResultTypeToken.searchResultProcessDefinition.getClass(),
+        "/process-definitions/search");
+    map.put(
+        SearchResultTypeToken.searchResultDecisionDefinition.getClass(),
+        "/decision-definitions/search");
+    map.put(
+        SearchResultTypeToken.searchResultDecisionInstance.getClass(),
+        "/decision-instances/search");
+    map.put(
+        SearchResultTypeToken.searchResultFlowNodeInstance.getClass(),
+        "/flownode-instances/search");
     map.put(SearchResultTypeToken.searchResultVariable.getClass(), "/variables/search");
-    map.put(SearchResultTypeToken.searchResultProcessInstance.getClass(), "/process-instances/search");
+    map.put(
+        SearchResultTypeToken.searchResultProcessInstance.getClass(), "/process-instances/search");
     map.put(SearchResultTypeToken.searchResultDecisionRequirements.getClass(), "/drd/search");
     map.put(SearchResultTypeToken.searchResultIncident.getClass(), "/incidents/search");
     httpClient.loadMap(Product.OPERATE, map);
@@ -56,7 +63,7 @@ public class CamundaOperateClientBuilder {
 
   private String formatUrl(String url) {
     if (url.endsWith("/")) {
-      return url.substring(0, url.length()-1);
+      return url.substring(0, url.length() - 1);
     }
     return url;
   }

--- a/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/exception/OperateException.java
+++ b/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/exception/OperateException.java
@@ -1,21 +1,21 @@
 package io.camunda.operate.exception;
 
 public class OperateException extends Exception {
-    private static final long serialVersionUID = -7593616210087047797L;
+  private static final long serialVersionUID = -7593616210087047797L;
 
-    public OperateException() {
-        super();
-    }
+  public OperateException() {
+    super();
+  }
 
-    public OperateException(Exception e) {
-        super(e);
-    }
+  public OperateException(Exception e) {
+    super(e);
+  }
 
-    public OperateException(String message) {
-        super(message);
-    }
+  public OperateException(String message) {
+    super(message);
+  }
 
-    public OperateException(String message, Exception e) {
-        super(message, e);
-    }
+  public OperateException(String message, Exception e) {
+    super(message, e);
+  }
 }

--- a/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/model/ChangeStatus.java
+++ b/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/model/ChangeStatus.java
@@ -20,5 +20,4 @@ public class ChangeStatus {
   public void setDeleted(Long deleted) {
     this.deleted = deleted;
   }
-
 }

--- a/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/model/DecisionInstanceInput.java
+++ b/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/model/DecisionInstanceInput.java
@@ -5,6 +5,7 @@ public class DecisionInstanceInput {
   private String id;
   private String name;
   private String value;
+
   public String getId() {
     return id;
   }

--- a/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/model/DecisionRequirements.java
+++ b/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/model/DecisionRequirements.java
@@ -9,6 +9,7 @@ public class DecisionRequirements {
   private Long version;
   private String resourceName;
   private String tenantId;
+
   public String getId() {
     return id;
   }

--- a/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/model/FlowNodeInstance.java
+++ b/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/model/FlowNodeInstance.java
@@ -15,75 +15,99 @@ public class FlowNodeInstance {
   private FlowNodeInstanceState state;
   private Boolean incident;
   private String tenantId;
+
   public Long getKey() {
     return key;
   }
+
   public void setKey(Long key) {
     this.key = key;
   }
+
   public Long getProcessInstanceKey() {
     return processInstanceKey;
   }
+
   public void setProcessInstanceKey(Long processInstanceKey) {
     this.processInstanceKey = processInstanceKey;
   }
+
   public Long getProcessDefinitionKey() {
     return processDefinitionKey;
   }
+
   public void setProcessDefinitionKey(Long processDefinitionKey) {
     this.processDefinitionKey = processDefinitionKey;
   }
+
   public Date getStartDate() {
     return startDate;
   }
+
   public void setStartDate(Date startDate) {
     this.startDate = startDate;
   }
+
   public Date getEndDate() {
     return endDate;
   }
+
   public void setEndDate(Date endDate) {
     this.endDate = endDate;
   }
+
   public String getFlowNodeId() {
     return flowNodeId;
   }
+
   public void setFlowNodeId(String flowNodeId) {
     this.flowNodeId = flowNodeId;
   }
+
   public String getFlowNodeName() {
     return flowNodeName;
   }
+
   public void setFlowNodeName(String flowNodeName) {
     this.flowNodeName = flowNodeName;
   }
+
   public Long getIncidentKey() {
     return incidentKey;
   }
+
   public void setIncidentKey(Long incidentKey) {
     this.incidentKey = incidentKey;
   }
+
   public String getType() {
     return type;
   }
+
   public void setType(String type) {
     this.type = type;
   }
+
   public FlowNodeInstanceState getState() {
     return state;
   }
+
   public void setState(FlowNodeInstanceState state) {
     this.state = state;
   }
+
   public Boolean getIncident() {
     return incident;
   }
+
   public void setIncident(Boolean incident) {
     this.incident = incident;
   }
+
   public String getTenantId() {
     return tenantId;
   }
+
   public void setTenantId(String tenantId) {
     this.tenantId = tenantId;
   }

--- a/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/model/FlowNodeInstanceState.java
+++ b/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/model/FlowNodeInstanceState.java
@@ -1,5 +1,8 @@
 package io.camunda.operate.model;
 
 public enum FlowNodeInstanceState {
-  ACTIVE, INCIDENT, COMPLETED, TERMINATED;
+  ACTIVE,
+  INCIDENT,
+  COMPLETED,
+  TERMINATED;
 }

--- a/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/model/FlowNodeStatistics.java
+++ b/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/model/FlowNodeStatistics.java
@@ -47,5 +47,4 @@ public class FlowNodeStatistics {
   public void setCompleted(Long completed) {
     this.completed = completed;
   }
-
 }

--- a/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/model/Incident.java
+++ b/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/model/Incident.java
@@ -11,51 +11,67 @@ public class Incident {
   private Date creationTime;
   private String state;
   private String tenantId;
+
   public Long getKey() {
     return key;
   }
+
   public void setKey(Long key) {
     this.key = key;
   }
+
   public Long getProcessDefinitionKey() {
     return processDefinitionKey;
   }
+
   public void setProcessDefinitionKey(Long processDefinitionKey) {
     this.processDefinitionKey = processDefinitionKey;
   }
+
   public Long getProcessInstanceKey() {
     return processInstanceKey;
   }
+
   public void setProcessInstanceKey(Long processInstanceKey) {
     this.processInstanceKey = processInstanceKey;
   }
+
   public String getType() {
     return type;
   }
+
   public void setType(String type) {
     this.type = type;
   }
+
   public String getMessage() {
     return message;
   }
+
   public void setMessage(String message) {
     this.message = message;
   }
+
   public Date getCreationTime() {
     return creationTime;
   }
+
   public void setCreationTime(Date creationTime) {
     this.creationTime = creationTime;
   }
+
   public String getState() {
     return state;
   }
+
   public void setState(String state) {
     this.state = state;
   }
+
   public String getTenantId() {
     return tenantId;
   }
+
   public void setTenantId(String tenantId) {
     this.tenantId = tenantId;
   }

--- a/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/model/ListTypeToken.java
+++ b/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/model/ListTypeToken.java
@@ -1,11 +1,11 @@
 package io.camunda.operate.model;
 
 import com.google.common.reflect.TypeToken;
-
 import java.util.List;
 
 // See https://github.com/google/guava/wiki/ReflectionExplained
 public class ListTypeToken {
-  public static TypeToken<List<FlowNodeStatistics>> listFlowNodeStatistics = new TypeToken<List<FlowNodeStatistics>>() {};
+  public static TypeToken<List<FlowNodeStatistics>> listFlowNodeStatistics =
+      new TypeToken<List<FlowNodeStatistics>>() {};
   public static TypeToken<List<String>> listSequenceFlows = new TypeToken<List<String>>() {};
 }

--- a/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/model/ProcessDefinition.java
+++ b/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/model/ProcessDefinition.java
@@ -1,39 +1,48 @@
 package io.camunda.operate.model;
 
-
 public class ProcessDefinition {
   private Long key;
   private String name;
   private Long version;
   private String bpmnProcessId;
   private String tenantId;
+
   public Long getKey() {
     return key;
   }
+
   public void setKey(Long key) {
     this.key = key;
   }
+
   public String getName() {
     return name;
   }
+
   public void setName(String name) {
     this.name = name;
   }
+
   public Long getVersion() {
     return version;
   }
+
   public void setVersion(Long version) {
     this.version = version;
   }
+
   public String getBpmnProcessId() {
     return bpmnProcessId;
   }
+
   public void setBpmnProcessId(String bpmnProcessId) {
     this.bpmnProcessId = bpmnProcessId;
   }
+
   public String getTenantId() {
     return tenantId;
   }
+
   public void setTenantId(String tenantId) {
     this.tenantId = tenantId;
   }

--- a/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/model/ProcessInstanceState.java
+++ b/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/model/ProcessInstanceState.java
@@ -1,5 +1,7 @@
 package io.camunda.operate.model;
 
 public enum ProcessInstanceState {
-  ACTIVE, COMPLETED, CANCELED;
+  ACTIVE,
+  COMPLETED,
+  CANCELED;
 }

--- a/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/model/SearchResultTypeToken.java
+++ b/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/model/SearchResultTypeToken.java
@@ -5,12 +5,20 @@ import com.google.common.reflect.TypeToken;
 // See https://github.com/google/guava/wiki/ReflectionExplained
 public class SearchResultTypeToken {
 
-  public static TypeToken<SearchResult<ProcessDefinition>> searchResultProcessDefinition = new TypeToken<SearchResult<ProcessDefinition>>() {};
-  public static TypeToken<SearchResult<DecisionDefinition>> searchResultDecisionDefinition = new TypeToken<SearchResult<DecisionDefinition>>() {};
-  public static TypeToken<SearchResult<DecisionInstance>> searchResultDecisionInstance = new TypeToken<SearchResult<DecisionInstance>>() {};
-  public static TypeToken<SearchResult<FlowNodeInstance>> searchResultFlowNodeInstance = new TypeToken<SearchResult<FlowNodeInstance>>() {};
-  public static TypeToken<SearchResult<Variable>> searchResultVariable = new TypeToken<SearchResult<Variable>>() {};
-  public static TypeToken<SearchResult<ProcessInstance>> searchResultProcessInstance = new TypeToken<SearchResult<ProcessInstance>>() {};
-  public static TypeToken<SearchResult<DecisionRequirements>> searchResultDecisionRequirements = new TypeToken<SearchResult<DecisionRequirements>>() {};
-  public static TypeToken<SearchResult<Incident>> searchResultIncident = new TypeToken<SearchResult<Incident>>() {};
+  public static TypeToken<SearchResult<ProcessDefinition>> searchResultProcessDefinition =
+      new TypeToken<SearchResult<ProcessDefinition>>() {};
+  public static TypeToken<SearchResult<DecisionDefinition>> searchResultDecisionDefinition =
+      new TypeToken<SearchResult<DecisionDefinition>>() {};
+  public static TypeToken<SearchResult<DecisionInstance>> searchResultDecisionInstance =
+      new TypeToken<SearchResult<DecisionInstance>>() {};
+  public static TypeToken<SearchResult<FlowNodeInstance>> searchResultFlowNodeInstance =
+      new TypeToken<SearchResult<FlowNodeInstance>>() {};
+  public static TypeToken<SearchResult<Variable>> searchResultVariable =
+      new TypeToken<SearchResult<Variable>>() {};
+  public static TypeToken<SearchResult<ProcessInstance>> searchResultProcessInstance =
+      new TypeToken<SearchResult<ProcessInstance>>() {};
+  public static TypeToken<SearchResult<DecisionRequirements>> searchResultDecisionRequirements =
+      new TypeToken<SearchResult<DecisionRequirements>>() {};
+  public static TypeToken<SearchResult<Incident>> searchResultIncident =
+      new TypeToken<SearchResult<Incident>>() {};
 }

--- a/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/DateFilter.java
+++ b/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/DateFilter.java
@@ -1,44 +1,42 @@
 package io.camunda.operate.search;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-
 import java.util.Date;
 
 @JsonSerialize(using = DateFilterSerializer.class)
 public class DateFilter {
 
-    private Date date;
+  private Date date;
 
-    private DateFilterRange range;
+  private DateFilterRange range;
 
-    public DateFilter(Date date, DateFilterRange range) {
-        super();
-        this.date = date;
-        this.range = range;
-    }
+  public DateFilter(Date date, DateFilterRange range) {
+    super();
+    this.date = date;
+    this.range = range;
+  }
 
-    public DateFilter(Date date) {
-        this(date, DateFilterRange.SECOND);
-    }
+  public DateFilter(Date date) {
+    this(date, DateFilterRange.SECOND);
+  }
 
-    public DateFilter() {
-        this(new Date());
-    }
+  public DateFilter() {
+    this(new Date());
+  }
 
-    public Date getDate() {
-        return date;
-    }
+  public Date getDate() {
+    return date;
+  }
 
-    public void setDate(Date date) {
-        this.date = date;
-    }
+  public void setDate(Date date) {
+    this.date = date;
+  }
 
-    public DateFilterRange getRange() {
-        return range;
-    }
+  public DateFilterRange getRange() {
+    return range;
+  }
 
-    public void setRange(DateFilterRange range) {
-        this.range = range;
-    }
-
+  public void setRange(DateFilterRange range) {
+    this.range = range;
+  }
 }

--- a/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/DateFilterRange.java
+++ b/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/DateFilterRange.java
@@ -1,16 +1,21 @@
 package io.camunda.operate.search;
 
 public enum DateFilterRange {
-    YEAR("y"), MONTH("M"), WEEK("w"), DAY("d"), HOUR("h"), MINUTE("m"), SECOND("s");
+  YEAR("y"),
+  MONTH("M"),
+  WEEK("w"),
+  DAY("d"),
+  HOUR("h"),
+  MINUTE("m"),
+  SECOND("s");
 
-    private String value;
+  private String value;
 
-    DateFilterRange(String value) {
-        this.value = value;
-    }
+  DateFilterRange(String value) {
+    this.value = value;
+  }
 
-    public String getValue() {
-        return value;
-    }
-
+  public String getValue() {
+    return value;
+  }
 }

--- a/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/DateFilterSerializer.java
+++ b/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/DateFilterSerializer.java
@@ -4,27 +4,24 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
-
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 
 public class DateFilterSerializer extends StdSerializer<DateFilter> {
 
-    public static SimpleDateFormat isoFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZZ");
+  public static SimpleDateFormat isoFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZZ");
 
-    /**
-     * serial version uid
-     */
-    private static final long serialVersionUID = -8106244922585465120L;
+  /** serial version uid */
+  private static final long serialVersionUID = -8106244922585465120L;
 
-    public DateFilterSerializer() {
-        super(DateFilter.class);
-    }
+  public DateFilterSerializer() {
+    super(DateFilter.class);
+  }
 
-    @Override
-    public void serialize(DateFilter value, JsonGenerator jgen, SerializerProvider provider)
-            throws IOException, JsonProcessingException {
+  @Override
+  public void serialize(DateFilter value, JsonGenerator jgen, SerializerProvider provider)
+      throws IOException, JsonProcessingException {
 
-        jgen.writeString(isoFormat.format(value.getDate()) + "||/" + value.getRange().getValue());
-    }
+    jgen.writeString(isoFormat.format(value.getDate()) + "||/" + value.getRange().getValue());
+  }
 }

--- a/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/DecisionDefinitionFilter.java
+++ b/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/DecisionDefinitionFilter.java
@@ -7,5 +7,4 @@ public class DecisionDefinitionFilter extends DecisionDefinition implements Filt
   public static DecisionDefinitionFilterBuilder builder() {
     return new DecisionDefinitionFilterBuilder();
   }
-
 }

--- a/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/DecisionDefinitionFilterBuilder.java
+++ b/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/DecisionDefinitionFilterBuilder.java
@@ -48,7 +48,8 @@ public class DecisionDefinitionFilterBuilder {
     return this;
   }
 
-  public DecisionDefinitionFilterBuilder decisionRequirementsVersion(Long decisionRequirementsVersion) {
+  public DecisionDefinitionFilterBuilder decisionRequirementsVersion(
+      Long decisionRequirementsVersion) {
     filter.setDecisionRequirementsVersion(decisionRequirementsVersion);
     return this;
   }
@@ -58,6 +59,7 @@ public class DecisionDefinitionFilterBuilder {
     return this;
   }
 
-  public DecisionDefinitionFilter build() { return filter; }
-
+  public DecisionDefinitionFilter build() {
+    return filter;
+  }
 }

--- a/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/DecisionInstanceFilter.java
+++ b/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/DecisionInstanceFilter.java
@@ -4,6 +4,7 @@ import io.camunda.operate.model.DecisionInstance;
 
 public class DecisionInstanceFilter extends DecisionInstance implements Filter {
 
-  public static DecisionInstanceFilterBuilder builder() { return new DecisionInstanceFilterBuilder(); }
-
+  public static DecisionInstanceFilterBuilder builder() {
+    return new DecisionInstanceFilterBuilder();
+  }
 }

--- a/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/DecisionInstanceFilterBuilder.java
+++ b/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/DecisionInstanceFilterBuilder.java
@@ -4,14 +4,15 @@ import io.camunda.operate.model.DecisionInstanceInput;
 import io.camunda.operate.model.DecisionInstanceOutput;
 import io.camunda.operate.model.DecisionState;
 import io.camunda.operate.model.DecisionType;
-
 import java.util.List;
 
 public class DecisionInstanceFilterBuilder {
 
   DecisionInstanceFilter filter;
 
-  DecisionInstanceFilterBuilder() { filter = new DecisionInstanceFilter(); }
+  DecisionInstanceFilterBuilder() {
+    filter = new DecisionInstanceFilter();
+  }
 
   public DecisionInstanceFilterBuilder id(String id) {
     filter.setId(id);
@@ -78,12 +79,14 @@ public class DecisionInstanceFilterBuilder {
     return this;
   }
 
-  public DecisionInstanceFilterBuilder evaluatedInputs(List<DecisionInstanceInput> evaluatedInputs) {
+  public DecisionInstanceFilterBuilder evaluatedInputs(
+      List<DecisionInstanceInput> evaluatedInputs) {
     filter.setEvaluatedInputs(evaluatedInputs);
     return this;
   }
 
-  public DecisionInstanceFilterBuilder evaluatedOutputs(List<DecisionInstanceOutput> evaluatedOutputs) {
+  public DecisionInstanceFilterBuilder evaluatedOutputs(
+      List<DecisionInstanceOutput> evaluatedOutputs) {
     filter.setEvaluatedOutputs(evaluatedOutputs);
     return this;
   }
@@ -93,6 +96,7 @@ public class DecisionInstanceFilterBuilder {
     return this;
   }
 
-  public DecisionInstanceFilter build() { return filter; }
-
+  public DecisionInstanceFilter build() {
+    return filter;
+  }
 }

--- a/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/DecisionRequirementsFilter.java
+++ b/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/DecisionRequirementsFilter.java
@@ -4,6 +4,7 @@ import io.camunda.operate.model.DecisionRequirements;
 
 public class DecisionRequirementsFilter extends DecisionRequirements implements Filter {
 
-  public static DecisionRequirementsFilterBuilder builder() { return new DecisionRequirementsFilterBuilder(); }
-
+  public static DecisionRequirementsFilterBuilder builder() {
+    return new DecisionRequirementsFilterBuilder();
+  }
 }

--- a/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/DecisionRequirementsFilterBuilder.java
+++ b/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/DecisionRequirementsFilterBuilder.java
@@ -1,11 +1,12 @@
 package io.camunda.operate.search;
 
-
 public class DecisionRequirementsFilterBuilder {
 
   DecisionRequirementsFilter filter;
 
-  DecisionRequirementsFilterBuilder() { filter = new DecisionRequirementsFilter(); }
+  DecisionRequirementsFilterBuilder() {
+    filter = new DecisionRequirementsFilter();
+  }
 
   public DecisionRequirementsFilterBuilder id(String id) {
     filter.setId(id);
@@ -42,6 +43,7 @@ public class DecisionRequirementsFilterBuilder {
     return this;
   }
 
-  public DecisionRequirementsFilter build() { return filter; }
-
+  public DecisionRequirementsFilter build() {
+    return filter;
+  }
 }

--- a/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/Filter.java
+++ b/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/Filter.java
@@ -1,5 +1,3 @@
 package io.camunda.operate.search;
 
-public interface Filter {
-
-}
+public interface Filter {}

--- a/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/FlowNodeInstanceFilter.java
+++ b/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/FlowNodeInstanceFilter.java
@@ -4,6 +4,7 @@ import io.camunda.operate.model.FlowNodeInstance;
 
 public class FlowNodeInstanceFilter extends FlowNodeInstance implements Filter {
 
-  public static FlowNodeInstanceFilterBuilder builder() { return new FlowNodeInstanceFilterBuilder(); }
-
+  public static FlowNodeInstanceFilterBuilder builder() {
+    return new FlowNodeInstanceFilterBuilder();
+  }
 }

--- a/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/FlowNodeInstanceFilterBuilder.java
+++ b/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/FlowNodeInstanceFilterBuilder.java
@@ -1,14 +1,15 @@
 package io.camunda.operate.search;
 
 import io.camunda.operate.model.FlowNodeInstanceState;
-
 import java.util.Date;
 
 public class FlowNodeInstanceFilterBuilder {
 
   FlowNodeInstanceFilter filter;
 
-  FlowNodeInstanceFilterBuilder() { filter = new FlowNodeInstanceFilter(); }
+  FlowNodeInstanceFilterBuilder() {
+    filter = new FlowNodeInstanceFilter();
+  }
 
   public FlowNodeInstanceFilterBuilder key(Long key) {
     filter.setKey(key);
@@ -70,6 +71,7 @@ public class FlowNodeInstanceFilterBuilder {
     return this;
   }
 
-  public FlowNodeInstanceFilter build() { return filter; }
-
+  public FlowNodeInstanceFilter build() {
+    return filter;
+  }
 }

--- a/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/IncidentFilter.java
+++ b/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/IncidentFilter.java
@@ -4,6 +4,7 @@ import io.camunda.operate.model.Incident;
 
 public class IncidentFilter extends Incident implements Filter {
 
-  public static IncidentFilterBuilder builder() { return new IncidentFilterBuilder(); }
-
+  public static IncidentFilterBuilder builder() {
+    return new IncidentFilterBuilder();
+  }
 }

--- a/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/IncidentFilterBuilder.java
+++ b/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/IncidentFilterBuilder.java
@@ -6,7 +6,9 @@ public class IncidentFilterBuilder {
 
   IncidentFilter filter;
 
-  IncidentFilterBuilder() { filter = new IncidentFilter(); }
+  IncidentFilterBuilder() {
+    filter = new IncidentFilter();
+  }
 
   public IncidentFilterBuilder key(Long key) {
     filter.setKey(key);
@@ -48,6 +50,7 @@ public class IncidentFilterBuilder {
     return this;
   }
 
-  public IncidentFilter build() { return filter; }
-
+  public IncidentFilter build() {
+    return filter;
+  }
 }

--- a/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/ProcessDefinitionFilter.java
+++ b/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/ProcessDefinitionFilter.java
@@ -7,5 +7,4 @@ public class ProcessDefinitionFilter extends ProcessDefinition implements Filter
   public static ProcessDefinitionFilterBuilder builder() {
     return new ProcessDefinitionFilterBuilder();
   }
-
 }

--- a/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/ProcessDefinitionFilterBuilder.java
+++ b/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/ProcessDefinitionFilterBuilder.java
@@ -36,5 +36,4 @@ public class ProcessDefinitionFilterBuilder {
   public ProcessDefinitionFilter build() {
     return filter;
   }
-
 }

--- a/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/ProcessInstanceFilter.java
+++ b/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/ProcessInstanceFilter.java
@@ -4,6 +4,7 @@ import io.camunda.operate.model.ProcessInstance;
 
 public class ProcessInstanceFilter extends ProcessInstance implements Filter {
 
-  public static ProcessInstanceFilterBuilder builder() { return new ProcessInstanceFilterBuilder(); }
-
+  public static ProcessInstanceFilterBuilder builder() {
+    return new ProcessInstanceFilterBuilder();
+  }
 }

--- a/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/ProcessInstanceFilterBuilder.java
+++ b/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/ProcessInstanceFilterBuilder.java
@@ -1,14 +1,15 @@
 package io.camunda.operate.search;
 
 import io.camunda.operate.model.ProcessInstanceState;
-
 import java.util.Date;
 
 public class ProcessInstanceFilterBuilder {
 
   ProcessInstanceFilter filter;
 
-  ProcessInstanceFilterBuilder() { filter = new ProcessInstanceFilter(); }
+  ProcessInstanceFilterBuilder() {
+    filter = new ProcessInstanceFilter();
+  }
 
   public ProcessInstanceFilterBuilder key(Long key) {
     filter.setKey(key);
@@ -55,6 +56,7 @@ public class ProcessInstanceFilterBuilder {
     return this;
   }
 
-  public ProcessInstanceFilter build() { return filter; }
-
+  public ProcessInstanceFilter build() {
+    return filter;
+  }
 }

--- a/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/SearchQuery.java
+++ b/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/SearchQuery.java
@@ -1,106 +1,103 @@
 package io.camunda.operate.search;
 
 import io.camunda.operate.exception.OperateException;
-
 import java.util.ArrayList;
 import java.util.List;
 
 public class SearchQuery {
+  private Filter filter;
+  private Integer size;
+  private List<Sort> sort;
+  private List<Object> searchAfter;
+
+  public Filter getFilter() {
+    return filter;
+  }
+
+  public void setFilter(Filter filter) {
+    this.filter = filter;
+  }
+
+  public Integer getSize() {
+    return size;
+  }
+
+  public void setSize(Integer size) {
+    this.size = size;
+  }
+
+  public List<Sort> getSort() {
+    return sort;
+  }
+
+  public void setSort(List<Sort> sort) {
+    this.sort = sort;
+  }
+
+  public List<Object> getSearchAfter() {
+    return searchAfter;
+  }
+
+  public void setSearchAfter(List<Object> searchAfter) {
+    this.searchAfter = searchAfter;
+  }
+
+  public static class Builder {
+
     private Filter filter;
     private Integer size;
-    private List<Sort> sort;
-    private List<Object> searchAfter;
+    private List<Sort> sorts = new ArrayList<>();
+    private List<Object> searchAfter = null;
 
-    public Filter getFilter() {
-        return filter;
+    public Builder() {}
+
+    @Deprecated
+    public Builder withFilter(Filter filter) {
+      this.filter = filter;
+      return this;
     }
 
-    public void setFilter(Filter filter) {
-        this.filter = filter;
+    public Builder filter(Filter filter) {
+      this.filter = filter;
+      return this;
     }
 
-    public Integer getSize() {
-        return size;
+    @Deprecated
+    public Builder withSize(Integer size) {
+      this.size = size;
+      return this;
     }
 
-    public void setSize(Integer size) {
-        this.size = size;
+    public Builder size(Integer size) {
+      this.size = size;
+      return this;
     }
 
-    public List<Sort> getSort() {
-        return sort;
+    @Deprecated
+    public Builder withSort(Sort sort) {
+      this.sorts.add(sort);
+      return this;
     }
 
-    public void setSort(List<Sort> sort) {
-        this.sort = sort;
+    public Builder sort(Sort sort) {
+      this.sorts.add(sort);
+      return this;
     }
 
-    public List<Object> getSearchAfter() {
-      return searchAfter;
-    }
-
-    public void setSearchAfter(List<Object> searchAfter) {
+    public Builder searchAfter(List<Object> searchAfter) {
       this.searchAfter = searchAfter;
+      return this;
     }
 
-    public static class Builder {
-
-        private Filter filter;
-        private Integer size;
-        private List<Sort> sorts = new ArrayList<>();
-        private List<Object> searchAfter=null;
-
-        public Builder() {
-
-        }
-
-        @Deprecated
-        public Builder withFilter(Filter filter) {
-            this.filter = filter;
-            return this;
-        }
-
-        public Builder filter(Filter filter) {
-            this.filter = filter;
-            return this;
-        }
-
-        @Deprecated
-        public Builder withSize(Integer size) {
-            this.size = size;
-            return this;
-        }
-
-        public Builder size(Integer size) {
-          this.size = size;
-          return this;
-        }
-
-        @Deprecated
-        public Builder withSort(Sort sort) {
-            this.sorts.add(sort);
-            return this;
-        }
-
-        public Builder sort(Sort sort) {
-            this.sorts.add(sort);
-            return this;
-        }
-
-        public Builder searchAfter(List<Object> searchAfter) {
-            this.searchAfter=searchAfter;
-            return this;
-        }
-
-        public SearchQuery build() throws OperateException {
-            SearchQuery query = new SearchQuery();
-            query.filter = filter;
-            query.size = size;
-            query.searchAfter = searchAfter;
-            if (!sorts.isEmpty()) {
-                query.setSort(sorts);
-            }
-            return query;
-        }
+    public SearchQuery build() throws OperateException {
+      SearchQuery query = new SearchQuery();
+      query.filter = filter;
+      query.size = size;
+      query.searchAfter = searchAfter;
+      if (!sorts.isEmpty()) {
+        query.setSort(sorts);
+      }
+      return query;
     }
+  }
 }

--- a/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/Sort.java
+++ b/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/Sort.java
@@ -2,34 +2,33 @@ package io.camunda.operate.search;
 
 public class Sort {
 
-    private String field;
+  private String field;
 
-    private SortOrder order;
+  private SortOrder order;
 
-    public Sort() {
-        super();
-    }
+  public Sort() {
+    super();
+  }
 
-    public Sort(String field, SortOrder order) {
-        super();
-        this.field = field;
-        this.order = order;
-    }
+  public Sort(String field, SortOrder order) {
+    super();
+    this.field = field;
+    this.order = order;
+  }
 
-    public String getField() {
-        return field;
-    }
+  public String getField() {
+    return field;
+  }
 
-    public void setField(String field) {
-        this.field = field;
-    }
+  public void setField(String field) {
+    this.field = field;
+  }
 
-    public SortOrder getOrder() {
-        return order;
-    }
+  public SortOrder getOrder() {
+    return order;
+  }
 
-    public void setOrder(SortOrder order) {
-        this.order = order;
-    }
-
+  public void setOrder(SortOrder order) {
+    this.order = order;
+  }
 }

--- a/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/SortOrder.java
+++ b/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/SortOrder.java
@@ -1,5 +1,6 @@
 package io.camunda.operate.search;
 
 public enum SortOrder {
-    ASC, DESC;
+  ASC,
+  DESC;
 }

--- a/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/VariableFilter.java
+++ b/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/VariableFilter.java
@@ -4,6 +4,7 @@ import io.camunda.operate.model.Variable;
 
 public class VariableFilter extends Variable implements Filter {
 
-  public static VariableFilterBuilder builder() { return new VariableFilterBuilder(); }
-
+  public static VariableFilterBuilder builder() {
+    return new VariableFilterBuilder();
+  }
 }

--- a/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/VariableFilterBuilder.java
+++ b/camunda-sdk-java/java-client-operate/src/main/java/io/camunda/operate/search/VariableFilterBuilder.java
@@ -4,7 +4,9 @@ public class VariableFilterBuilder {
 
   VariableFilter filter;
 
-  VariableFilterBuilder() { filter = new VariableFilter(); }
+  VariableFilterBuilder() {
+    filter = new VariableFilter();
+  }
 
   public VariableFilterBuilder key(Long key) {
     filter.setKey(key);
@@ -41,6 +43,7 @@ public class VariableFilterBuilder {
     return this;
   }
 
-  public VariableFilter build() { return filter; }
-
+  public VariableFilter build() {
+    return filter;
+  }
 }

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/DefaultNoopAuthentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/DefaultNoopAuthentication.java
@@ -1,21 +1,21 @@
 package io.camunda.common.auth;
 
 import io.camunda.common.exception.SdkException;
+import java.lang.invoke.MethodHandles;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.lang.invoke.MethodHandles;
-import java.util.Map;
-
 /**
- * Default implementation for Authentication
- * Typically you will replace this by a proper authentication by setting the right properties
+ * Default implementation for Authentication Typically you will replace this by a proper
+ * authentication by setting the right properties
  */
 public class DefaultNoopAuthentication implements Authentication {
 
   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  private final String errorMessage = "Unable to determine authentication. Please check your configuration";
+  private final String errorMessage =
+      "Unable to determine authentication. Please check your configuration";
 
   @Override
   public Authentication build() {

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/JwtAuthentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/JwtAuthentication.java
@@ -1,9 +1,7 @@
 package io.camunda.common.auth;
 
 /**
- * TODO: Figure out common functionality between SaaS and Self Managed that can be inserted here
- * to reduce code duplication. If not, remove this class
+ * TODO: Figure out common functionality between SaaS and Self Managed that can be inserted here to
+ * reduce code duplication. If not, remove this class
  */
-public abstract class JwtAuthentication implements Authentication {
-
-}
+public abstract class JwtAuthentication implements Authentication {}

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/JwtConfig.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/JwtConfig.java
@@ -3,9 +3,7 @@ package io.camunda.common.auth;
 import java.util.HashMap;
 import java.util.Map;
 
-/**
- * Contains mapping between products and their JWT credentials
- */
+/** Contains mapping between products and their JWT credentials */
 public class JwtConfig {
 
   private Map<Product, JwtCredential> map;
@@ -25,8 +23,4 @@ public class JwtConfig {
   public Map<Product, JwtCredential> getMap() {
     return map;
   }
-
 }
-
-
-

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/JwtCredential.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/JwtCredential.java
@@ -1,8 +1,6 @@
 package io.camunda.common.auth;
 
-/**
- * Contains credential for particular product. Used for JWT authentication.
- */
+/** Contains credential for particular product. Used for JWT authentication. */
 public class JwtCredential {
 
   public JwtCredential(String clientId, String clientSecret, String audience, String authUrl) {
@@ -32,5 +30,4 @@ public class JwtCredential {
   public String getAuthUrl() {
     return authUrl;
   }
-
 }

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/Product.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/Product.java
@@ -1,8 +1,11 @@
 package io.camunda.common.auth;
 
-/**
- * Enum for different C8 Products
- */
+/** Enum for different C8 Products */
 public enum Product {
-  ZEEBE, OPERATE, TASKLIST, CONSOLE, OPTIMIZE, WEB_MODELER
+  ZEEBE,
+  OPERATE,
+  TASKLIST,
+  CONSOLE,
+  OPTIMIZE,
+  WEB_MODELER
 }

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SaaSAuthentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SaaSAuthentication.java
@@ -2,6 +2,10 @@ package io.camunda.common.auth;
 
 import io.camunda.common.json.JsonMapper;
 import io.camunda.common.json.SdkObjectMapper;
+import java.lang.invoke.MethodHandles;
+import java.util.AbstractMap;
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
@@ -9,12 +13,6 @@ import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.lang.invoke.MethodHandles;
-import java.time.LocalDateTime;
-import java.util.AbstractMap;
-import java.util.HashMap;
-import java.util.Map;
 
 public class SaaSAuthentication extends JwtAuthentication {
 
@@ -52,13 +50,16 @@ public class SaaSAuthentication extends JwtAuthentication {
   }
 
   private String retrieveToken(Product product, JwtCredential jwtCredential) {
-      try(CloseableHttpClient client = HttpClients.createDefault()){
-        HttpPost request = buildRequest(jwtCredential);
-        TokenResponse tokenResponse = client.execute(request, response ->
-           jsonMapper.fromJson(EntityUtils.toString(response.getEntity()), TokenResponse.class)
-        );
-        tokens.put(product, tokenResponse.getAccessToken());
-      } catch (Exception e) {
+    try (CloseableHttpClient client = HttpClients.createDefault()) {
+      HttpPost request = buildRequest(jwtCredential);
+      TokenResponse tokenResponse =
+          client.execute(
+              request,
+              response ->
+                  jsonMapper.fromJson(
+                      EntityUtils.toString(response.getEntity()), TokenResponse.class));
+      tokens.put(product, tokenResponse.getAccessToken());
+    } catch (Exception e) {
       LOG.error("Authenticating for " + product + " failed due to " + e);
       throw new RuntimeException("Unable to authenticate", e);
     }
@@ -68,7 +69,11 @@ public class SaaSAuthentication extends JwtAuthentication {
   private HttpPost buildRequest(JwtCredential jwtCredential) {
     HttpPost httpPost = new HttpPost(jwtCredential.getAuthUrl());
     httpPost.addHeader("Content-Type", "application/json");
-    TokenRequest tokenRequest = new TokenRequest(jwtCredential.getAudience(), jwtCredential.getClientId(), jwtCredential.getClientSecret());
+    TokenRequest tokenRequest =
+        new TokenRequest(
+            jwtCredential.getAudience(),
+            jwtCredential.getClientId(),
+            jwtCredential.getClientSecret());
     httpPost.setEntity(new StringEntity(jsonMapper.toJson(tokenRequest)));
     return httpPost;
   }

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SaaSAuthenticationBuilder.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SaaSAuthenticationBuilder.java
@@ -16,5 +16,4 @@ public class SaaSAuthenticationBuilder {
   public Authentication build() {
     return saaSAuthentication.build();
   }
-
 }

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SelfManagedAuthentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SelfManagedAuthentication.java
@@ -3,14 +3,12 @@ package io.camunda.common.auth;
 import io.camunda.common.auth.identity.IdentityConfig;
 import io.camunda.identity.sdk.Identity;
 import io.camunda.identity.sdk.authentication.Tokens;
-import io.camunda.identity.sdk.authentication.exception.TokenExpiredException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.lang.invoke.MethodHandles;
 import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SelfManagedAuthentication extends JwtAuthentication {
 

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SimpleAuthentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SimpleAuthentication.java
@@ -1,5 +1,7 @@
 package io.camunda.common.auth;
 
+import java.lang.invoke.MethodHandles;
+import java.util.*;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.entity.UrlEncodedFormEntity;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
@@ -9,9 +11,6 @@ import org.apache.hc.core5.http.NameValuePair;
 import org.apache.hc.core5.http.message.BasicNameValuePair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.lang.invoke.MethodHandles;
-import java.util.*;
 
 public class SimpleAuthentication implements Authentication {
 
@@ -39,29 +38,34 @@ public class SimpleAuthentication implements Authentication {
     tokens = new HashMap<>();
   }
 
-  public static SimpleAuthenticationBuilder builder() { return new SimpleAuthenticationBuilder(); }
+  public static SimpleAuthenticationBuilder builder() {
+    return new SimpleAuthenticationBuilder();
+  }
 
   @Override
   public Authentication build() {
-    authUrl = simpleUrl+"/api/login";
+    authUrl = simpleUrl + "/api/login";
     return this;
   }
 
   private String retrieveToken(Product product, SimpleCredential simpleCredential) {
-    try(CloseableHttpClient client = HttpClients.createDefault()) {
+    try (CloseableHttpClient client = HttpClients.createDefault()) {
       HttpPost request = buildRequest(simpleCredential);
-      String cookie = client.execute(request, response -> {
-        Header[] cookieHeaders = response.getHeaders("Set-Cookie");
-        String cookieCandidate = null;
-        String cookiePrefix = product.toString().toUpperCase() + "-SESSION";
-        for (Header cookieHeader : cookieHeaders) {
-          if (cookieHeader.getValue().startsWith(cookiePrefix)) {
-            cookieCandidate = response.getHeader("Set-Cookie").getValue();
-            break;
-          }
-        }
-        return cookieCandidate;
-      });
+      String cookie =
+          client.execute(
+              request,
+              response -> {
+                Header[] cookieHeaders = response.getHeaders("Set-Cookie");
+                String cookieCandidate = null;
+                String cookiePrefix = product.toString().toUpperCase() + "-SESSION";
+                for (Header cookieHeader : cookieHeaders) {
+                  if (cookieHeader.getValue().startsWith(cookiePrefix)) {
+                    cookieCandidate = response.getHeader("Set-Cookie").getValue();
+                    break;
+                  }
+                }
+                return cookieCandidate;
+              });
       if (cookie == null) {
         throw new RuntimeException("Unable to authenticate due to missing Set-Cookie");
       }
@@ -82,7 +86,7 @@ public class SimpleAuthentication implements Authentication {
     return httpPost;
   }
 
-    @Override
+  @Override
   public Map.Entry<String, String> getTokenHeader(Product product) {
     String token;
     if (tokens.containsKey(product)) {

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SimpleAuthenticationBuilder.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SimpleAuthenticationBuilder.java
@@ -21,5 +21,4 @@ public class SimpleAuthenticationBuilder {
   public Authentication build() {
     return simpleAuthentication.build();
   }
-
 }

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SimpleConfig.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SimpleConfig.java
@@ -3,9 +3,7 @@ package io.camunda.common.auth;
 import java.util.HashMap;
 import java.util.Map;
 
-/**
- * Contains mapping between products and their Simple credentials
- */
+/** Contains mapping between products and their Simple credentials */
 public class SimpleConfig {
 
   private Map<Product, SimpleCredential> map;
@@ -25,5 +23,4 @@ public class SimpleConfig {
   public SimpleCredential getProduct(Product product) {
     return map.get(product);
   }
-
 }

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SimpleCredential.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SimpleCredential.java
@@ -1,8 +1,6 @@
 package io.camunda.common.auth;
 
-/**
- * Contains credential for particular product. Used for Simple authentication.
- */
+/** Contains credential for particular product. Used for Simple authentication. */
 public class SimpleCredential {
 
   public SimpleCredential(String user, String password) {
@@ -20,5 +18,4 @@ public class SimpleCredential {
   public String getPassword() {
     return password;
   }
-
 }

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/TokenRequest.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/TokenRequest.java
@@ -53,5 +53,4 @@ public class TokenRequest {
     this.clientId = clientId;
     this.clientSecret = clientSecret;
   }
-
 }

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/TokenResponse.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/TokenResponse.java
@@ -6,14 +6,13 @@ public class TokenResponse {
 
   @JsonProperty("access_token")
   private String accessToken;
+
   private String scope;
 
   @JsonProperty("expires_in")
-
   private Integer expiresIn;
 
   @JsonProperty("token_type")
-
   private String tokenType;
 
   TokenResponse() {}

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/identity/IdentityConfig.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/identity/IdentityConfig.java
@@ -1,13 +1,10 @@
 package io.camunda.common.auth.identity;
 
 import io.camunda.common.auth.Product;
-
 import java.util.HashMap;
 import java.util.Map;
 
-/**
- * Contains mapping between products and their Identity and IdentityConfiguration
- */
+/** Contains mapping between products and their Identity and IdentityConfiguration */
 public class IdentityConfig {
 
   private final Map<Product, IdentityContainer> map;

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/exception/SdkException.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/exception/SdkException.java
@@ -7,9 +7,11 @@ public class SdkException extends RuntimeException {
   public SdkException(final Throwable cause) {
     super(cause);
   }
+
   public SdkException(final String message) {
     super(message);
   }
+
   public SdkException(final String message, final Throwable cause) {
     super(message, cause);
   }

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/http/HttpClient.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/http/HttpClient.java
@@ -2,12 +2,9 @@ package io.camunda.common.http;
 
 import com.google.common.reflect.TypeToken;
 import io.camunda.common.auth.Product;
-
 import java.util.Map;
 
-/**
- * Interface to enable swappable http client implementations
- */
+/** Interface to enable swappable http client implementations */
 public interface HttpClient {
 
   void init(String host, String basePath);
@@ -25,5 +22,4 @@ public interface HttpClient {
   <T, V, W, U> T post(Class<T> responseType, Class<V> parameterType, TypeToken<W> selector, U body);
 
   <T, V> T delete(Class<T> responseType, Class<V> selector, Long key);
-
 }

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/http/Java8Utils.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/http/Java8Utils.java
@@ -3,16 +3,10 @@ package io.camunda.common.http;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.AbstractMap;
-import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class Java8Utils {
 
-  private Java8Utils() {
-
-  }
+  private Java8Utils() {}
 
   public static byte[] readAllBytes(InputStream inputStream) throws IOException {
     final int bufLen = 4 * 0x400; // 4KB
@@ -32,11 +26,12 @@ public class Java8Utils {
       throw e;
     } finally {
       if (exception == null) inputStream.close();
-      else try {
-        inputStream.close();
-      } catch (IOException e) {
-        exception.addSuppressed(e);
-      }
+      else
+        try {
+          inputStream.close();
+        } catch (IOException e) {
+          exception.addSuppressed(e);
+        }
     }
   }
 }

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/http/Request.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/http/Request.java
@@ -4,5 +4,4 @@ public class Request {
 
   String uri;
   String query;
-
 }

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/json/JsonMapper.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/json/JsonMapper.java
@@ -5,9 +5,12 @@ import java.util.Map;
 public interface JsonMapper {
 
   <T> T fromJson(final String json, final Class<T> resultType);
-  <T, U> T fromJson(final String json, final Class<T> resultType, final Class<U> parameterType);
-  Map<String, Object> fromJsonAsMap(final String json);
-  Map<String, String> fromJsonAsStringMap(final String json);
-  String toJson(final Object value);
 
+  <T, U> T fromJson(final String json, final Class<T> resultType, final Class<U> parameterType);
+
+  Map<String, Object> fromJsonAsMap(final String json);
+
+  Map<String, String> fromJsonAsStringMap(final String json);
+
+  String toJson(final Object value);
 }

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/json/SdkObjectMapper.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/json/SdkObjectMapper.java
@@ -8,17 +8,16 @@ import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import io.camunda.common.exception.SdkException;
-
 import java.io.IOException;
 import java.util.Map;
 
 public class SdkObjectMapper implements JsonMapper {
 
   private static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE =
-    new TypeReference<Map<String, Object>>() {};
+      new TypeReference<Map<String, Object>>() {};
 
   private static final TypeReference<Map<String, String>> STRING_MAP_TYPE_REFERENCE =
-    new TypeReference<Map<String, String>>() {};
+      new TypeReference<Map<String, String>>() {};
 
   private final ObjectMapper objectMapper;
 
@@ -29,9 +28,9 @@ public class SdkObjectMapper implements JsonMapper {
   public SdkObjectMapper(ObjectMapper objectMapper) {
     this.objectMapper = objectMapper;
     this.objectMapper
-      .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
-      .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-      .setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+        .setSerializationInclusion(JsonInclude.Include.NON_NULL);
   }
 
   @Override
@@ -40,18 +39,22 @@ public class SdkObjectMapper implements JsonMapper {
       return objectMapper.readValue(json, typeClass);
     } catch (final IOException e) {
       throw new SdkException(
-        String.format("Failed to deserialize json '%s' to class '%s'", json, typeClass), e);
+          String.format("Failed to deserialize json '%s' to class '%s'", json, typeClass), e);
     }
   }
 
   @Override
   public <T, U> T fromJson(String json, Class<T> resultType, Class<U> parameterType) {
     try {
-      JavaType javaType = objectMapper.getTypeFactory().constructParametricType(resultType, parameterType);
+      JavaType javaType =
+          objectMapper.getTypeFactory().constructParametricType(resultType, parameterType);
       return objectMapper.readValue(json, javaType);
     } catch (final IOException e) {
       throw new SdkException(
-        String.format("Failed to deserialize json '%s' to class '%s' with parameter '%s", json, resultType, parameterType), e);
+          String.format(
+              "Failed to deserialize json '%s' to class '%s' with parameter '%s",
+              json, resultType, parameterType),
+          e);
     }
   }
 
@@ -61,7 +64,7 @@ public class SdkObjectMapper implements JsonMapper {
       return objectMapper.readValue(json, MAP_TYPE_REFERENCE);
     } catch (final IOException e) {
       throw new SdkException(
-        String.format("Failed to deserialize json '%s' to 'Map<String, Object>'", json), e);
+          String.format("Failed to deserialize json '%s' to 'Map<String, Object>'", json), e);
     }
   }
 
@@ -71,7 +74,7 @@ public class SdkObjectMapper implements JsonMapper {
       return objectMapper.readValue(json, STRING_MAP_TYPE_REFERENCE);
     } catch (final IOException e) {
       throw new SdkException(
-        String.format("Failed to deserialize json '%s' to 'Map<String, String>'", json), e);
+          String.format("Failed to deserialize json '%s' to 'Map<String, String>'", json), e);
     }
   }
 
@@ -80,8 +83,7 @@ public class SdkObjectMapper implements JsonMapper {
     try {
       return objectMapper.writeValueAsString(value);
     } catch (final JsonProcessingException e) {
-      throw new SdkException(
-        String.format("Failed to serialize object '%s' to json", value), e);
+      throw new SdkException(String.format("Failed to serialize object '%s' to json", value), e);
     }
   }
 }

--- a/camunda-sdk-java/java-common/src/test/java/io/camunda/common/http/DefaultHttpClientTest.java
+++ b/camunda-sdk-java/java-common/src/test/java/io/camunda/common/http/DefaultHttpClientTest.java
@@ -1,10 +1,18 @@
 package io.camunda.common.http;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
 import com.google.common.reflect.TypeToken;
 import io.camunda.common.auth.Authentication;
 import io.camunda.common.auth.Product;
 import io.camunda.common.json.JsonMapper;
 import io.camunda.common.json.SdkObjectMapper;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.*;
 import org.apache.hc.client5.http.classic.methods.HttpDelete;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
@@ -16,30 +24,19 @@ import org.mockito.Mock;
 import org.mockito.internal.matchers.apachecommons.ReflectionEquals;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.util.*;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
-
 @ExtendWith(MockitoExtension.class)
 public class DefaultHttpClientTest {
 
-
-  @Mock
-  Authentication authentication;
-  @Mock
-  CloseableHttpClient chClient;
+  @Mock Authentication authentication;
+  @Mock CloseableHttpClient chClient;
   JsonMapper jsonMapper = new SdkObjectMapper();
 
   @Test
   public void shouldReturnGetType() throws IOException {
     // given
     Map<Product, Map<Class<?>, String>> productMap = new HashMap<>();
-    DefaultHttpClient defaultHttpClient = new DefaultHttpClient(authentication, chClient, jsonMapper, productMap);
+    DefaultHttpClient defaultHttpClient =
+        new DefaultHttpClient(authentication, chClient, jsonMapper, productMap);
     CloseableHttpResponse response = mock(CloseableHttpResponse.class, RETURNS_DEEP_STUBS);
     MyResponseClass expectedOutput = new MyResponseClass();
     expectedOutput.setName("test-name");
@@ -47,8 +44,10 @@ public class DefaultHttpClientTest {
     // when
     when(chClient.execute(any(HttpGet.class))).thenReturn(response);
     when(response.getCode()).thenReturn(200);
-    when(authentication.getTokenHeader(any())).thenReturn(new AbstractMap.SimpleEntry<>("key", "value"));
-    when(response.getEntity().getContent()).thenReturn(new ByteArrayInputStream("{\"name\" : \"test-name\"}".getBytes()));
+    when(authentication.getTokenHeader(any()))
+        .thenReturn(new AbstractMap.SimpleEntry<>("key", "value"));
+    when(response.getEntity().getContent())
+        .thenReturn(new ByteArrayInputStream("{\"name\" : \"test-name\"}".getBytes()));
     MyResponseClass parsedResponse = defaultHttpClient.get(MyResponseClass.class, "123");
 
     // then
@@ -59,7 +58,8 @@ public class DefaultHttpClientTest {
   public void shouldReturnPostType() throws IOException {
     // given
     Map<Product, Map<Class<?>, String>> productMap = new HashMap<>();
-    DefaultHttpClient defaultHttpClient = new DefaultHttpClient(authentication, chClient, jsonMapper, productMap);
+    DefaultHttpClient defaultHttpClient =
+        new DefaultHttpClient(authentication, chClient, jsonMapper, productMap);
     CloseableHttpResponse response = mock(CloseableHttpResponse.class, RETURNS_DEEP_STUBS);
     MyResponseClass insideClass = new MyResponseClass();
     insideClass.setName("test-name");
@@ -69,9 +69,13 @@ public class DefaultHttpClientTest {
     // when
     when(chClient.execute(any(HttpPost.class))).thenReturn(response);
     when(response.getCode()).thenReturn(200);
-    when(authentication.getTokenHeader(any())).thenReturn(new AbstractMap.SimpleEntry<>("key", "value"));
-    when(response.getEntity().getContent()).thenReturn(new ByteArrayInputStream("[{\"name\" : \"test-name\"}]".getBytes()));
-    List parsedResponse = defaultHttpClient.post(List.class, MyResponseClass.class, TypeToken.of(MyResponseClass.class), "dummy");
+    when(authentication.getTokenHeader(any()))
+        .thenReturn(new AbstractMap.SimpleEntry<>("key", "value"));
+    when(response.getEntity().getContent())
+        .thenReturn(new ByteArrayInputStream("[{\"name\" : \"test-name\"}]".getBytes()));
+    List parsedResponse =
+        defaultHttpClient.post(
+            List.class, MyResponseClass.class, TypeToken.of(MyResponseClass.class), "dummy");
 
     // then
     assertEquals(expectedOutput.size(), parsedResponse.size());
@@ -82,7 +86,8 @@ public class DefaultHttpClientTest {
   public void shouldReturnDeleteType() throws IOException {
     // given
     Map<Product, Map<Class<?>, String>> productMap = new HashMap<>();
-    DefaultHttpClient defaultHttpClient = new DefaultHttpClient(authentication, chClient, jsonMapper, productMap);
+    DefaultHttpClient defaultHttpClient =
+        new DefaultHttpClient(authentication, chClient, jsonMapper, productMap);
     CloseableHttpResponse response = mock(CloseableHttpResponse.class, RETURNS_DEEP_STUBS);
     MyResponseClass expectedOutput = new MyResponseClass();
     expectedOutput.setName("test-name");
@@ -90,9 +95,12 @@ public class DefaultHttpClientTest {
     // when
     when(chClient.execute(any(HttpDelete.class))).thenReturn(response);
     when(response.getCode()).thenReturn(200);
-    when(authentication.getTokenHeader(any())).thenReturn(new AbstractMap.SimpleEntry<>("key", "value"));
-    when(response.getEntity().getContent()).thenReturn(new ByteArrayInputStream("{\"name\" : \"test-name\"}".getBytes()));
-    MyResponseClass parsedResponse = defaultHttpClient.delete(MyResponseClass.class, MySelectorClass.class, 123L);
+    when(authentication.getTokenHeader(any()))
+        .thenReturn(new AbstractMap.SimpleEntry<>("key", "value"));
+    when(response.getEntity().getContent())
+        .thenReturn(new ByteArrayInputStream("{\"name\" : \"test-name\"}".getBytes()));
+    MyResponseClass parsedResponse =
+        defaultHttpClient.delete(MyResponseClass.class, MySelectorClass.class, 123L);
 
     // then
     assertTrue(new ReflectionEquals(expectedOutput).matches(parsedResponse));
@@ -102,10 +110,11 @@ public class DefaultHttpClientTest {
 
   public static class MyResponseClass {
     private String name;
+
     public void setName(String name) {
       this.name = name;
     }
   }
 
-  public static class MySelectorClass { }
+  public static class MySelectorClass {}
 }

--- a/example/src/main/java/io/camunda/zeebe/spring/example/ExampleApplication.java
+++ b/example/src/main/java/io/camunda/zeebe/spring/example/ExampleApplication.java
@@ -13,5 +13,4 @@ public class ExampleApplication {
   public static void main(final String... args) {
     SpringApplication.run(ExampleApplication.class, args);
   }
-
 }

--- a/example/src/main/java/io/camunda/zeebe/spring/example/ExampleJobWorkers.java
+++ b/example/src/main/java/io/camunda/zeebe/spring/example/ExampleJobWorkers.java
@@ -1,16 +1,13 @@
 package io.camunda.zeebe.spring.example;
 
-import io.camunda.zeebe.client.api.worker.JobClient;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
+import io.camunda.zeebe.client.api.worker.JobClient;
 import io.camunda.zeebe.spring.client.annotation.JobWorker;
 import io.camunda.zeebe.spring.client.annotation.Variable;
-
+import io.camunda.zeebe.spring.client.exception.ZeebeBpmnError;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.Map;
-
-import io.camunda.zeebe.spring.client.exception.ZeebeBpmnError;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -32,22 +29,22 @@ public class ExampleJobWorkers {
   }
 
   @JobWorker(type = "fail", fetchAllVariables = true)
-  public void handleFailingJob(final JobClient client, final ActivatedJob job, @Variable String someResult) {
+  public void handleFailingJob(
+      final JobClient client, final ActivatedJob job, @Variable String someResult) {
     logJob(job, someResult);
     throw new ZeebeBpmnError("DOESNT_WORK", "This will actually never work :-)");
   }
 
   private static void logJob(final ActivatedJob job, Object parameterValue) {
     log.info(
-      "complete job\n>>> [type: {}, key: {}, element: {}, workflow instance: {}]\n{deadline; {}]\n[headers: {}]\n[variable parameter: {}\n[variables: {}]",
-      job.getType(),
-      job.getKey(),
-      job.getElementId(),
-      job.getProcessInstanceKey(),
-      Instant.ofEpochMilli(job.getDeadline()),
-      job.getCustomHeaders(),
-      parameterValue,
-      job.getVariables());
+        "complete job\n>>> [type: {}, key: {}, element: {}, workflow instance: {}]\n{deadline; {}]\n[headers: {}]\n[variable parameter: {}\n[variables: {}]",
+        job.getType(),
+        job.getKey(),
+        job.getElementId(),
+        job.getProcessInstanceKey(),
+        Instant.ofEpochMilli(job.getDeadline()),
+        job.getCustomHeaders(),
+        parameterValue,
+        job.getVariables());
   }
-
 }

--- a/example/src/main/java/io/camunda/zeebe/spring/example/PeriodicProcessStarter.java
+++ b/example/src/main/java/io/camunda/zeebe/spring/example/PeriodicProcessStarter.java
@@ -2,35 +2,42 @@ package io.camunda.zeebe.spring.example;
 
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
+import java.util.Date;
+import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-import java.util.Date;
-import java.util.UUID;
-
 @Component
 public class PeriodicProcessStarter {
 
   private static Logger log = LoggerFactory.getLogger(ExampleApplication.class);
 
-  @Autowired
-  private ZeebeClient client;
+  @Autowired private ZeebeClient client;
 
   @Scheduled(fixedRate = 5000L)
   public void startProcesses() {
     final ProcessInstanceEvent event =
-      client
-        .newCreateInstanceCommand()
-        .bpmnProcessId("demoProcess")
-        .latestVersion()
-        .variables("{\"a\": \"" + UUID.randomUUID().toString() + "\",\"b\": \"" + new Date().toString() + "\"}")
-        .send()
-        .join();
+        client
+            .newCreateInstanceCommand()
+            .bpmnProcessId("demoProcess")
+            .latestVersion()
+            .variables(
+                "{\"a\": \""
+                    + UUID.randomUUID().toString()
+                    + "\",\"b\": \""
+                    + new Date().toString()
+                    + "\"}")
+            .send()
+            .join();
 
-    log.info("started instance for workflowKey='{}', bpmnProcessId='{}', version='{}' with workflowInstanceKey='{}'",
-      event.getProcessDefinitionKey(), event.getBpmnProcessId(), event.getVersion(), event.getProcessInstanceKey());
+    log.info(
+        "started instance for workflowKey='{}', bpmnProcessId='{}', version='{}' with workflowInstanceKey='{}'",
+        event.getProcessDefinitionKey(),
+        event.getBpmnProcessId(),
+        event.getVersion(),
+        event.getProcessInstanceKey());
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -276,8 +276,82 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>2.41.1</version>
+        <configuration>
+          <formats>
+            <format>
+              <includes>
+                <include>*.md</include>
+                <include>.gitignore</include>
+              </includes>
+              <trimTrailingWhitespace />
+              <endWithNewline />
+              <indent>
+                <spaces>true</spaces>
+                <spacesPerTab>2</spacesPerTab>
+              </indent>
+            </format>
+          </formats>
+          <java>
+            <googleJavaFormat />
+          </java>
+          <pom />
+        </configuration>
+      </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <!-- profile to auto format -->
+    <profile>
+      <id>autoFormat</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.diffplug.spotless</groupId>
+            <artifactId>spotless-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>spotless-format</id>
+                <goals>
+                  <goal>apply</goal>
+                </goals>
+                <phase>process-sources</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <!-- profile to perform strict validation checks -->
+    <profile>
+      <id>checkFormat</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.diffplug.spotless</groupId>
+            <artifactId>spotless-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>spotless-check</id>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+                <phase>validate</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
   <repositories>
     <repository>

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/CamundaAutoConfiguration.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/CamundaAutoConfiguration.java
@@ -1,5 +1,8 @@
 package io.camunda.zeebe.spring.client;
 
+import static com.fasterxml.jackson.databind.DeserializationFeature.ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT;
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.JsonMapper;
@@ -7,6 +10,7 @@ import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
 import io.camunda.zeebe.spring.client.configuration.*;
 import io.camunda.zeebe.spring.client.event.ZeebeLifecycleEventProducer;
 import io.camunda.zeebe.spring.client.testsupport.SpringZeebeTestContext;
+import java.lang.invoke.MethodHandles;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -17,15 +21,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.lang.invoke.MethodHandles;
-
-import static com.fasterxml.jackson.databind.DeserializationFeature.ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT;
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
-
-/**
- *
- * Enabled by META-INF of Spring Boot Starter to provide beans for Camunda Clients
- */
+/** Enabled by META-INF of Spring Boot Starter to provide beans for Camunda Clients */
 @Configuration
 @ImportAutoConfiguration({
   ZeebeClientProdAutoConfiguration.class,
@@ -35,34 +31,43 @@ import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKN
   ZeebeActuatorConfiguration.class,
   MetricsDefaultConfiguration.class
 })
-@AutoConfigureAfter(JacksonAutoConfiguration.class) // make sure Spring created ObjectMapper is preferred if available
+@AutoConfigureAfter(
+    JacksonAutoConfiguration
+        .class) // make sure Spring created ObjectMapper is preferred if available
 public class CamundaAutoConfiguration {
 
   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  public static final ObjectMapper DEFAULT_OBJECT_MAPPER = new ObjectMapper()
-    .configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
-    .configure(ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT, true);
+  public static final ObjectMapper DEFAULT_OBJECT_MAPPER =
+      new ObjectMapper()
+          .configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
+          .configure(ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT, true);
 
   @Bean
-  @ConditionalOnMissingBean(SpringZeebeTestContext.class) // only run if we are not running in a test case - as otherwise the the lifecycle is controlled by the test
-  public ZeebeLifecycleEventProducer zeebeLifecycleEventProducer(final ZeebeClient client, final ApplicationEventPublisher publisher) {
+  @ConditionalOnMissingBean(
+      SpringZeebeTestContext
+          .class) // only run if we are not running in a test case - as otherwise the the lifecycle
+  // is controlled by the test
+  public ZeebeLifecycleEventProducer zeebeLifecycleEventProducer(
+      final ZeebeClient client, final ApplicationEventPublisher publisher) {
     return new ZeebeLifecycleEventProducer(client, publisher);
   }
 
   /**
-   * Registering a JsonMapper bean when there is none already exists in {@link org.springframework.beans.factory.BeanFactory}.
+   * Registering a JsonMapper bean when there is none already exists in {@link
+   * org.springframework.beans.factory.BeanFactory}.
    *
-   * NOTE: This method SHOULD NOT be explicitly called as it might lead to unexpected behaviour due to the
-   * {@link ConditionalOnMissingBean} annotation. i.e. Calling this method when another JsonMapper bean is defined in the context
-   * might throw {@link org.springframework.beans.factory.NoSuchBeanDefinitionException}
+   * <p>NOTE: This method SHOULD NOT be explicitly called as it might lead to unexpected behaviour
+   * due to the {@link ConditionalOnMissingBean} annotation. i.e. Calling this method when another
+   * JsonMapper bean is defined in the context might throw {@link
+   * org.springframework.beans.factory.NoSuchBeanDefinitionException}
    *
-   * @return a new JsonMapper bean if none already exists in {@link org.springframework.beans.factory.BeanFactory}
+   * @return a new JsonMapper bean if none already exists in {@link
+   *     org.springframework.beans.factory.BeanFactory}
    */
   @Bean(name = "zeebeJsonMapper")
   @ConditionalOnMissingBean
   public JsonMapper jsonMapper(ObjectMapper objectMapper) {
     return new ZeebeObjectMapper(objectMapper);
   }
-
 }

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/actuator/MicrometerMetricsRecorder.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/actuator/MicrometerMetricsRecorder.java
@@ -5,18 +5,18 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Timer;
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.lang.invoke.MethodHandles;
-import java.util.HashMap;
-import java.util.Map;
-
 public class MicrometerMetricsRecorder implements MetricsRecorder {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   private final MeterRegistry meterRegistry;
   private final Map<String, Counter> counters = new HashMap<>();
@@ -51,5 +51,4 @@ public class MicrometerMetricsRecorder implements MetricsRecorder {
     Timer timer = meterRegistry.timer(metricName, "type", jobType);
     timer.record(methodToExecute);
   }
-
 }

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/actuator/ZeebeClientHealthIndicator.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/actuator/ZeebeClientHealthIndicator.java
@@ -5,11 +5,6 @@ import io.camunda.zeebe.client.api.response.Topology;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.health.AbstractHealthIndicator;
 import org.springframework.boot.actuate.health.Health;
-import org.springframework.boot.actuate.health.HealthIndicator;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.stereotype.Component;
 
 public class ZeebeClientHealthIndicator extends AbstractHealthIndicator {
 
@@ -29,5 +24,4 @@ public class ZeebeClientHealthIndicator extends AbstractHealthIndicator {
       builder.up();
     }
   }
-
 }

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/CommonClientConfiguration.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/CommonClientConfiguration.java
@@ -1,21 +1,23 @@
 package io.camunda.zeebe.spring.client.configuration;
 
+import static org.springframework.util.StringUtils.hasText;
+
 import io.camunda.common.auth.*;
-import io.camunda.common.auth.identity.IdentityContainer;
 import io.camunda.common.auth.identity.IdentityConfig;
+import io.camunda.common.auth.identity.IdentityContainer;
 import io.camunda.common.exception.SdkException;
-import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.identity.sdk.Identity;
+import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.zeebe.spring.client.properties.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 
-import static org.springframework.util.StringUtils.hasText;
-
-@EnableConfigurationProperties({CommonConfigurationProperties.class, ZeebeSelfManagedProperties.class})
+@EnableConfigurationProperties({
+  CommonConfigurationProperties.class,
+  ZeebeSelfManagedProperties.class
+})
 public class CommonClientConfiguration {
-
 
   @Autowired(required = false)
   CommonConfigurationProperties commonConfigurationProperties;
@@ -48,28 +50,32 @@ public class CommonClientConfiguration {
     if (zeebeClientConfigurationProperties != null) {
       // check if Zeebe has clusterId provided, then must be SaaS
       if (zeebeClientConfigurationProperties.getCloud().getClusterId() != null) {
-        return SaaSAuthentication.builder()
-          .jwtConfig(configureJwtConfig())
-          .build();
-      } else if (zeebeClientConfigurationProperties.getBroker().getGatewayAddress() != null || zeebeSelfManagedProperties.getGatewayAddress() != null) {
+        return SaaSAuthentication.builder().jwtConfig(configureJwtConfig()).build();
+      } else if (zeebeClientConfigurationProperties.getBroker().getGatewayAddress() != null
+          || zeebeSelfManagedProperties.getGatewayAddress() != null) {
         // figure out if Self-Managed JWT or Self-Managed Basic
         // Operate Client props take first priority
         if (operateClientConfigurationProperties != null) {
-          if (hasText(operateClientConfigurationProperties.getKeycloakUrl()) || hasText(operateClientConfigurationProperties.getKeycloakTokenUrl())) {
+          if (hasText(operateClientConfigurationProperties.getKeycloakUrl())
+              || hasText(operateClientConfigurationProperties.getKeycloakTokenUrl())) {
             JwtConfig jwtConfig = configureJwtConfig();
             IdentityConfig identityConfig = configureIdentities(jwtConfig);
             return SelfManagedAuthentication.builder()
-              .jwtConfig(jwtConfig)
-              .identityConfig(identityConfig)
-              .build();
-          } else if (operateClientConfigurationProperties.getUsername() != null && operateClientConfigurationProperties.getPassword() != null) {
+                .jwtConfig(jwtConfig)
+                .identityConfig(identityConfig)
+                .build();
+          } else if (operateClientConfigurationProperties.getUsername() != null
+              && operateClientConfigurationProperties.getPassword() != null) {
             SimpleConfig simpleConfig = new SimpleConfig();
-            SimpleCredential simpleCredential = new SimpleCredential(operateClientConfigurationProperties.getUsername(), operateClientConfigurationProperties.getPassword());
+            SimpleCredential simpleCredential =
+                new SimpleCredential(
+                    operateClientConfigurationProperties.getUsername(),
+                    operateClientConfigurationProperties.getPassword());
             simpleConfig.addProduct(Product.OPERATE, simpleCredential);
             return SimpleAuthentication.builder()
-              .simpleConfig(simpleConfig)
-              .simpleUrl(operateClientConfigurationProperties.getUrl())
-              .build();
+                .simpleConfig(simpleConfig)
+                .simpleUrl(operateClientConfigurationProperties.getUrl())
+                .build();
           }
         }
 
@@ -79,9 +85,9 @@ public class CommonClientConfiguration {
             JwtConfig jwtConfig = configureJwtConfig();
             IdentityConfig identityConfig = configureIdentities(jwtConfig);
             return SelfManagedAuthentication.builder()
-              .jwtConfig(jwtConfig)
-              .identityConfig(identityConfig)
-              .build();
+                .jwtConfig(jwtConfig)
+                .identityConfig(identityConfig)
+                .build();
           }
         }
 
@@ -91,24 +97,28 @@ public class CommonClientConfiguration {
             JwtConfig jwtConfig = configureJwtConfig();
             IdentityConfig identityConfig = configureIdentities(jwtConfig);
             return SelfManagedAuthentication.builder()
-              .jwtConfig(jwtConfig)
-              .identityConfig(identityConfig)
-              .build();
+                .jwtConfig(jwtConfig)
+                .identityConfig(identityConfig)
+                .build();
           } else if (commonConfigurationProperties.getKeycloak().getTokenUrl() != null) {
             JwtConfig jwtConfig = configureJwtConfig();
             IdentityConfig identityConfig = configureIdentities(jwtConfig);
             return SelfManagedAuthentication.builder()
-              .jwtConfig(jwtConfig)
-              .identityConfig(identityConfig)
-              .build();
-          } else if (commonConfigurationProperties.getUsername() != null && commonConfigurationProperties.getPassword() != null) {
+                .jwtConfig(jwtConfig)
+                .identityConfig(identityConfig)
+                .build();
+          } else if (commonConfigurationProperties.getUsername() != null
+              && commonConfigurationProperties.getPassword() != null) {
             SimpleConfig simpleConfig = new SimpleConfig();
-            SimpleCredential simpleCredential = new SimpleCredential(commonConfigurationProperties.getUsername(), commonConfigurationProperties.getPassword());
+            SimpleCredential simpleCredential =
+                new SimpleCredential(
+                    commonConfigurationProperties.getUsername(),
+                    commonConfigurationProperties.getPassword());
             simpleConfig.addProduct(Product.OPERATE, simpleCredential);
             return SimpleAuthentication.builder()
-              .simpleConfig(simpleConfig)
-              .simpleUrl(commonConfigurationProperties.getUrl())
-              .build();
+                .simpleConfig(simpleConfig)
+                .simpleUrl(commonConfigurationProperties.getUrl())
+                .build();
           }
         }
       }
@@ -119,27 +129,33 @@ public class CommonClientConfiguration {
   private JwtConfig configureJwtConfig() {
     JwtConfig jwtConfig = new JwtConfig();
     // ZEEBE
-    if (zeebeClientConfigurationProperties.getCloud().getClientId() != null && zeebeClientConfigurationProperties.getCloud().getClientSecret() != null) {
-      jwtConfig.addProduct(Product.ZEEBE, new JwtCredential(
-        zeebeClientConfigurationProperties.getCloud().getClientId(),
-        zeebeClientConfigurationProperties.getCloud().getClientSecret(),
-        zeebeClientConfigurationProperties.getCloud().getAudience(),
-        zeebeClientConfigurationProperties.getCloud().getAuthUrl())
-      );
-    } else if (zeebeSelfManagedProperties.getClientId() != null && zeebeSelfManagedProperties.getClientSecret() != null) {
-      jwtConfig.addProduct(Product.ZEEBE, new JwtCredential(
-        zeebeSelfManagedProperties.getClientId(),
-        zeebeSelfManagedProperties.getClientSecret(),
-        zeebeSelfManagedProperties.getAudience(),
-        zeebeSelfManagedProperties.getAuthServer())
-      );
-    } else if (commonConfigurationProperties.getClientId() != null && commonConfigurationProperties.getClientSecret() != null) {
-      jwtConfig.addProduct(Product.ZEEBE, new JwtCredential(
-        commonConfigurationProperties.getClientId(),
-        commonConfigurationProperties.getClientSecret(),
-        zeebeClientConfigurationProperties.getCloud().getAudience(),
-        zeebeClientConfigurationProperties.getCloud().getAuthUrl())
-      );
+    if (zeebeClientConfigurationProperties.getCloud().getClientId() != null
+        && zeebeClientConfigurationProperties.getCloud().getClientSecret() != null) {
+      jwtConfig.addProduct(
+          Product.ZEEBE,
+          new JwtCredential(
+              zeebeClientConfigurationProperties.getCloud().getClientId(),
+              zeebeClientConfigurationProperties.getCloud().getClientSecret(),
+              zeebeClientConfigurationProperties.getCloud().getAudience(),
+              zeebeClientConfigurationProperties.getCloud().getAuthUrl()));
+    } else if (zeebeSelfManagedProperties.getClientId() != null
+        && zeebeSelfManagedProperties.getClientSecret() != null) {
+      jwtConfig.addProduct(
+          Product.ZEEBE,
+          new JwtCredential(
+              zeebeSelfManagedProperties.getClientId(),
+              zeebeSelfManagedProperties.getClientSecret(),
+              zeebeSelfManagedProperties.getAudience(),
+              zeebeSelfManagedProperties.getAuthServer()));
+    } else if (commonConfigurationProperties.getClientId() != null
+        && commonConfigurationProperties.getClientSecret() != null) {
+      jwtConfig.addProduct(
+          Product.ZEEBE,
+          new JwtCredential(
+              commonConfigurationProperties.getClientId(),
+              commonConfigurationProperties.getClientSecret(),
+              zeebeClientConfigurationProperties.getCloud().getAudience(),
+              zeebeClientConfigurationProperties.getCloud().getAuthUrl()));
     }
 
     // OPERATE
@@ -151,30 +167,64 @@ public class CommonClientConfiguration {
         operateAuthUrl = operateClientConfigurationProperties.getAuthUrl();
       } else if (hasText(operateClientConfigurationProperties.getKeycloakTokenUrl())) {
         operateAuthUrl = operateClientConfigurationProperties.getKeycloakTokenUrl();
-      } else if (hasText(operateClientConfigurationProperties.getKeycloakUrl()) && hasText(operateClientConfigurationProperties.getKeycloakRealm())) {
-        operateAuthUrl = operateClientConfigurationProperties.getKeycloakUrl()+"/auth/realms/"+operateClientConfigurationProperties.getKeycloakRealm();
+      } else if (hasText(operateClientConfigurationProperties.getKeycloakUrl())
+          && hasText(operateClientConfigurationProperties.getKeycloakRealm())) {
+        operateAuthUrl =
+            operateClientConfigurationProperties.getKeycloakUrl()
+                + "/auth/realms/"
+                + operateClientConfigurationProperties.getKeycloakRealm();
       }
 
       if (operateClientConfigurationProperties.getBaseUrl() != null) {
         operateAudience = operateClientConfigurationProperties.getBaseUrl();
       }
 
-      if (operateClientConfigurationProperties.getClientId() != null && operateClientConfigurationProperties.getClientSecret() != null) {
-        jwtConfig.addProduct(Product.OPERATE, new JwtCredential(operateClientConfigurationProperties.getClientId(), operateClientConfigurationProperties.getClientSecret(), operateAudience, operateAuthUrl));
-      } else if (identityConfigurationFromProperties != null && hasText(identityConfigurationFromProperties.getClientId()) && hasText(identityConfigurationFromProperties.getClientSecret())) {
-        jwtConfig.addProduct(Product.OPERATE, new JwtCredential(identityConfigurationFromProperties.getClientId(), identityConfigurationFromProperties.getClientSecret(), identityConfigurationFromProperties.getAudience(), identityConfigurationFromProperties.getIssuerBackendUrl()));
-      }
-      else if (commonConfigurationProperties.getClientId() != null && commonConfigurationProperties.getClientSecret() != null) {
-        jwtConfig.addProduct(Product.OPERATE, new JwtCredential(
-          commonConfigurationProperties.getClientId(),
-          commonConfigurationProperties.getClientSecret(),
-          operateAudience,
-          operateAuthUrl)
-        );
-      } else if (zeebeClientConfigurationProperties.getCloud().getClientId() != null && zeebeClientConfigurationProperties.getCloud().getClientSecret() != null) {
-        jwtConfig.addProduct(Product.OPERATE, new JwtCredential(zeebeClientConfigurationProperties.getCloud().getClientId(), zeebeClientConfigurationProperties.getCloud().getClientSecret(), operateAudience, operateAuthUrl));
-      } else if (zeebeSelfManagedProperties.getClientId() != null && zeebeSelfManagedProperties.getClientSecret() != null) {
-        jwtConfig.addProduct(Product.OPERATE, new JwtCredential(zeebeSelfManagedProperties.getClientId(), zeebeSelfManagedProperties.getClientSecret(), operateAudience, operateAuthUrl));
+      if (operateClientConfigurationProperties.getClientId() != null
+          && operateClientConfigurationProperties.getClientSecret() != null) {
+        jwtConfig.addProduct(
+            Product.OPERATE,
+            new JwtCredential(
+                operateClientConfigurationProperties.getClientId(),
+                operateClientConfigurationProperties.getClientSecret(),
+                operateAudience,
+                operateAuthUrl));
+      } else if (identityConfigurationFromProperties != null
+          && hasText(identityConfigurationFromProperties.getClientId())
+          && hasText(identityConfigurationFromProperties.getClientSecret())) {
+        jwtConfig.addProduct(
+            Product.OPERATE,
+            new JwtCredential(
+                identityConfigurationFromProperties.getClientId(),
+                identityConfigurationFromProperties.getClientSecret(),
+                identityConfigurationFromProperties.getAudience(),
+                identityConfigurationFromProperties.getIssuerBackendUrl()));
+      } else if (commonConfigurationProperties.getClientId() != null
+          && commonConfigurationProperties.getClientSecret() != null) {
+        jwtConfig.addProduct(
+            Product.OPERATE,
+            new JwtCredential(
+                commonConfigurationProperties.getClientId(),
+                commonConfigurationProperties.getClientSecret(),
+                operateAudience,
+                operateAuthUrl));
+      } else if (zeebeClientConfigurationProperties.getCloud().getClientId() != null
+          && zeebeClientConfigurationProperties.getCloud().getClientSecret() != null) {
+        jwtConfig.addProduct(
+            Product.OPERATE,
+            new JwtCredential(
+                zeebeClientConfigurationProperties.getCloud().getClientId(),
+                zeebeClientConfigurationProperties.getCloud().getClientSecret(),
+                operateAudience,
+                operateAuthUrl));
+      } else if (zeebeSelfManagedProperties.getClientId() != null
+          && zeebeSelfManagedProperties.getClientSecret() != null) {
+        jwtConfig.addProduct(
+            Product.OPERATE,
+            new JwtCredential(
+                zeebeSelfManagedProperties.getClientId(),
+                zeebeSelfManagedProperties.getClientSecret(),
+                operateAudience,
+                operateAuthUrl));
       } else {
         throw new SdkException("Unable to determine OPERATE credentials");
       }
@@ -195,8 +245,9 @@ public class CommonClientConfiguration {
   }
 
   /**
-   * Identity properties supplied by the user are optional, so if they don't exist, we have to backfill them from somewhere
-   * like the OperateClientConfigurationProperties.
+   * Identity properties supplied by the user are optional, so if they don't exist, we have to
+   * backfill them from somewhere like the OperateClientConfigurationProperties.
+   *
    * @param jwtConfig
    * @return
    */
@@ -215,15 +266,16 @@ public class CommonClientConfiguration {
       issuerBackendUrl = jwtConfig.getProduct(Product.OPERATE).getAuthUrl();
     }
 
-    IdentityConfiguration operateIdentityConfiguration = new IdentityConfiguration.Builder()
-      .withBaseUrl(identityConfigurationFromProperties.getBaseUrl())
-      .withIssuer(issuer)
-      .withIssuerBackendUrl(issuerBackendUrl)
-      .withClientId(jwtConfig.getProduct(Product.OPERATE).getClientId())
-      .withClientSecret(jwtConfig.getProduct(Product.OPERATE).getClientSecret())
-      .withAudience(jwtConfig.getProduct(Product.OPERATE).getAudience())
-      .withType(identityConfigurationFromProperties.getType().name())
-      .build();
+    IdentityConfiguration operateIdentityConfiguration =
+        new IdentityConfiguration.Builder()
+            .withBaseUrl(identityConfigurationFromProperties.getBaseUrl())
+            .withIssuer(issuer)
+            .withIssuerBackendUrl(issuerBackendUrl)
+            .withClientId(jwtConfig.getProduct(Product.OPERATE).getClientId())
+            .withClientSecret(jwtConfig.getProduct(Product.OPERATE).getClientSecret())
+            .withAudience(jwtConfig.getProduct(Product.OPERATE).getAudience())
+            .withType(identityConfigurationFromProperties.getType().name())
+            .build();
     Identity operateIdentity = new Identity(operateIdentityConfiguration);
     return new IdentityContainer(operateIdentity, operateIdentityConfiguration);
   }

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/ConsoleClientConfiguration.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/ConsoleClientConfiguration.java
@@ -6,12 +6,15 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
-@ConditionalOnProperty(prefix = "console.client", name = "enabled", havingValue = "true", matchIfMissing = false)
+@ConditionalOnProperty(
+    prefix = "console.client",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = false)
 @EnableConfigurationProperties(ConsoleClientConfigurationProperties.class)
 public class ConsoleClientConfiguration {
 
-  @Autowired
-  Authentication authentication;
+  @Autowired Authentication authentication;
 
   // TODO: Declare bean for Console
 }

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/ExecutorServiceConfiguration.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/ExecutorServiceConfiguration.java
@@ -5,30 +5,33 @@ import io.camunda.zeebe.spring.client.properties.ZeebeClientConfigurationPropert
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.MeterBinder;
 import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics;
+import java.util.Collections;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
-
-import java.util.Collections;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 
 @ConditionalOnClass(MeterRegistry.class)
 @ConditionalOnMissingBean(ZeebeClientExecutorService.class)
 public class ExecutorServiceConfiguration {
 
   private final ZeebeClientConfigurationProperties configurationProperties;
+
   public ExecutorServiceConfiguration(ZeebeClientConfigurationProperties configurationProperties) {
     this.configurationProperties = configurationProperties;
   }
 
   @Bean
-  public ZeebeClientExecutorService zeebeClientThreadPool(@Autowired(required = false) MeterRegistry meterRegistry) {
-    ScheduledExecutorService threadPool = Executors.newScheduledThreadPool(configurationProperties.getNumJobWorkerExecutionThreads());
+  public ZeebeClientExecutorService zeebeClientThreadPool(
+      @Autowired(required = false) MeterRegistry meterRegistry) {
+    ScheduledExecutorService threadPool =
+        Executors.newScheduledThreadPool(configurationProperties.getNumJobWorkerExecutionThreads());
     if (meterRegistry != null) {
-      MeterBinder threadPoolMetrics = new ExecutorServiceMetrics(
-        threadPool, "zeebe_client_thread_pool", Collections.emptyList());
+      MeterBinder threadPoolMetrics =
+          new ExecutorServiceMetrics(
+              threadPool, "zeebe_client_thread_pool", Collections.emptyList());
       threadPoolMetrics.bindTo(meterRegistry);
     }
     configurationProperties.setOwnsJobWorkerExecutor(true);

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/MetricsDefaultConfiguration.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/MetricsDefaultConfiguration.java
@@ -3,13 +3,7 @@ package io.camunda.zeebe.spring.client.configuration;
 import io.camunda.zeebe.spring.client.metrics.DefaultNoopMetricsRecorder;
 import io.camunda.zeebe.spring.client.metrics.MetricsRecorder;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.SearchStrategy;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Condition;
-import org.springframework.context.annotation.ConditionContext;
-import org.springframework.context.annotation.Conditional;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.core.type.AnnotatedTypeMetadata;
 
 public class MetricsDefaultConfiguration {
 

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/OperateClientConfiguration.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/OperateClientConfiguration.java
@@ -6,6 +6,7 @@ import io.camunda.operate.CamundaOperateClientBuilder;
 import io.camunda.zeebe.spring.client.configuration.condition.OperateClientCondition;
 import io.camunda.zeebe.spring.client.properties.OperateClientConfigurationProperties;
 import io.camunda.zeebe.spring.client.testsupport.SpringZeebeTestContext;
+import java.lang.invoke.MethodHandles;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,29 +16,31 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 
-import java.lang.invoke.MethodHandles;
-
 @Conditional(OperateClientCondition.class)
-@ConditionalOnProperty(prefix = "camunda.operate.client", name = "enabled", havingValue = "true",  matchIfMissing = true)
+@ConditionalOnProperty(
+    prefix = "camunda.operate.client",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = true)
 @ConditionalOnMissingBean(SpringZeebeTestContext.class)
 @EnableConfigurationProperties(OperateClientConfigurationProperties.class)
 public class OperateClientConfiguration {
 
   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  @Autowired
-  Authentication authentication;
+  @Autowired Authentication authentication;
 
   @Bean
   @ConditionalOnMissingBean
   public CamundaOperateClient camundaOperateClient(OperateClientConfigurationProperties props) {
     CamundaOperateClient client;
     try {
-      client = new CamundaOperateClientBuilder()
-        .authentication(authentication)
-        .operateUrl(props.getOperateUrl())
-        .setup()
-        .build();
+      client =
+          new CamundaOperateClientBuilder()
+              .authentication(authentication)
+              .operateUrl(props.getOperateUrl())
+              .setup()
+              .build();
     } catch (Exception e) {
       LOG.warn("An attempt to connect to Operate failed: " + e);
       throw new RuntimeException(e);
@@ -45,5 +48,3 @@ public class OperateClientConfiguration {
     return client;
   }
 }
-
-

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/OptimizeClientConfiguration.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/OptimizeClientConfiguration.java
@@ -6,12 +6,15 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
-@ConditionalOnProperty(prefix = "optimize.client", name = "enabled", havingValue = "true",  matchIfMissing = false)
+@ConditionalOnProperty(
+    prefix = "optimize.client",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = false)
 @EnableConfigurationProperties(OptimizeClientConfigurationProperties.class)
 public class OptimizeClientConfiguration {
 
-  @Autowired
-  Authentication authentication;
+  @Autowired Authentication authentication;
 
   // TODO: Declare bean for Optimize
 }

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/TasklistClientConfiguration.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/TasklistClientConfiguration.java
@@ -6,12 +6,15 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
-@ConditionalOnProperty(prefix = "tasklist.client", name = "enabled", havingValue = "true", matchIfMissing = false)
+@ConditionalOnProperty(
+    prefix = "tasklist.client",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = false)
 @EnableConfigurationProperties(TasklistClientConfigurationProperties.class)
 public class TasklistClientConfiguration {
 
-  @Autowired
-  Authentication authentication;
+  @Autowired Authentication authentication;
 
   // TODO: Declare bean for Tasklist
 }

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeActuatorConfiguration.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeActuatorConfiguration.java
@@ -4,7 +4,6 @@ import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.spring.client.actuator.MicrometerMetricsRecorder;
 import io.camunda.zeebe.spring.client.actuator.ZeebeClientHealthIndicator;
 import io.camunda.zeebe.spring.client.metrics.DefaultNoopMetricsRecorder;
-import io.camunda.zeebe.spring.client.configuration.MetricsDefaultConfiguration;
 import io.camunda.zeebe.spring.client.metrics.MetricsRecorder;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.beans.factory.InitializingBean;
@@ -18,17 +17,20 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 
 @AutoConfigureBefore(MetricsDefaultConfiguration.class)
-@ConditionalOnClass({EndpointAutoConfiguration.class, MeterRegistry.class}) // only if actuator is on classpath
+@ConditionalOnClass({
+  EndpointAutoConfiguration.class,
+  MeterRegistry.class
+}) // only if actuator is on classpath
 public class ZeebeActuatorConfiguration {
   @Bean
-  // ConditionalOnBean for MeterRegistry does not work (always missing, seems to be created too late)
+  // ConditionalOnBean for MeterRegistry does not work (always missing, seems to be created too
+  // late)
   // so using @Autowired(required=false) with null check
   public MetricsRecorder micrometerMetricsRecorder(
-          final @Autowired(required = false) @Lazy MeterRegistry meterRegistry) {
+      final @Autowired(required = false) @Lazy MeterRegistry meterRegistry) {
     if (meterRegistry == null) {
       // We might have Actuator on the classpath without starting a MetricsRecorder in some cases
       return new DefaultNoopMetricsRecorder();
@@ -38,13 +40,15 @@ public class ZeebeActuatorConfiguration {
   }
 
   /**
-   * Workaround to fix premature initialization of MeterRegistry that seems to happen here, see https://github.com/camunda-community-hub/spring-zeebe/issues/296
+   * Workaround to fix premature initialization of MeterRegistry that seems to happen here, see
+   * https://github.com/camunda-community-hub/spring-zeebe/issues/296
    */
   @Bean
   InitializingBean forceMeterRegistryPostProcessor(
-    final @Autowired(required = false) @Qualifier("meterRegistryPostProcessor") BeanPostProcessor meterRegistryPostProcessor,
-    final @Autowired(required = false) MeterRegistry registry) {
-    if (registry == null || meterRegistryPostProcessor==null) {
+      final @Autowired(required = false) @Qualifier("meterRegistryPostProcessor") BeanPostProcessor
+              meterRegistryPostProcessor,
+      final @Autowired(required = false) MeterRegistry registry) {
+    if (registry == null || meterRegistryPostProcessor == null) {
       return () -> {};
     } else {
       return () -> meterRegistryPostProcessor.postProcessAfterInitialization(registry, "");
@@ -52,7 +56,10 @@ public class ZeebeActuatorConfiguration {
   }
 
   @Bean
-  @ConditionalOnProperty(prefix = "management.health.zeebe", name = "enabled", matchIfMissing = true)
+  @ConditionalOnProperty(
+      prefix = "management.health.zeebe",
+      name = "enabled",
+      matchIfMissing = true)
   @ConditionalOnClass(HealthIndicator.class)
   @ConditionalOnMissingBean(name = "zeebeClientHealthIndicator")
   public ZeebeClientHealthIndicator zeebeClientHealthIndicator(ZeebeClient client) {

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientAllAutoConfiguration.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientAllAutoConfiguration.java
@@ -1,12 +1,8 @@
 package io.camunda.zeebe.spring.client.configuration;
 
-import io.camunda.zeebe.client.ClientProperties;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.api.worker.BackoffSupplier;
-import io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl;
 import io.camunda.zeebe.client.impl.worker.ExponentialBackoffBuilderImpl;
-import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebePropertiesImpl;
-import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeProperties;
 import io.camunda.zeebe.spring.client.annotation.customizer.ZeebeWorkerValueCustomizer;
 import io.camunda.zeebe.spring.client.annotation.processor.AnnotationProcessorConfiguration;
 import io.camunda.zeebe.spring.client.jobhandling.CommandExceptionHandlingStrategy;
@@ -22,17 +18,19 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 
-@ConditionalOnProperty(prefix = "zeebe.client", name = "enabled", havingValue = "true",  matchIfMissing = true)
+@ConditionalOnProperty(
+    prefix = "zeebe.client",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = true)
 @Import(AnnotationProcessorConfiguration.class)
 @EnableConfigurationProperties(ZeebeClientConfigurationProperties.class)
 public class ZeebeClientAllAutoConfiguration {
 
   private final ZeebeClientConfigurationProperties configurationProperties;
-  public ZeebeClientAllAutoConfiguration(ZeebeClientConfigurationProperties configurationProperties) {
-    // TODO Remove workaround as soon as https://github.com/camunda/zeebe/issues/14176 is fixed
-    if(configurationProperties.getWorker().getDefaultName() == null) {
-      configurationProperties.getWorker().setDefaultName(ClientProperties.DEFAULT_JOB_WORKER_NAME);
-    }
+
+  public ZeebeClientAllAutoConfiguration(
+      ZeebeClientConfigurationProperties configurationProperties) {
     this.configurationProperties = configurationProperties;
   }
 
@@ -44,25 +42,28 @@ public class ZeebeClientAllAutoConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
-  public CommandExceptionHandlingStrategy commandExceptionHandlingStrategy(ZeebeClientExecutorService scheduledExecutorService) {
-    return new DefaultCommandExceptionHandlingStrategy(backoffSupplier(), scheduledExecutorService.get());
+  public CommandExceptionHandlingStrategy commandExceptionHandlingStrategy(
+      ZeebeClientExecutorService scheduledExecutorService) {
+    return new DefaultCommandExceptionHandlingStrategy(
+        backoffSupplier(), scheduledExecutorService.get());
   }
 
   @Bean
-  public JobWorkerManager jobWorkerManager(final CommandExceptionHandlingStrategy commandExceptionHandlingStrategy,
-                                           final JsonMapper jsonMapper,
-                                           final MetricsRecorder metricsRecorder) {
+  public JobWorkerManager jobWorkerManager(
+      final CommandExceptionHandlingStrategy commandExceptionHandlingStrategy,
+      final JsonMapper jsonMapper,
+      final MetricsRecorder metricsRecorder) {
     return new JobWorkerManager(commandExceptionHandlingStrategy, jsonMapper, metricsRecorder);
   }
 
   @Bean
   public BackoffSupplier backoffSupplier() {
     return new ExponentialBackoffBuilderImpl()
-      .maxDelay(1000L)
-      .minDelay(50L)
-      .backoffFactor(1.5)
-      .jitterFactor(0.2)
-      .build();
+        .maxDelay(1000L)
+        .minDelay(50L)
+        .backoffFactor(1.5)
+        .jitterFactor(0.2)
+        .build();
   }
 
   @Bean("propertyBasedZeebeWorkerValueCustomizer")
@@ -70,6 +71,4 @@ public class ZeebeClientAllAutoConfiguration {
   public ZeebeWorkerValueCustomizer propertyBasedZeebeWorkerValueCustomizer() {
     return new PropertyBasedZeebeWorkerValueCustomizer(this.configurationProperties);
   }
-
-
 }

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientConfiguration.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientConfiguration.java
@@ -1,5 +1,7 @@
 package io.camunda.zeebe.spring.client.configuration;
 
+import static org.springframework.util.StringUtils.hasText;
+
 import io.camunda.common.auth.Authentication;
 import io.camunda.common.auth.DefaultNoopAuthentication;
 import io.camunda.common.auth.Product;
@@ -15,26 +17,20 @@ import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import jakarta.annotation.PostConstruct;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Lazy;
-
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
-
-import static org.springframework.util.StringUtils.hasText;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 
 public class ZeebeClientConfiguration implements io.camunda.zeebe.client.ZeebeClientConfiguration {
 
-  @Autowired
-  private ZeebeClientConfigurationProperties properties;
+  @Autowired private ZeebeClientConfigurationProperties properties;
 
-  @Autowired
-  private CommonConfigurationProperties commonConfigurationProperties;
+  @Autowired private CommonConfigurationProperties commonConfigurationProperties;
 
-  @Autowired
-  private Authentication authentication;
+  @Autowired private Authentication authentication;
 
   @Lazy // Must be lazy, otherwise we get circular dependencies on beans
   @Autowired
@@ -44,13 +40,12 @@ public class ZeebeClientConfiguration implements io.camunda.zeebe.client.ZeebeCl
   @Autowired(required = false)
   private List<ClientInterceptor> interceptors;
 
-  @Lazy
-  @Autowired
-  private ZeebeClientExecutorService zeebeClientExecutorService;
+  @Lazy @Autowired private ZeebeClientExecutorService zeebeClientExecutorService;
 
   @PostConstruct
   public void applyLegacy() {
-    // make sure environment variables and other legacy config options are taken into account (duplicate, also done by  qPostConstruct, whatever)
+    // make sure environment variables and other legacy config options are taken into account
+    // (duplicate, also done by  qPostConstruct, whatever)
     properties.applyOverrides();
   }
 
@@ -117,12 +112,14 @@ public class ZeebeClientConfiguration implements io.camunda.zeebe.client.ZeebeCl
   @Override
   public CredentialsProvider getCredentialsProvider() {
     // TODO: Refactor when integrating Identity SDK
-    if (commonConfigurationProperties.getEnabled() && !(authentication instanceof DefaultNoopAuthentication)) {
+    if (commonConfigurationProperties.getEnabled()
+        && !(authentication instanceof DefaultNoopAuthentication)) {
       return new CredentialsProvider() {
         @Override
         public void applyCredentials(Metadata headers) {
           final Map.Entry<String, String> authHeader = authentication.getTokenHeader(Product.ZEEBE);
-          final Metadata.Key<String> authHeaderKey = Metadata.Key.of(authHeader.getKey(), Metadata.ASCII_STRING_MARSHALLER);
+          final Metadata.Key<String> authHeaderKey =
+              Metadata.Key.of(authHeader.getKey(), Metadata.ASCII_STRING_MARSHALLER);
           headers.put(authHeaderKey, authHeader.getValue());
         }
 
@@ -132,21 +129,24 @@ public class ZeebeClientConfiguration implements io.camunda.zeebe.client.ZeebeCl
         }
       };
     }
-    if (hasText(properties.getCloud().getClientId()) && hasText(properties.getCloud().getClientSecret())) {
-//        log.debug("Client ID and secret are configured. Creating OAuthCredientialsProvider with: {}", this);
+    if (hasText(properties.getCloud().getClientId())
+        && hasText(properties.getCloud().getClientSecret())) {
+      //        log.debug("Client ID and secret are configured. Creating OAuthCredientialsProvider
+      // with: {}", this);
       return CredentialsProvider.newCredentialsProviderBuilder()
-        .clientId(properties.getCloud().getClientId())
-        .clientSecret(properties.getCloud().getClientSecret())
-        .audience(properties.getCloud().getAudience())
-        .scope(properties.getCloud().getScope())
-        .authorizationServerUrl(properties.getCloud().getAuthUrl())
-        .credentialsCachePath(properties.getCloud().getCredentialsCachePath())
-        .build();
+          .clientId(properties.getCloud().getClientId())
+          .clientSecret(properties.getCloud().getClientSecret())
+          .audience(properties.getCloud().getAudience())
+          .scope(properties.getCloud().getScope())
+          .authorizationServerUrl(properties.getCloud().getAuthUrl())
+          .credentialsCachePath(properties.getCloud().getCredentialsCachePath())
+          .build();
     }
-    if (Environment.system().get("ZEEBE_CLIENT_ID") != null && Environment.system().get("ZEEBE_CLIENT_SECRET") != null) {
+    if (Environment.system().get("ZEEBE_CLIENT_ID") != null
+        && Environment.system().get("ZEEBE_CLIENT_SECRET") != null) {
       // Copied from ZeebeClientBuilderImpl
       OAuthCredentialsProviderBuilder builder = CredentialsProvider.newCredentialsProviderBuilder();
-      int separatorIndex = properties.getBroker().getGatewayAddress().lastIndexOf(58); //":"
+      int separatorIndex = properties.getBroker().getGatewayAddress().lastIndexOf(58); // ":"
       if (separatorIndex > 0) {
         builder.audience(properties.getBroker().getGatewayAddress().substring(0, separatorIndex));
       }
@@ -199,5 +199,4 @@ public class ZeebeClientConfiguration implements io.camunda.zeebe.client.ZeebeCl
   public boolean useDefaultRetryPolicy() {
     return properties.useDefaultRetryPolicy();
   }
-
 }

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientProdAutoConfiguration.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientProdAutoConfiguration.java
@@ -6,6 +6,8 @@ import io.camunda.zeebe.client.impl.util.ExecutorResource;
 import io.camunda.zeebe.gateway.protocol.GatewayGrpc;
 import io.camunda.zeebe.spring.client.testsupport.SpringZeebeTestContext;
 import io.grpc.ManagedChannel;
+import java.lang.invoke.MethodHandles;
+import java.util.concurrent.ScheduledExecutorService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
@@ -14,17 +16,16 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 
-import java.lang.invoke.MethodHandles;
-import java.util.concurrent.ScheduledExecutorService;
-
 /*
  * All configurations that will only be used in production code - meaning NO TEST cases
  */
-@ConditionalOnProperty(prefix = "zeebe.client", name = "enabled", havingValue = "true",  matchIfMissing = true)
+@ConditionalOnProperty(
+    prefix = "zeebe.client",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = true)
 @ConditionalOnMissingBean(SpringZeebeTestContext.class)
-@ImportAutoConfiguration({
-  ExecutorServiceConfiguration.class, ZeebeActuatorConfiguration.class
-})
+@ImportAutoConfiguration({ExecutorServiceConfiguration.class, ZeebeActuatorConfiguration.class})
 @AutoConfigureBefore(ZeebeClientAllAutoConfiguration.class)
 public class ZeebeClientProdAutoConfiguration {
 
@@ -38,15 +39,17 @@ public class ZeebeClientProdAutoConfiguration {
   @Bean(destroyMethod = "close")
   public ZeebeClient zeebeClient(
       final ZeebeClientConfiguration configuration) { // (ZeebeClientBuilder builder) {
-    //LOG.info("Creating ZeebeClient using ZeebeClientBuilder [" + builder + "]");
-    //return builder.build();
+    // LOG.info("Creating ZeebeClient using ZeebeClientBuilder [" + builder + "]");
+    // return builder.build();
 
     LOG.info("Creating ZeebeClient using ZeebeClientConfiguration [" + configuration + "]");
     final ScheduledExecutorService jobWorkerExecutor = configuration.jobWorkerExecutor();
-    if (jobWorkerExecutor!=null) {
+    if (jobWorkerExecutor != null) {
       ManagedChannel managedChannel = ZeebeClientImpl.buildChannel(configuration);
-      GatewayGrpc.GatewayStub gatewayStub = ZeebeClientImpl.buildGatewayStub(managedChannel, configuration);
-      ExecutorResource executorResource = new ExecutorResource(jobWorkerExecutor, configuration.ownsJobWorkerExecutor());
+      GatewayGrpc.GatewayStub gatewayStub =
+          ZeebeClientImpl.buildGatewayStub(managedChannel, configuration);
+      ExecutorResource executorResource =
+          new ExecutorResource(jobWorkerExecutor, configuration.ownsJobWorkerExecutor());
       return new ZeebeClientImpl(configuration, managedChannel, gatewayStub, executorResource);
     } else {
       return new ZeebeClientImpl(configuration);
@@ -54,7 +57,7 @@ public class ZeebeClientProdAutoConfiguration {
   }
   // TODO: Interceptors
   // TODO: applyOverrides()
-/*
+  /*
   @Bean
   public ZeebeClientBuilder builder(JsonMapper jsonMapper,
                                     @Autowired(required = false) List<ClientInterceptor> clientInterceptorList) {
@@ -82,6 +85,5 @@ public class ZeebeClientProdAutoConfiguration {
     }
     return builder;
   }*/
-
 
 }

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/condition/OperateClientCondition.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/condition/OperateClientCondition.java
@@ -9,26 +9,26 @@ public class OperateClientCondition extends AnyNestedCondition {
   }
 
   @ConditionalOnProperty(name = "camunda.operate.client.client-id")
-  static class ClientIdCondition { }
+  static class ClientIdCondition {}
 
   @ConditionalOnProperty(name = "camunda.operate.client.username")
-  static class UsernameCondition { }
+  static class UsernameCondition {}
 
   @ConditionalOnProperty(name = "camunda.operate.client.auth-url")
-  static class AuthUrlCondition { }
+  static class AuthUrlCondition {}
 
   @ConditionalOnProperty(name = "camunda.operate.client.base-url")
-  static class BaseUrlCondition { }
+  static class BaseUrlCondition {}
 
   @ConditionalOnProperty(name = "camunda.operate.client.keycloak-url")
-  static class KeycloakUrlCondition { }
+  static class KeycloakUrlCondition {}
 
   @ConditionalOnProperty(name = "camunda.operate.client.keycloak-token-url")
-  static class KeycloakTokenUrlCondition { }
+  static class KeycloakTokenUrlCondition {}
 
   @ConditionalOnProperty(name = "camunda.operate.client.url")
-  static class UrlCondition { }
+  static class UrlCondition {}
 
   @ConditionalOnProperty(name = "camunda.operate.client.enabled")
-  static class EnableCondition { }
+  static class EnableCondition {}
 }

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/event/ZeebeLifecycleEventProducer.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/event/ZeebeLifecycleEventProducer.java
@@ -12,14 +12,16 @@ public class ZeebeLifecycleEventProducer implements SmartLifecycle {
 
   private final ZeebeClient client;
 
-  public ZeebeLifecycleEventProducer(final ZeebeClient client, final ApplicationEventPublisher publisher) {
+  public ZeebeLifecycleEventProducer(
+      final ZeebeClient client, final ApplicationEventPublisher publisher) {
     this.client = client;
     this.publisher = publisher;
   }
 
   @Override
   public void start() {
-    publisher.publishEvent(new ClientStartedEvent()); // keep old deprecated event for a bit before delting it
+    publisher.publishEvent(
+        new ClientStartedEvent()); // keep old deprecated event for a bit before delting it
     publisher.publishEvent(new ZeebeClientCreatedEvent(this, client));
 
     this.running = true;
@@ -27,7 +29,8 @@ public class ZeebeLifecycleEventProducer implements SmartLifecycle {
 
   @Override
   public void stop() {
-    publisher.publishEvent(new ClientStoppedEvent()); // keep old deprecated event for a bit before delting it
+    publisher.publishEvent(
+        new ClientStoppedEvent()); // keep old deprecated event for a bit before delting it
     publisher.publishEvent(new ZeebeClientClosingEvent(this, client));
 
     this.running = false;
@@ -37,5 +40,4 @@ public class ZeebeLifecycleEventProducer implements SmartLifecycle {
   public boolean isRunning() {
     return running;
   }
-
 }

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/properties/CommonConfigurationProperties.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/properties/CommonConfigurationProperties.java
@@ -1,20 +1,19 @@
 package io.camunda.zeebe.spring.client.properties;
 
 import io.camunda.zeebe.spring.client.properties.common.*;
+import java.lang.invoke.MethodHandles;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
-import java.lang.invoke.MethodHandles;
-
 @ConfigurationProperties(prefix = "common")
 public class CommonConfigurationProperties extends Client {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  @NestedConfigurationProperty
-  private Keycloak keycloak = new Keycloak();
+  @NestedConfigurationProperty private Keycloak keycloak = new Keycloak();
 
   public Keycloak getKeycloak() {
     return keycloak;

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/properties/ConsoleClientConfigurationProperties.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/properties/ConsoleClientConfigurationProperties.java
@@ -4,5 +4,4 @@ import io.camunda.zeebe.spring.client.properties.common.Client;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "console.client")
-public class ConsoleClientConfigurationProperties extends Client {
-}
+public class ConsoleClientConfigurationProperties extends Client {}

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/properties/OperateClientConfigurationProperties.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/properties/OperateClientConfigurationProperties.java
@@ -1,11 +1,10 @@
 package io.camunda.zeebe.spring.client.properties;
 
+import java.lang.invoke.MethodHandles;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-
-import java.lang.invoke.MethodHandles;
 
 @ConfigurationProperties(prefix = "camunda.operate.client")
 public class OperateClientConfigurationProperties {
@@ -124,7 +123,7 @@ public class OperateClientConfigurationProperties {
 
   public String getOperateUrl() {
     if (url != null) {
-      LOG.debug("Connecting to Camunda Operate on URL: " +url);
+      LOG.debug("Connecting to Camunda Operate on URL: " + url);
       return url;
     } else if (clusterId != null) {
       String url = "https://" + region + "." + getFinalBaseUrl() + "/" + clusterId + "/";
@@ -132,7 +131,7 @@ public class OperateClientConfigurationProperties {
       return url;
     }
     throw new IllegalArgumentException(
-      "In order to connect to Camunda Operate you need to specify either a SaaS clusterId or an Operate URL.");
+        "In order to connect to Camunda Operate you need to specify either a SaaS clusterId or an Operate URL.");
   }
 
   private String getFinalBaseUrl() {

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/properties/OptimizeClientConfigurationProperties.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/properties/OptimizeClientConfigurationProperties.java
@@ -4,5 +4,4 @@ import io.camunda.zeebe.spring.client.properties.common.Client;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "optimize.client")
-public class OptimizeClientConfigurationProperties extends Client {
-}
+public class OptimizeClientConfigurationProperties extends Client {}

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/properties/PropertyBasedZeebeWorkerValueCustomizer.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/properties/PropertyBasedZeebeWorkerValueCustomizer.java
@@ -1,25 +1,155 @@
 package io.camunda.zeebe.spring.client.properties;
 
+import static org.apache.commons.lang3.StringUtils.*;
+
+import io.camunda.zeebe.spring.client.annotation.Variable;
+import io.camunda.zeebe.spring.client.annotation.VariablesAsType;
+import io.camunda.zeebe.spring.client.annotation.ZeebeVariable;
+import io.camunda.zeebe.spring.client.annotation.ZeebeVariablesAsType;
 import io.camunda.zeebe.spring.client.annotation.customizer.ZeebeWorkerValueCustomizer;
 import io.camunda.zeebe.spring.client.annotation.value.ZeebeWorkerValue;
-
+import io.camunda.zeebe.spring.client.bean.CopyNotNullBeanUtilsBean;
+import io.camunda.zeebe.spring.client.bean.MethodInfo;
+import io.camunda.zeebe.spring.client.bean.ParameterInfo;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.ReflectionUtils;
 
 public class PropertyBasedZeebeWorkerValueCustomizer implements ZeebeWorkerValueCustomizer {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(PropertyBasedZeebeWorkerValueCustomizer.class);
+  private static final CopyNotNullBeanUtilsBean BEAN_UTILS_BEAN = new CopyNotNullBeanUtilsBean();
 
   private final ZeebeClientConfigurationProperties zeebeClientConfigurationProperties;
 
-  public PropertyBasedZeebeWorkerValueCustomizer(final ZeebeClientConfigurationProperties zeebeClientConfigurationProperties) {
+  public PropertyBasedZeebeWorkerValueCustomizer(
+      final ZeebeClientConfigurationProperties zeebeClientConfigurationProperties) {
     this.zeebeClientConfigurationProperties = zeebeClientConfigurationProperties;
   }
 
   @Override
   public void customize(ZeebeWorkerValue zeebeWorker) {
-    final Map<String, ZeebeWorkerValue> workerConfigurationMap = zeebeClientConfigurationProperties.getWorker().getOverride();
+    applyDefaultWorkerName(zeebeWorker);
+    applyDefaultJobWorkerType(zeebeWorker);
+    applyTenantIds(zeebeWorker);
+    applyFetchVariables(zeebeWorker);
+    applyOverrides(zeebeWorker);
+  }
+
+  private void applyFetchVariables(ZeebeWorkerValue zeebeWorkerValue) {
+    if (zeebeWorkerValue.isForceFetchAllVariables()) {
+      LOG.debug("Worker '{}': Force fetch all variables is enabled", zeebeWorkerValue.getName());
+      zeebeWorkerValue.setFetchVariables(new String[0]);
+    } else {
+      Set<String> variables = new HashSet<>();
+      if (zeebeWorkerValue.getFetchVariables() != null) {
+        variables.addAll(Arrays.asList(zeebeWorkerValue.getFetchVariables()));
+      }
+      variables.addAll(
+          readZeebeVariableParameters(zeebeWorkerValue.getMethodInfo()).stream()
+              .map(ParameterInfo::getParameterName)
+              .collect(Collectors.toList()));
+      variables.addAll(readVariablesAsTypeParameters(zeebeWorkerValue.getMethodInfo()));
+      zeebeWorkerValue.setFetchVariables(variables.toArray(new String[0]));
+      LOG.debug(
+          "Worker '{}': Fetching only required variables {}",
+          zeebeWorkerValue.getName(),
+          variables);
+    }
+  }
+
+  private List<ParameterInfo> readZeebeVariableParameters(MethodInfo methodInfo) {
+    List<ParameterInfo> result = methodInfo.getParametersFilteredByAnnotation(Variable.class);
+    result.addAll(methodInfo.getParametersFilteredByAnnotation(ZeebeVariable.class));
+    return result;
+  }
+
+  private List<String> readVariablesAsTypeParameters(MethodInfo methodInfo) {
+    List<String> result = new ArrayList<>();
+    List<ParameterInfo> parameters =
+        methodInfo.getParametersFilteredByAnnotation(VariablesAsType.class);
+    parameters.addAll(methodInfo.getParametersFilteredByAnnotation(ZeebeVariablesAsType.class));
+    parameters.forEach(
+        pi ->
+            ReflectionUtils.doWithFields(
+                pi.getParameterInfo().getType(), f -> result.add(f.getName())));
+    return result;
+  }
+
+  private void applyOverrides(ZeebeWorkerValue zeebeWorker) {
+    final Map<String, ZeebeWorkerValue> workerConfigurationMap =
+        zeebeClientConfigurationProperties.getWorker().getOverride();
     final String workerType = zeebeWorker.getType();
     if (workerConfigurationMap.containsKey(workerType)) {
       final ZeebeWorkerValue zeebeWorkerValue = workerConfigurationMap.get(workerType);
-      zeebeWorker.merge(zeebeWorkerValue);
+      LOG.debug("Worker '{}': Applying overrides {}", workerType, zeebeWorkerValue);
+      try {
+        BEAN_UTILS_BEAN.copyProperties(zeebeWorker, zeebeWorkerValue);
+      } catch (IllegalAccessException | InvocationTargetException e) {
+        throw new RuntimeException(
+            "Error while copying properties from " + zeebeWorkerValue + " to " + zeebeWorker, e);
+      }
+    }
+  }
+
+  private void applyTenantIds(ZeebeWorkerValue zeebeWorker) {
+    List<String> defaultJobWorkerTenantIds =
+        zeebeClientConfigurationProperties.getDefaultJobWorkerTenantIds();
+    if (defaultJobWorkerTenantIds != null
+        && !defaultJobWorkerTenantIds.isEmpty()
+        && (zeebeWorker.getTenantIds() == null || zeebeWorker.getTenantIds().isEmpty())) {
+      LOG.debug(
+          "Worker '{}': Setting default tenant ids to {}",
+          zeebeWorker.getName(),
+          defaultJobWorkerTenantIds);
+      zeebeWorker.setTenantIds(defaultJobWorkerTenantIds);
+    }
+  }
+
+  private void applyDefaultWorkerName(ZeebeWorkerValue zeebeWorker) {
+    String defaultJobWorkerName = zeebeClientConfigurationProperties.getDefaultJobWorkerName();
+    if (isBlank(zeebeWorker.getName())) {
+      if (isNotBlank(defaultJobWorkerName)) {
+        LOG.debug(
+            "Worker '{}': Setting name to default {}", zeebeWorker.getName(), defaultJobWorkerName);
+        zeebeWorker.setName(defaultJobWorkerName);
+      } else {
+        String generatedJobWorkerName =
+            zeebeWorker.getMethodInfo().getBeanName()
+                + "#"
+                + zeebeWorker.getMethodInfo().getMethodName();
+        LOG.debug(
+            "Worker '{}': Setting name to generated {}",
+            zeebeWorker.getName(),
+            generatedJobWorkerName);
+        zeebeWorker.setName(generatedJobWorkerName);
+      }
+    }
+  }
+
+  private void applyDefaultJobWorkerType(ZeebeWorkerValue zeebeWorker) {
+    String defaultJobWorkerType = zeebeClientConfigurationProperties.getDefaultJobWorkerType();
+    if (isBlank(zeebeWorker.getType())) {
+      if (isNotBlank(defaultJobWorkerType)) {
+        LOG.debug(
+            "Worker '{}': Setting type to default {}", zeebeWorker.getName(), defaultJobWorkerType);
+        zeebeWorker.setType(defaultJobWorkerType);
+      } else {
+        String generatedJobWorkerType = zeebeWorker.getMethodInfo().getMethodName();
+        LOG.debug(
+            "Worker '{}': Setting type to generated {}",
+            zeebeWorker.getName(),
+            generatedJobWorkerType);
+        zeebeWorker.setType(generatedJobWorkerType);
+      }
     }
   }
 }

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/properties/PropertyBasedZeebeWorkerValueCustomizer.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/properties/PropertyBasedZeebeWorkerValueCustomizer.java
@@ -39,7 +39,6 @@ public class PropertyBasedZeebeWorkerValueCustomizer implements ZeebeWorkerValue
   public void customize(ZeebeWorkerValue zeebeWorker) {
     applyDefaultWorkerName(zeebeWorker);
     applyDefaultJobWorkerType(zeebeWorker);
-    applyTenantIds(zeebeWorker);
     applyFetchVariables(zeebeWorker);
     applyOverrides(zeebeWorker);
   }
@@ -97,20 +96,6 @@ public class PropertyBasedZeebeWorkerValueCustomizer implements ZeebeWorkerValue
         throw new RuntimeException(
             "Error while copying properties from " + zeebeWorkerValue + " to " + zeebeWorker, e);
       }
-    }
-  }
-
-  private void applyTenantIds(ZeebeWorkerValue zeebeWorker) {
-    List<String> defaultJobWorkerTenantIds =
-        zeebeClientConfigurationProperties.getDefaultJobWorkerTenantIds();
-    if (defaultJobWorkerTenantIds != null
-        && !defaultJobWorkerTenantIds.isEmpty()
-        && (zeebeWorker.getTenantIds() == null || zeebeWorker.getTenantIds().isEmpty())) {
-      LOG.debug(
-          "Worker '{}': Setting default tenant ids to {}",
-          zeebeWorker.getName(),
-          defaultJobWorkerTenantIds);
-      zeebeWorker.setTenantIds(defaultJobWorkerTenantIds);
     }
   }
 

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/properties/TasklistClientConfigurationProperties.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/properties/TasklistClientConfigurationProperties.java
@@ -4,5 +4,4 @@ import io.camunda.zeebe.spring.client.properties.common.Client;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "tasklist.client")
-public class TasklistClientConfigurationProperties extends Client {
-}
+public class TasklistClientConfigurationProperties extends Client {}

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientStarterAutoConfigurationCustomJsonMapperTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientStarterAutoConfigurationCustomJsonMapperTest.java
@@ -1,11 +1,15 @@
 package io.camunda.zeebe.spring.client.config;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
 import io.camunda.zeebe.spring.client.CamundaAutoConfiguration;
 import io.camunda.zeebe.spring.client.configuration.ZeebeClientProdAutoConfiguration;
+import java.time.Duration;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,29 +22,27 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.util.AopTestUtils;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import java.time.Duration;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 @ExtendWith(SpringExtension.class)
 @TestPropertySource(
-  properties = {
-    "zeebe.client.broker.gatewayAddress=localhost12345",
-    "zeebe.client.requestTimeout=99s",
-    "zeebe.client.job.timeout=99s",
-    "zeebe.client.job.pollInterval=99s",
-    "zeebe.client.worker.maxJobsActive=99",
-    "zeebe.client.worker.threads=99",
-    "zeebe.client.worker.defaultName=testName",
-    "zeebe.client.worker.defaultType=testType",
-    "zeebe.client.worker.override.foo.enabled=false",
-    "zeebe.client.message.timeToLive=99s",
-    "zeebe.client.security.certpath=aPath",
-    "zeebe.client.security.plaintext=true"
-  }
-)
-@ContextConfiguration(classes = { ZeebeClientStarterAutoConfigurationCustomJsonMapperTest.TestConfig.class, CamundaAutoConfiguration.class })
+    properties = {
+      "zeebe.client.broker.gatewayAddress=localhost12345",
+      "zeebe.client.requestTimeout=99s",
+      "zeebe.client.job.timeout=99s",
+      "zeebe.client.job.pollInterval=99s",
+      "zeebe.client.worker.maxJobsActive=99",
+      "zeebe.client.worker.threads=99",
+      "zeebe.client.worker.defaultName=testName",
+      "zeebe.client.worker.defaultType=testType",
+      "zeebe.client.worker.override.foo.enabled=false",
+      "zeebe.client.message.timeToLive=99s",
+      "zeebe.client.security.certpath=aPath",
+      "zeebe.client.security.plaintext=true"
+    })
+@ContextConfiguration(
+    classes = {
+      ZeebeClientStarterAutoConfigurationCustomJsonMapperTest.TestConfig.class,
+      CamundaAutoConfiguration.class
+    })
 public class ZeebeClientStarterAutoConfigurationCustomJsonMapperTest {
 
   public static class TestConfig {
@@ -48,17 +50,19 @@ public class ZeebeClientStarterAutoConfigurationCustomJsonMapperTest {
     @Primary
     @Bean(name = "overridingJsonMapper")
     public io.camunda.zeebe.client.api.JsonMapper zeebeJsonMapper() {
-      ObjectMapper objectMapper = new ObjectMapper()
-        .configure(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES, true)
-        .configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, true);
+      ObjectMapper objectMapper =
+          new ObjectMapper()
+              .configure(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES, true)
+              .configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, true);
       return new ZeebeObjectMapper(objectMapper);
     }
 
     @Bean(name = "aSecondJsonMapper")
     public io.camunda.zeebe.client.api.JsonMapper aSecondJsonMapper() {
-      ObjectMapper objectMapper = new ObjectMapper()
-        .configure(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES, true)
-        .configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, true);
+      ObjectMapper objectMapper =
+          new ObjectMapper()
+              .configure(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES, true)
+              .configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, true);
       return new ZeebeObjectMapper(objectMapper);
     }
 
@@ -68,19 +72,17 @@ public class ZeebeClientStarterAutoConfigurationCustomJsonMapperTest {
     }
   }
 
-  @Autowired
-  private io.camunda.zeebe.client.api.JsonMapper jsonMapper;
-  @Autowired
-  private ZeebeClientProdAutoConfiguration autoConfiguration;
-  @Autowired
-  private ApplicationContext applicationContext;
+  @Autowired private io.camunda.zeebe.client.api.JsonMapper jsonMapper;
+  @Autowired private ZeebeClientProdAutoConfiguration autoConfiguration;
+  @Autowired private ApplicationContext applicationContext;
 
   @Test
   void getJsonMapper() {
     assertThat(jsonMapper).isNotNull();
     assertThat(autoConfiguration).isNotNull();
 
-    Map<String, io.camunda.zeebe.client.api.JsonMapper> jsonMapperBeans = applicationContext.getBeansOfType(io.camunda.zeebe.client.api.JsonMapper.class);
+    Map<String, io.camunda.zeebe.client.api.JsonMapper> jsonMapperBeans =
+        applicationContext.getBeansOfType(io.camunda.zeebe.client.api.JsonMapper.class);
     Object objectMapper = ReflectionTestUtils.getField(jsonMapper, "objectMapper");
 
     assertThat(jsonMapperBeans.size()).isEqualTo(2);
@@ -90,29 +92,38 @@ public class ZeebeClientStarterAutoConfigurationCustomJsonMapperTest {
     assertThat(jsonMapperBeans.get("aSecondJsonMapper")).isNotSameAs(jsonMapper);
     assertThat(objectMapper).isNotNull();
     assertThat(objectMapper).isInstanceOf(ObjectMapper.class);
-    assertThat(((ObjectMapper)objectMapper).getDeserializationConfig()).isNotNull();
-    assertThat(((ObjectMapper)objectMapper).getDeserializationConfig().isEnabled(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES)).isTrue();
-    assertThat(((ObjectMapper)objectMapper).getDeserializationConfig().isEnabled(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)).isTrue();
+    assertThat(((ObjectMapper) objectMapper).getDeserializationConfig()).isNotNull();
+    assertThat(
+            ((ObjectMapper) objectMapper)
+                .getDeserializationConfig()
+                .isEnabled(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES))
+        .isTrue();
+    assertThat(
+            ((ObjectMapper) objectMapper)
+                .getDeserializationConfig()
+                .isEnabled(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES))
+        .isTrue();
   }
 
   @Test
   void testBuilder() {
-    //ZeebeClientBuilder builder = autoConfiguration.builder(jsonMapper, Collections.emptyList());
-    //assertThat(builder).isNotNull();
+    // ZeebeClientBuilder builder = autoConfiguration.builder(jsonMapper, Collections.emptyList());
+    // assertThat(builder).isNotNull();
 
     ZeebeClient client = applicationContext.getBean(ZeebeClient.class);
-    final io.camunda.zeebe.client.api.JsonMapper clientJsonMapper = AopTestUtils.getUltimateTargetObject(client.getConfiguration().getJsonMapper());
+    final io.camunda.zeebe.client.api.JsonMapper clientJsonMapper =
+        AopTestUtils.getUltimateTargetObject(client.getConfiguration().getJsonMapper());
     assertThat(clientJsonMapper).isSameAs(jsonMapper);
     assertThat(clientJsonMapper).isSameAs(applicationContext.getBean("overridingJsonMapper"));
     assertThat(client.getConfiguration().getGatewayAddress()).isEqualTo("localhost12345");
-    assertThat(client.getConfiguration().getDefaultRequestTimeout()).isEqualTo(Duration.ofSeconds(99));
+    assertThat(client.getConfiguration().getDefaultRequestTimeout())
+        .isEqualTo(Duration.ofSeconds(99));
     assertThat(client.getConfiguration().getCaCertificatePath()).isEqualTo("aPath");
     assertThat(client.getConfiguration().isPlaintextConnectionEnabled()).isTrue();
     assertThat(client.getConfiguration().getDefaultJobWorkerMaxJobsActive()).isEqualTo(99);
-    assertThat(client.getConfiguration().getDefaultJobPollInterval()).isEqualTo(Duration.ofSeconds(99));
+    assertThat(client.getConfiguration().getDefaultJobPollInterval())
+        .isEqualTo(Duration.ofSeconds(99));
   }
 
-  private static class JsonMapper {
-
-  }
+  private static class JsonMapper {}
 }

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientStarterAutoConfigurationTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientStarterAutoConfigurationTest.java
@@ -1,10 +1,13 @@
 package io.camunda.zeebe.spring.client.config;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.spring.client.CamundaAutoConfiguration;
 import io.camunda.zeebe.spring.client.configuration.ZeebeClientProdAutoConfiguration;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,28 +18,27 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 @ExtendWith(SpringExtension.class)
 @TestPropertySource(
-  properties = {
-    "zeebe.client.broker.gatewayAddress=localhost12345",
-    "zeebe.client.requestTimeout=99s",
-    "zeebe.client.job.timeout=99s",
-    "zeebe.client.job.pollInterval=99s",
-    "zeebe.client.worker.maxJobsActive=99",
-    "zeebe.client.worker.threads=99",
-    "zeebe.client.worker.defaultName=testName",
-    "zeebe.client.worker.defaultType=testType",
-    "zeebe.client.worker.override.foo.enabled=false",
-    "zeebe.client.message.timeToLive=99s",
-    "zeebe.client.security.certpath=aPath",
-    "zeebe.client.security.plaintext=true"
-  }
-)
-@ContextConfiguration(classes = { CamundaAutoConfiguration.class, ZeebeClientStarterAutoConfigurationTest.TestConfig.class })
+    properties = {
+      "zeebe.client.broker.gatewayAddress=localhost12345",
+      "zeebe.client.requestTimeout=99s",
+      "zeebe.client.job.timeout=99s",
+      "zeebe.client.job.pollInterval=99s",
+      "zeebe.client.worker.maxJobsActive=99",
+      "zeebe.client.worker.threads=99",
+      "zeebe.client.worker.defaultName=testName",
+      "zeebe.client.worker.defaultType=testType",
+      "zeebe.client.worker.override.foo.enabled=false",
+      "zeebe.client.message.timeToLive=99s",
+      "zeebe.client.security.certpath=aPath",
+      "zeebe.client.security.plaintext=true"
+    })
+@ContextConfiguration(
+    classes = {
+      CamundaAutoConfiguration.class,
+      ZeebeClientStarterAutoConfigurationTest.TestConfig.class
+    })
 public class ZeebeClientStarterAutoConfigurationTest {
 
   public static class TestConfig {
@@ -45,15 +47,11 @@ public class ZeebeClientStarterAutoConfigurationTest {
     public ObjectMapper objectMapper() {
       return new ObjectMapper();
     }
-
   }
 
-  @Autowired
-  private JsonMapper jsonMapper;
-  @Autowired
-  private ZeebeClientProdAutoConfiguration autoConfiguration;
-  @Autowired
-  private ApplicationContext applicationContext;
+  @Autowired private JsonMapper jsonMapper;
+  @Autowired private ZeebeClientProdAutoConfiguration autoConfiguration;
+  @Autowired private ApplicationContext applicationContext;
 
   @Test
   void getJsonMapper() {
@@ -68,9 +66,16 @@ public class ZeebeClientStarterAutoConfigurationTest {
     assertThat(jsonMapperBeans.get("zeebeJsonMapper")).isSameAs(jsonMapper);
     assertThat(objectMapper).isNotNull();
     assertThat(objectMapper).isInstanceOf(ObjectMapper.class);
-    assertThat(((ObjectMapper)objectMapper).getDeserializationConfig()).isNotNull();
-    assertThat(((ObjectMapper)objectMapper).getDeserializationConfig().isEnabled(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES)).isFalse();
-    assertThat(((ObjectMapper)objectMapper).getDeserializationConfig().isEnabled(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)).isFalse();
+    assertThat(((ObjectMapper) objectMapper).getDeserializationConfig()).isNotNull();
+    assertThat(
+            ((ObjectMapper) objectMapper)
+                .getDeserializationConfig()
+                .isEnabled(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES))
+        .isFalse();
+    assertThat(
+            ((ObjectMapper) objectMapper)
+                .getDeserializationConfig()
+                .isEnabled(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES))
+        .isFalse();
   }
-
 }

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSaasOperateCredentialTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSaasOperateCredentialTest.java
@@ -1,5 +1,7 @@
 package io.camunda.zeebe.spring.client.config.authentication;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.camunda.common.auth.Authentication;
 import io.camunda.common.auth.JwtCredential;
 import io.camunda.common.auth.Product;
@@ -17,34 +19,27 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 @ExtendWith(SpringExtension.class)
 @TestPropertySource(
-  properties = {
-    "zeebe.client.cloud.region=syd-1",
-    "zeebe.client.cloud.clusterId=cluster-id",
-    "zeebe.client.cloud.clientId=client-id",
-    "zeebe.client.cloud.clientSecret=client-secret",
-    "camunda.operate.client.enabled=true",
-    "camunda.operate.client.client-id=operate-client-id",
-    "camunda.operate.client.client-secret=operate-client-secret"
-  }
-)
+    properties = {
+      "zeebe.client.cloud.region=syd-1",
+      "zeebe.client.cloud.clusterId=cluster-id",
+      "zeebe.client.cloud.clientId=client-id",
+      "zeebe.client.cloud.clientSecret=client-secret",
+      "camunda.operate.client.enabled=true",
+      "camunda.operate.client.client-id=operate-client-id",
+      "camunda.operate.client.client-secret=operate-client-secret"
+    })
 @ContextConfiguration(classes = OperateSaasOperateCredentialTest.TestConfig.class)
 public class OperateSaasOperateCredentialTest {
 
   @ImportAutoConfiguration({CommonClientConfiguration.class, OperateClientConfiguration.class})
   @EnableConfigurationProperties(ZeebeClientConfigurationProperties.class)
-  public static class TestConfig {
+  public static class TestConfig {}
 
-  }
+  @Autowired private Authentication authentication;
 
-  @Autowired
-  private Authentication authentication;
-
-  @Autowired
-  private CamundaOperateClient operateClient;
+  @Autowired private CamundaOperateClient operateClient;
 
   @Test
   public void testAuthentication() {

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSaasZeebeCredentialTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSaasZeebeCredentialTest.java
@@ -1,5 +1,7 @@
 package io.camunda.zeebe.spring.client.config.authentication;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.camunda.common.auth.*;
 import io.camunda.operate.CamundaOperateClient;
 import io.camunda.zeebe.spring.client.configuration.CommonClientConfiguration;
@@ -14,32 +16,25 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 @ExtendWith(SpringExtension.class)
 @TestPropertySource(
-  properties = {
-    "zeebe.client.cloud.region=syd-1",
-    "zeebe.client.cloud.clusterId=cluster-id",
-    "zeebe.client.cloud.clientId=client-id",
-    "zeebe.client.cloud.clientSecret=client-secret",
-    "camunda.operate.client.enabled=true"
-  }
-)
+    properties = {
+      "zeebe.client.cloud.region=syd-1",
+      "zeebe.client.cloud.clusterId=cluster-id",
+      "zeebe.client.cloud.clientId=client-id",
+      "zeebe.client.cloud.clientSecret=client-secret",
+      "camunda.operate.client.enabled=true"
+    })
 @ContextConfiguration(classes = OperateSaasZeebeCredentialTest.TestConfig.class)
 public class OperateSaasZeebeCredentialTest {
 
   @ImportAutoConfiguration({CommonClientConfiguration.class, OperateClientConfiguration.class})
   @EnableConfigurationProperties(ZeebeClientConfigurationProperties.class)
-  public static class TestConfig {
+  public static class TestConfig {}
 
-  }
+  @Autowired private Authentication authentication;
 
-  @Autowired
-  private Authentication authentication;
-
-  @Autowired
-  private CamundaOperateClient operateClient;
+  @Autowired private CamundaOperateClient operateClient;
 
   @Test
   public void testAuthentication() {

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedBasicTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedBasicTest.java
@@ -1,5 +1,7 @@
 package io.camunda.zeebe.spring.client.config.authentication;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.camunda.common.auth.Authentication;
 import io.camunda.common.auth.Product;
 import io.camunda.common.auth.SimpleAuthentication;
@@ -18,31 +20,28 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 @ExtendWith(SpringExtension.class)
 @TestPropertySource(
-  properties = {
-    "zeebe.client.broker.gatewayAddress=localhost12345",
-    "camunda.operate.client.url=http://localhost:8081",
-    "camunda.operate.client.username=username",
-    "camunda.operate.client.password=password"
-  }
-)
+    properties = {
+      "zeebe.client.broker.gatewayAddress=localhost12345",
+      "camunda.operate.client.url=http://localhost:8081",
+      "camunda.operate.client.username=username",
+      "camunda.operate.client.password=password"
+    })
 @ContextConfiguration(classes = OperateSelfManagedBasicTest.TestConfig.class)
 public class OperateSelfManagedBasicTest {
 
-  @ImportAutoConfiguration({CommonClientConfiguration.class, OperateClientConfiguration.class, IdentityAutoConfiguration.class})
+  @ImportAutoConfiguration({
+    CommonClientConfiguration.class,
+    OperateClientConfiguration.class,
+    IdentityAutoConfiguration.class
+  })
   @EnableConfigurationProperties(ZeebeClientConfigurationProperties.class)
-  public static class TestConfig {
+  public static class TestConfig {}
 
-  }
+  @Autowired private Authentication authentication;
 
-  @Autowired
-  private Authentication authentication;
-
-  @Autowired
-  private CamundaOperateClient operateClient;
+  @Autowired private CamundaOperateClient operateClient;
 
   @Test
   public void testAuthentication() {
@@ -53,7 +52,8 @@ public class OperateSelfManagedBasicTest {
   @Test
   public void testCredential() {
     SimpleAuthentication simpleAuthentication = (SimpleAuthentication) authentication;
-    SimpleCredential simpleCredential = simpleAuthentication.getSimpleConfig().getProduct(Product.OPERATE);
+    SimpleCredential simpleCredential =
+        simpleAuthentication.getSimpleConfig().getProduct(Product.OPERATE);
 
     assertThat(simpleCredential.getUser()).isEqualTo("username");
     assertThat(simpleCredential.getPassword()).isEqualTo("password");

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedBasicWithZeebeCredentialsTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedBasicWithZeebeCredentialsTest.java
@@ -1,5 +1,7 @@
 package io.camunda.zeebe.spring.client.config.authentication;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.camunda.common.auth.Authentication;
 import io.camunda.common.auth.Product;
 import io.camunda.common.auth.SimpleAuthentication;
@@ -18,35 +20,32 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 @ExtendWith(SpringExtension.class)
 @TestPropertySource(
-  properties = {
-    "zeebe.client.broker.gatewayAddress=localhost12345",
-    "zeebe.authorization.server.url=http://zeebe-authorization-server",
-    "zeebe.client.id=client-id",
-    "zeebe.client.secret=client-secret",
-    "zeebe.token.audience=sample-audience",
-    "camunda.operate.client.url=http://localhost:8081",
-    "camunda.operate.client.username=username",
-    "camunda.operate.client.password=password"
-  }
-)
+    properties = {
+      "zeebe.client.broker.gatewayAddress=localhost12345",
+      "zeebe.authorization.server.url=http://zeebe-authorization-server",
+      "zeebe.client.id=client-id",
+      "zeebe.client.secret=client-secret",
+      "zeebe.token.audience=sample-audience",
+      "camunda.operate.client.url=http://localhost:8081",
+      "camunda.operate.client.username=username",
+      "camunda.operate.client.password=password"
+    })
 @ContextConfiguration(classes = OperateSelfManagedBasicWithZeebeCredentialsTest.TestConfig.class)
 public class OperateSelfManagedBasicWithZeebeCredentialsTest {
 
-  @ImportAutoConfiguration({CommonClientConfiguration.class, OperateClientConfiguration.class, IdentityAutoConfiguration.class})
+  @ImportAutoConfiguration({
+    CommonClientConfiguration.class,
+    OperateClientConfiguration.class,
+    IdentityAutoConfiguration.class
+  })
   @EnableConfigurationProperties(ZeebeClientConfigurationProperties.class)
-  public static class TestConfig {
+  public static class TestConfig {}
 
-  }
+  @Autowired private Authentication authentication;
 
-  @Autowired
-  private Authentication authentication;
-
-  @Autowired
-  private CamundaOperateClient operateClient;
+  @Autowired private CamundaOperateClient operateClient;
 
   @Test
   public void testAuthentication() {
@@ -57,7 +56,8 @@ public class OperateSelfManagedBasicWithZeebeCredentialsTest {
   @Test
   public void testCredential() {
     SimpleAuthentication simpleAuthentication = (SimpleAuthentication) authentication;
-    SimpleCredential simpleCredential = simpleAuthentication.getSimpleConfig().getProduct(Product.OPERATE);
+    SimpleCredential simpleCredential =
+        simpleAuthentication.getSimpleConfig().getProduct(Product.OPERATE);
 
     assertThat(simpleCredential.getUser()).isEqualTo("username");
     assertThat(simpleCredential.getPassword()).isEqualTo("password");

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedIdentityTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedIdentityTest.java
@@ -1,5 +1,7 @@
 package io.camunda.zeebe.spring.client.config.authentication;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.camunda.common.auth.*;
 import io.camunda.identity.autoconfigure.IdentityAutoConfiguration;
 import io.camunda.operate.CamundaOperateClient;
@@ -15,39 +17,36 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 @ExtendWith(SpringExtension.class)
 @TestPropertySource(
-  properties = {
-    "zeebe.client.broker.gatewayAddress=localhost12345",
-    "zeebe.authorization.server.url=http://zeebe-authorization-server",
-    "zeebe.client.id=client-id",
-    "zeebe.client.secret=client-secret",
-    "zeebe.token.audience=sample-audience",
-    "camunda.operate.client.url=http://localhost:8081",
-    "camunda.identity.issuer=http://some-oidc-issuer",
-    "camunda.identity.issuer-backend-url=http://some-oidc-issuer-backend-url",
-    "camunda.identity.type=MICROSOFT",
-    "camunda.identity.client-id=client-id2",
-    "camunda.identity.client-secret=client-secret2",
-    "camunda.identity.audience=sample-audience2"
-  }
-)
+    properties = {
+      "zeebe.client.broker.gatewayAddress=localhost12345",
+      "zeebe.authorization.server.url=http://zeebe-authorization-server",
+      "zeebe.client.id=client-id",
+      "zeebe.client.secret=client-secret",
+      "zeebe.token.audience=sample-audience",
+      "camunda.operate.client.url=http://localhost:8081",
+      "camunda.identity.issuer=http://some-oidc-issuer",
+      "camunda.identity.issuer-backend-url=http://some-oidc-issuer-backend-url",
+      "camunda.identity.type=MICROSOFT",
+      "camunda.identity.client-id=client-id2",
+      "camunda.identity.client-secret=client-secret2",
+      "camunda.identity.audience=sample-audience2"
+    })
 @ContextConfiguration(classes = OperateSelfManagedIdentityTest.TestConfig.class)
 public class OperateSelfManagedIdentityTest {
 
-  @ImportAutoConfiguration({CommonClientConfiguration.class, OperateClientConfiguration.class, IdentityAutoConfiguration.class})
+  @ImportAutoConfiguration({
+    CommonClientConfiguration.class,
+    OperateClientConfiguration.class,
+    IdentityAutoConfiguration.class
+  })
   @EnableConfigurationProperties(ZeebeClientConfigurationProperties.class)
-  public static class TestConfig {
+  public static class TestConfig {}
 
-  }
+  @Autowired private Authentication authentication;
 
-  @Autowired
-  private Authentication authentication;
-
-  @Autowired
-  private CamundaOperateClient operateClient;
+  @Autowired private CamundaOperateClient operateClient;
 
   @Test
   public void testAuthentication() {
@@ -57,8 +56,10 @@ public class OperateSelfManagedIdentityTest {
 
   @Test
   public void testCredential() {
-    SelfManagedAuthentication selfManagedAuthentication = (SelfManagedAuthentication) authentication;
-    JwtCredential jwtCredential = selfManagedAuthentication.getJwtConfig().getProduct(Product.OPERATE);
+    SelfManagedAuthentication selfManagedAuthentication =
+        (SelfManagedAuthentication) authentication;
+    JwtCredential jwtCredential =
+        selfManagedAuthentication.getJwtConfig().getProduct(Product.OPERATE);
 
     assertThat(jwtCredential.getClientId()).isEqualTo("client-id2");
     assertThat(jwtCredential.getClientSecret()).isEqualTo("client-secret2");

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedKeycloakTokenUrlTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedKeycloakTokenUrlTest.java
@@ -1,5 +1,7 @@
 package io.camunda.zeebe.spring.client.config.authentication;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.camunda.common.auth.*;
 import io.camunda.identity.autoconfigure.IdentityAutoConfiguration;
 import io.camunda.operate.CamundaOperateClient;
@@ -15,34 +17,31 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 @ExtendWith(SpringExtension.class)
 @TestPropertySource(
-  properties = {
-    "zeebe.client.broker.gatewayAddress=localhost12345",
-    "zeebe.authorization.server.url=http://zeebe-authorization-server",
-    "zeebe.client.id=client-id",
-    "zeebe.client.secret=client-secret",
-    "zeebe.token.audience=sample-audience",
-    "camunda.operate.client.keycloak-token-url=https://local-keycloak/auth/realms/camunda-platform/protocol/openid-connect/token",
-    "camunda.operate.client.url=http://localhost:8081"
-  }
-)
+    properties = {
+      "zeebe.client.broker.gatewayAddress=localhost12345",
+      "zeebe.authorization.server.url=http://zeebe-authorization-server",
+      "zeebe.client.id=client-id",
+      "zeebe.client.secret=client-secret",
+      "zeebe.token.audience=sample-audience",
+      "camunda.operate.client.keycloak-token-url=https://local-keycloak/auth/realms/camunda-platform/protocol/openid-connect/token",
+      "camunda.operate.client.url=http://localhost:8081"
+    })
 @ContextConfiguration(classes = OperateSelfManagedKeycloakTokenUrlTest.TestConfig.class)
 public class OperateSelfManagedKeycloakTokenUrlTest {
 
-  @ImportAutoConfiguration({CommonClientConfiguration.class, OperateClientConfiguration.class, IdentityAutoConfiguration.class})
+  @ImportAutoConfiguration({
+    CommonClientConfiguration.class,
+    OperateClientConfiguration.class,
+    IdentityAutoConfiguration.class
+  })
   @EnableConfigurationProperties(ZeebeClientConfigurationProperties.class)
-  public static class TestConfig {
+  public static class TestConfig {}
 
-  }
+  @Autowired private Authentication authentication;
 
-  @Autowired
-  private Authentication authentication;
-
-  @Autowired
-  private CamundaOperateClient operateClient;
+  @Autowired private CamundaOperateClient operateClient;
 
   @Test
   public void testAuthentication() {
@@ -52,11 +51,12 @@ public class OperateSelfManagedKeycloakTokenUrlTest {
 
   @Test
   public void testCredential() {
-    SelfManagedAuthentication selfManagedAuthentication = (SelfManagedAuthentication) authentication;
-    JwtCredential jwtCredential = selfManagedAuthentication.getJwtConfig().getProduct(Product.OPERATE);
+    SelfManagedAuthentication selfManagedAuthentication =
+        (SelfManagedAuthentication) authentication;
+    JwtCredential jwtCredential =
+        selfManagedAuthentication.getJwtConfig().getProduct(Product.OPERATE);
 
     assertThat(jwtCredential.getClientId()).isEqualTo("client-id");
     assertThat(jwtCredential.getClientSecret()).isEqualTo("client-secret");
   }
-
 }

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedKeycloakUrlTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedKeycloakUrlTest.java
@@ -1,5 +1,7 @@
 package io.camunda.zeebe.spring.client.config.authentication;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.camunda.common.auth.Authentication;
 import io.camunda.common.auth.JwtCredential;
 import io.camunda.common.auth.Product;
@@ -18,34 +20,31 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 @ExtendWith(SpringExtension.class)
 @TestPropertySource(
-  properties = {
-    "zeebe.client.broker.gatewayAddress=localhost12345",
-    "zeebe.authorization.server.url=http://zeebe-authorization-server",
-    "zeebe.client.id=client-id",
-    "zeebe.client.secret=client-secret",
-    "zeebe.token.audience=sample-audience",
-    "camunda.operate.client.keycloak-url=https://local-keycloak",
-    "camunda.operate.client.url=http://localhost:8081"
-  }
-)
+    properties = {
+      "zeebe.client.broker.gatewayAddress=localhost12345",
+      "zeebe.authorization.server.url=http://zeebe-authorization-server",
+      "zeebe.client.id=client-id",
+      "zeebe.client.secret=client-secret",
+      "zeebe.token.audience=sample-audience",
+      "camunda.operate.client.keycloak-url=https://local-keycloak",
+      "camunda.operate.client.url=http://localhost:8081"
+    })
 @ContextConfiguration(classes = OperateSelfManagedKeycloakUrlTest.TestConfig.class)
 public class OperateSelfManagedKeycloakUrlTest {
 
-  @ImportAutoConfiguration({CommonClientConfiguration.class, OperateClientConfiguration.class, IdentityAutoConfiguration.class})
+  @ImportAutoConfiguration({
+    CommonClientConfiguration.class,
+    OperateClientConfiguration.class,
+    IdentityAutoConfiguration.class
+  })
   @EnableConfigurationProperties(ZeebeClientConfigurationProperties.class)
-  public static class TestConfig {
+  public static class TestConfig {}
 
-  }
+  @Autowired private Authentication authentication;
 
-  @Autowired
-  private Authentication authentication;
-
-  @Autowired
-  private CamundaOperateClient operateClient;
+  @Autowired private CamundaOperateClient operateClient;
 
   @Test
   public void testAuthentication() {
@@ -55,8 +54,10 @@ public class OperateSelfManagedKeycloakUrlTest {
 
   @Test
   public void testCredential() {
-    SelfManagedAuthentication selfManagedAuthentication = (SelfManagedAuthentication) authentication;
-    JwtCredential jwtCredential = selfManagedAuthentication.getJwtConfig().getProduct(Product.OPERATE);
+    SelfManagedAuthentication selfManagedAuthentication =
+        (SelfManagedAuthentication) authentication;
+    JwtCredential jwtCredential =
+        selfManagedAuthentication.getJwtConfig().getProduct(Product.OPERATE);
 
     assertThat(jwtCredential.getClientId()).isEqualTo("client-id");
     assertThat(jwtCredential.getClientSecret()).isEqualTo("client-secret");

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/properties/JavaClientPropertiesTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/properties/JavaClientPropertiesTest.java
@@ -1,7 +1,10 @@
 package io.camunda.zeebe.spring.client.properties;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
+import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,19 +15,14 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import java.time.Duration;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 @ExtendWith(SpringExtension.class)
 @TestPropertySource(
-  properties = {
-    "zeebe.client.gateway.address=localhost12345",
-    "zeebe.client.job.pollinterval=99s",
-    "zeebe.client.worker.name=testName",
-    "zeebe.client.cloud.secret=processOrchestration"
-  }
-)
+    properties = {
+      "zeebe.client.gateway.address=localhost12345",
+      "zeebe.client.job.pollinterval=99s",
+      "zeebe.client.worker.name=testName",
+      "zeebe.client.cloud.secret=processOrchestration"
+    })
 @ContextConfiguration(classes = JavaClientPropertiesTest.TestConfig.class)
 public class JavaClientPropertiesTest {
 
@@ -37,8 +35,7 @@ public class JavaClientPropertiesTest {
     }
   }
 
-  @Autowired
-  private ZeebeClientConfigurationProperties properties;
+  @Autowired private ZeebeClientConfigurationProperties properties;
 
   @Test
   public void hasBrokerContactPoint() throws Exception {
@@ -59,5 +56,4 @@ public class JavaClientPropertiesTest {
   public void hasCloudSecret() throws Exception {
     assertThat(properties.getCloud().getClientSecret()).isEqualTo("processOrchestration");
   }
-
 }

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/properties/PropertyBasedZeebeWorkerValueCustomizerTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/properties/PropertyBasedZeebeWorkerValueCustomizerTest.java
@@ -139,21 +139,6 @@ public class PropertyBasedZeebeWorkerValueCustomizerTest {
   }
 
   @Test
-  void shouldSetDefaultTenantIds() {
-    // given
-    ZeebeClientConfigurationProperties properties = properties();
-    PropertyBasedZeebeWorkerValueCustomizer customizer =
-        new PropertyBasedZeebeWorkerValueCustomizer(properties);
-    ZeebeWorkerValue zeebeWorkerValue = new ZeebeWorkerValue();
-    zeebeWorkerValue.setMethodInfo(methodInfo(this, "testBean", "sampleWorker"));
-    // when
-    customizer.customize(zeebeWorkerValue);
-    // then
-    assertThat(zeebeWorkerValue.getTenantIds())
-        .containsOnly(ZeebeClientConfigurationProperties.DEFAULT.getDefaultTenantId());
-  }
-
-  @Test
   void shouldApplyOverrides() {
     // given
     ZeebeClientConfigurationProperties properties = properties();

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/properties/PropertyBasedZeebeWorkerValueCustomizerTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/properties/PropertyBasedZeebeWorkerValueCustomizerTest.java
@@ -1,0 +1,194 @@
+package io.camunda.zeebe.spring.client.properties;
+
+import static org.assertj.core.api.Assertions.*;
+
+import io.camunda.zeebe.spring.client.annotation.JobWorker;
+import io.camunda.zeebe.spring.client.annotation.Variable;
+import io.camunda.zeebe.spring.client.annotation.VariablesAsType;
+import io.camunda.zeebe.spring.client.annotation.value.ZeebeWorkerValue;
+import io.camunda.zeebe.spring.client.bean.ClassInfo;
+import io.camunda.zeebe.spring.client.bean.MethodInfo;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+public class PropertyBasedZeebeWorkerValueCustomizerTest {
+
+  private static MethodInfo methodInfo(Object bean, String beanName, String methodName) {
+    try {
+      return MethodInfo.builder()
+          .classInfo(ClassInfo.builder().beanName(beanName).bean(bean).build())
+          .method(
+              Arrays.stream(PropertyBasedZeebeWorkerValueCustomizerTest.class.getDeclaredMethods())
+                  .filter(m -> m.getName().equals(methodName))
+                  .findFirst()
+                  .orElseThrow(
+                      () -> new IllegalStateException("No method present with name " + methodName)))
+          .build();
+    } catch (Exception e) {
+      throw new RuntimeException("Error while constructing methodInfo for method " + methodName, e);
+    }
+  }
+
+  private static ZeebeClientConfigurationProperties properties() {
+    ZeebeClientConfigurationProperties properties = new ZeebeClientConfigurationProperties(null);
+    properties.applyOverrides();
+    return properties;
+  }
+
+  @JobWorker
+  void sampleWorker(@Variable String var1, @VariablesAsType ComplexProcessVariable var2) {}
+
+  @Test
+  void shouldSetDefaultName() throws NoSuchMethodException {
+    // given
+    ZeebeClientConfigurationProperties properties = properties();
+    properties.getWorker().setDefaultName("defaultName");
+    PropertyBasedZeebeWorkerValueCustomizer customizer =
+        new PropertyBasedZeebeWorkerValueCustomizer(properties);
+    ZeebeWorkerValue zeebeWorkerValue = new ZeebeWorkerValue();
+    zeebeWorkerValue.setMethodInfo(methodInfo(this, "testBean", "sampleWorker"));
+    // when
+    customizer.customize(zeebeWorkerValue);
+    // then
+    assertThat(zeebeWorkerValue.getName()).isEqualTo("defaultName");
+  }
+
+  @Test
+  void shouldSetGeneratedName() {
+    // given
+    ZeebeClientConfigurationProperties properties = properties();
+    PropertyBasedZeebeWorkerValueCustomizer customizer =
+        new PropertyBasedZeebeWorkerValueCustomizer(properties);
+    ZeebeWorkerValue zeebeWorkerValue = new ZeebeWorkerValue();
+    zeebeWorkerValue.setMethodInfo(methodInfo(this, "testBean", "sampleWorker"));
+    // when
+    customizer.customize(zeebeWorkerValue);
+    // then
+    assertThat(zeebeWorkerValue.getName()).isEqualTo("testBean#sampleWorker");
+  }
+
+  @Test
+  void shouldSetDefaultType() {
+    // given
+    ZeebeClientConfigurationProperties properties = properties();
+    properties.getWorker().setDefaultType("defaultType");
+    PropertyBasedZeebeWorkerValueCustomizer customizer =
+        new PropertyBasedZeebeWorkerValueCustomizer(properties);
+    ZeebeWorkerValue zeebeWorkerValue = new ZeebeWorkerValue();
+    zeebeWorkerValue.setMethodInfo(methodInfo(this, "testBean", "sampleWorker"));
+    // when
+    customizer.customize(zeebeWorkerValue);
+    // then
+    assertThat(zeebeWorkerValue.getType()).isEqualTo("defaultType");
+  }
+
+  @Test
+  void shouldSetGeneratedType() {
+    // given
+    ZeebeClientConfigurationProperties properties = properties();
+    PropertyBasedZeebeWorkerValueCustomizer customizer =
+        new PropertyBasedZeebeWorkerValueCustomizer(properties);
+    ZeebeWorkerValue zeebeWorkerValue = new ZeebeWorkerValue();
+    zeebeWorkerValue.setMethodInfo(methodInfo(this, "testBean", "sampleWorker"));
+    // when
+    customizer.customize(zeebeWorkerValue);
+    // then
+    assertThat(zeebeWorkerValue.getType()).isEqualTo("sampleWorker");
+  }
+
+  @Test
+  void shouldSetVariablesFromVariableAnnotation() {
+    // given
+    ZeebeClientConfigurationProperties properties = properties();
+    PropertyBasedZeebeWorkerValueCustomizer customizer =
+        new PropertyBasedZeebeWorkerValueCustomizer(properties);
+    ZeebeWorkerValue zeebeWorkerValue = new ZeebeWorkerValue();
+    zeebeWorkerValue.setMethodInfo(methodInfo(this, "testBean", "sampleWorker"));
+    // when
+    customizer.customize(zeebeWorkerValue);
+    // then
+    assertThat(zeebeWorkerValue.getFetchVariables()).contains("var1");
+  }
+
+  @Test
+  void shouldSetVariablesFromVariablesAsTypeAnnotation() {
+    // given
+    ZeebeClientConfigurationProperties properties = properties();
+    PropertyBasedZeebeWorkerValueCustomizer customizer =
+        new PropertyBasedZeebeWorkerValueCustomizer(properties);
+    ZeebeWorkerValue zeebeWorkerValue = new ZeebeWorkerValue();
+    zeebeWorkerValue.setMethodInfo(methodInfo(this, "testBean", "sampleWorker"));
+    // when
+    customizer.customize(zeebeWorkerValue);
+    // then
+    assertThat(zeebeWorkerValue.getFetchVariables()).contains("var3", "var4");
+  }
+
+  @Test
+  void shouldNotSetNameOfVariablesAsTypeAnnotatedField() {
+    // given
+    ZeebeClientConfigurationProperties properties = properties();
+    PropertyBasedZeebeWorkerValueCustomizer customizer =
+        new PropertyBasedZeebeWorkerValueCustomizer(properties);
+    ZeebeWorkerValue zeebeWorkerValue = new ZeebeWorkerValue();
+    zeebeWorkerValue.setMethodInfo(methodInfo(this, "testBean", "sampleWorker"));
+    // when
+    customizer.customize(zeebeWorkerValue);
+    // then
+    assertThat(zeebeWorkerValue.getFetchVariables()).doesNotContain("var2");
+  }
+
+  @Test
+  void shouldSetDefaultTenantIds() {
+    // given
+    ZeebeClientConfigurationProperties properties = properties();
+    PropertyBasedZeebeWorkerValueCustomizer customizer =
+        new PropertyBasedZeebeWorkerValueCustomizer(properties);
+    ZeebeWorkerValue zeebeWorkerValue = new ZeebeWorkerValue();
+    zeebeWorkerValue.setMethodInfo(methodInfo(this, "testBean", "sampleWorker"));
+    // when
+    customizer.customize(zeebeWorkerValue);
+    // then
+    assertThat(zeebeWorkerValue.getTenantIds())
+        .containsOnly(ZeebeClientConfigurationProperties.DEFAULT.getDefaultTenantId());
+  }
+
+  @Test
+  void shouldApplyOverrides() {
+    // given
+    ZeebeClientConfigurationProperties properties = properties();
+    ZeebeWorkerValue override = new ZeebeWorkerValue();
+    override.setEnabled(false);
+    properties.getWorker().getOverride().put("sampleWorker", override);
+    PropertyBasedZeebeWorkerValueCustomizer customizer =
+        new PropertyBasedZeebeWorkerValueCustomizer(properties);
+    ZeebeWorkerValue zeebeWorkerValue = new ZeebeWorkerValue();
+    zeebeWorkerValue.setMethodInfo(methodInfo(this, "testBean", "sampleWorker"));
+    assertThat(zeebeWorkerValue.getEnabled()).isNull();
+    // when
+    customizer.customize(zeebeWorkerValue);
+    // then
+    assertThat(zeebeWorkerValue.getEnabled()).isFalse();
+  }
+
+  private static class ComplexProcessVariable {
+    private String var3;
+    private String var4;
+
+    public String getVar3() {
+      return var3;
+    }
+
+    public void setVar3(String var3) {
+      this.var3 = var3;
+    }
+
+    public String getVar4() {
+      return var4;
+    }
+
+    public void setVar4(String var4) {
+      this.var4 = var4;
+    }
+  }
+}

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/properties/ZeebeClientSpringConfigurationDefaultPropertiesTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/properties/ZeebeClientSpringConfigurationDefaultPropertiesTest.java
@@ -3,7 +3,6 @@ package io.camunda.zeebe.spring.client.properties;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,16 +11,14 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
-@ContextConfiguration(classes = ZeebeClientSpringConfigurationDefaultPropertiesTest.TestConfig.class)
+@ContextConfiguration(
+    classes = ZeebeClientSpringConfigurationDefaultPropertiesTest.TestConfig.class)
 public class ZeebeClientSpringConfigurationDefaultPropertiesTest {
 
   @EnableConfigurationProperties(ZeebeClientConfigurationProperties.class)
-  public static class TestConfig {
+  public static class TestConfig {}
 
-  }
-
-  @Autowired
-  private ZeebeClientConfigurationProperties properties;
+  @Autowired private ZeebeClientConfigurationProperties properties;
 
   @Test
   public void hasGatewayAddress() throws Exception {
@@ -36,7 +33,6 @@ public class ZeebeClientSpringConfigurationDefaultPropertiesTest {
   @Test
   public void hasNoWorkerName() throws Exception {
     assertThat(properties.getDefaultJobWorkerName()).isNull();
-
   }
 
   @Test
@@ -47,7 +43,6 @@ public class ZeebeClientSpringConfigurationDefaultPropertiesTest {
   @Test
   public void hasWorkerMaxJobsActive() throws Exception {
     assertThat(properties.getDefaultJobWorkerMaxJobsActive()).isEqualTo(32);
-
   }
 
   @Test
@@ -74,5 +69,4 @@ public class ZeebeClientSpringConfigurationDefaultPropertiesTest {
   public void hasSecurityCertificatePath() throws Exception {
     assertThat(properties.getCaCertificatePath()).isNull();
   }
-
 }

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/properties/ZeebeClientSpringConfigurationPropertiesTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/properties/ZeebeClientSpringConfigurationPropertiesTest.java
@@ -1,7 +1,10 @@
 package io.camunda.zeebe.spring.client.properties;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
+import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,27 +15,22 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import java.time.Duration;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 @ExtendWith(SpringExtension.class)
 @TestPropertySource(
-  properties = {
-    "zeebe.client.broker.gatewayAddress=localhost12345",
-    "zeebe.client.requestTimeout=99s",
-    "zeebe.client.job.timeout=99s",
-    "zeebe.client.job.pollInterval=99s",
-    "zeebe.client.worker.maxJobsActive=99",
-    "zeebe.client.worker.threads=99",
-    "zeebe.client.worker.defaultName=testName",
-    "zeebe.client.worker.defaultType=testType",
-    "zeebe.client.worker.override.foo.enabled=false",
-    "zeebe.client.message.timeToLive=99s",
-    "zeebe.client.security.certpath=aPath",
-    "zeebe.client.security.plaintext=true"
-  }
-)
+    properties = {
+      "zeebe.client.broker.gatewayAddress=localhost12345",
+      "zeebe.client.requestTimeout=99s",
+      "zeebe.client.job.timeout=99s",
+      "zeebe.client.job.pollInterval=99s",
+      "zeebe.client.worker.maxJobsActive=99",
+      "zeebe.client.worker.threads=99",
+      "zeebe.client.worker.defaultName=testName",
+      "zeebe.client.worker.defaultType=testType",
+      "zeebe.client.worker.override.foo.enabled=false",
+      "zeebe.client.message.timeToLive=99s",
+      "zeebe.client.security.certpath=aPath",
+      "zeebe.client.security.plaintext=true"
+    })
 @ContextConfiguration(classes = ZeebeClientSpringConfigurationPropertiesTest.TestConfig.class)
 public class ZeebeClientSpringConfigurationPropertiesTest {
 
@@ -45,11 +43,9 @@ public class ZeebeClientSpringConfigurationPropertiesTest {
     }
   }
 
-  @Autowired
-  private ZeebeClientConfigurationProperties properties;
+  @Autowired private ZeebeClientConfigurationProperties properties;
 
-  @Autowired
-  private JsonMapper jsonMapper;
+  @Autowired private JsonMapper jsonMapper;
 
   @Test
   public void hasBrokerContactPoint() throws Exception {
@@ -79,7 +75,6 @@ public class ZeebeClientSpringConfigurationPropertiesTest {
   @Test
   public void hasWorkerMaxJobsActive() throws Exception {
     assertThat(properties.getWorker().getMaxJobsActive()).isEqualTo(99);
-
   }
 
   @Test

--- a/spring-client-annotations/src/main/java/io/camunda/zeebe/spring/client/annotation/JobWorker.java
+++ b/spring-client-annotations/src/main/java/io/camunda/zeebe/spring/client/annotation/JobWorker.java
@@ -7,68 +7,79 @@ import java.lang.annotation.*;
 @Documented
 public @interface JobWorker {
 
-  String type() default ""; // set to empty string which leads to method name being used (if not ${zeebe.client.worker.default-type}" is configured) Implemented in ZeebeWorkerAnnotationProcessor
+  String type() default ""; // set to empty string which leads to method name being used (if not
 
-  String name() default ""; // set to empty string which leads to default from ZeebeClientBuilderImpl being used in ZeebeWorkerAnnotationProcessor
+  // ${zeebe.client.worker.default-type}" is configured) Implemented in
+  // ZeebeWorkerAnnotationProcessor
+
+  String name() default
+      ""; // set to empty string which leads to default from ZeebeClientBuilderImpl being used in
+
+  // ZeebeWorkerAnnotationProcessor
 
   /**
-   * Set the time (in milliseconds) for how long a job is exclusively assigned for this worker.
-   * In this time, the job can not be assigned by other workers to ensure that only one worker work on the job.
-   * When the time is over then the job can be assigned again by this or other worker if it's not completed yet.
-   * If no timeout is set, then the default is used from the configuration.
+   * Set the time (in milliseconds) for how long a job is exclusively assigned for this worker. In
+   * this time, the job can not be assigned by other workers to ensure that only one worker work on
+   * the job. When the time is over then the job can be assigned again by this or other worker if
+   * it's not completed yet. If no timeout is set, then the default is used from the configuration.
    */
   long timeout() default -1L;
 
   /**
-   * Set the maximum number of jobs which will be exclusively activated for this worker at the same time.
-   * This is used to control the backpressure of the worker. When the maximum is reached then the worker will stop activating new jobs
-   * in order to not overwhelm the client and give other workers the chance to work on the jobs.
-   * The worker will try to activate new jobs again when jobs are completed (or marked as failed).
-   * If no maximum is set then the default, from the ZeebeClientConfiguration, is used.
-   * <br/><br/>
-   * Considerations:
-   * A greater value can avoid situations in which the client waits idle for the broker to provide more jobs. This can improve the worker's throughput.
-   * The memory used by the worker is linear with respect to this value.
-   * The job's timeout starts to run down as soon as the broker pushes the job.
-   * Keep in mind that the following must hold to ensure fluent job handling:
+   * Set the maximum number of jobs which will be exclusively activated for this worker at the same
+   * time. This is used to control the backpressure of the worker. When the maximum is reached then
+   * the worker will stop activating new jobs in order to not overwhelm the client and give other
+   * workers the chance to work on the jobs. The worker will try to activate new jobs again when
+   * jobs are completed (or marked as failed). If no maximum is set then the default, from the
+   * ZeebeClientConfiguration, is used. <br>
+   * <br>
+   * Considerations: A greater value can avoid situations in which the client waits idle for the
+   * broker to provide more jobs. This can improve the worker's throughput. The memory used by the
+   * worker is linear with respect to this value. The job's timeout starts to run down as soon as
+   * the broker pushes the job. Keep in mind that the following must hold to ensure fluent job
+   * handling:
+   *
    * <pre>time spent in queue + time job handler needs until job completion < job timeout</pre>
    */
   int maxJobsActive() default -1;
 
   /**
-   * Set the request timeout (in seconds) for activate job request used to poll for new job.
-   * If no request timeout is set then the default is used from the {@link io.camunda.zeebe.client.ZeebeClientConfiguration ZeebeClientConfiguration}
+   * Set the request timeout (in seconds) for activate job request used to poll for new job. If no
+   * request timeout is set then the default is used from the {@link
+   * io.camunda.zeebe.client.ZeebeClientConfiguration ZeebeClientConfiguration}
    */
   long requestTimeout() default -1L;
 
   /**
-   * Set the maximal interval (in milliseconds) between polling for new jobs.
-   * A job worker will automatically try to always activate new jobs after completing jobs.
-   * If no jobs can be activated after completing the worker will periodically poll for new jobs.
-   * If no poll interval is set then the default is used from the {@link io.camunda.zeebe.client.ZeebeClientConfiguration ZeebeClientConfiguration}
+   * Set the maximal interval (in milliseconds) between polling for new jobs. A job worker will
+   * automatically try to always activate new jobs after completing jobs. If no jobs can be
+   * activated after completing the worker will periodically poll for new jobs. If no poll interval
+   * is set then the default is used from the {@link
+   * io.camunda.zeebe.client.ZeebeClientConfiguration ZeebeClientConfiguration}
    */
   long pollInterval() default -1L;
 
   /**
-   * Set a list of variable names which should be fetch on job activation.
-   * The jobs which are activated by this worker will only contain variables from this list.
-   * This can be used to limit the number of variables of the activated jobs.
+   * Set a list of variable names which should be fetch on job activation. The jobs which are
+   * activated by this worker will only contain variables from this list. This can be used to limit
+   * the number of variables of the activated jobs.
    */
   String[] fetchVariables() default {};
 
-  /**
-   * If set to true, all variables are fetched
-   */
+  /** If set to true, all variables are fetched */
   boolean fetchAllVariables() default false;
 
   /**
-   * If set to true, the job is automatically completed after the worker code has finished.
-   * In this case, your worker code is not allowed to complete the job itself.
+   * If set to true, the job is automatically completed after the worker code has finished. In this
+   * case, your worker code is not allowed to complete the job itself.
    *
-   *  You can still throw exceptions if you want to raise a problem instead of job completion.
-   *  You could also raise a BPMN problem throwing a {@link io.camunda.zeebe.spring.client.exception.ZeebeBpmnError}
+   * <p>You can still throw exceptions if you want to raise a problem instead of job completion. You
+   * could also raise a BPMN problem throwing a {@link
+   * io.camunda.zeebe.spring.client.exception.ZeebeBpmnError}
    */
   boolean autoComplete() default true;
 
   boolean enabled() default true;
+
+  String[] tenantIds() default {};
 }

--- a/spring-client-annotations/src/main/java/io/camunda/zeebe/spring/client/annotation/Variable.java
+++ b/spring-client-annotations/src/main/java/io/camunda/zeebe/spring/client/annotation/Variable.java
@@ -7,6 +7,8 @@ import java.lang.annotation.*;
 @Documented
 public @interface Variable {
   String DEFAULT_NAME = "$NULL$";
+
   String name() default DEFAULT_NAME;
+
   String value() default DEFAULT_NAME;
 }

--- a/spring-client-annotations/src/main/java/io/camunda/zeebe/spring/client/annotation/ZeebeCustomHeaders.java
+++ b/spring-client-annotations/src/main/java/io/camunda/zeebe/spring/client/annotation/ZeebeCustomHeaders.java
@@ -6,8 +6,7 @@ import java.lang.annotation.*;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 /**
- * @deprecated
- * Use {@link CustomHeaders} instead.
+ * @deprecated Use {@link CustomHeaders} instead.
  */
 @Deprecated
 public @interface ZeebeCustomHeaders {}

--- a/spring-client-annotations/src/main/java/io/camunda/zeebe/spring/client/annotation/ZeebeDeployment.java
+++ b/spring-client-annotations/src/main/java/io/camunda/zeebe/spring/client/annotation/ZeebeDeployment.java
@@ -12,8 +12,7 @@ import java.lang.annotation.Target;
 @Documented
 @Inherited // has to be inherited to work on spring aop beans
 /**
- * @deprecated
- * Use {@link Deployment} instead.
+ * @deprecated Use {@link Deployment} instead.
  */
 @Deprecated
 public @interface ZeebeDeployment {

--- a/spring-client-annotations/src/main/java/io/camunda/zeebe/spring/client/annotation/ZeebeVariable.java
+++ b/spring-client-annotations/src/main/java/io/camunda/zeebe/spring/client/annotation/ZeebeVariable.java
@@ -6,10 +6,7 @@ import java.lang.annotation.*;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 /**
- * @deprecated
- * Use {@link Variable} instead.
+ * @deprecated Use {@link Variable} instead.
  */
 @Deprecated
-public @interface ZeebeVariable {
-
-}
+public @interface ZeebeVariable {}

--- a/spring-client-annotations/src/main/java/io/camunda/zeebe/spring/client/annotation/ZeebeVariablesAsType.java
+++ b/spring-client-annotations/src/main/java/io/camunda/zeebe/spring/client/annotation/ZeebeVariablesAsType.java
@@ -6,8 +6,7 @@ import java.lang.annotation.*;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 /**
- * @deprecated
- * Use {@link VariablesAsType} instead.
+ * @deprecated Use {@link VariablesAsType} instead.
  */
 @Deprecated
 public @interface ZeebeVariablesAsType {}

--- a/spring-client-annotations/src/main/java/io/camunda/zeebe/spring/client/annotation/ZeebeWorker.java
+++ b/spring-client-annotations/src/main/java/io/camunda/zeebe/spring/client/annotation/ZeebeWorker.java
@@ -10,15 +10,21 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 /**
- * @deprecated
- * Use {@link JobWorker} instead. Note, that the default for auto completion has changed there from "false" to "true"!
+ * @deprecated Use {@link JobWorker} instead. Note, that the default for auto completion has changed
+ *     there from "false" to "true"!
  */
 @Deprecated
 public @interface ZeebeWorker {
 
-  String type() default ""; // set to empty string which leads to method name being used (if not ${zeebe.client.worker.default-type}" is configured) Implemented in ZeebeWorkerAnnotationProcessor
+  String type() default ""; // set to empty string which leads to method name being used (if not
 
-  String name() default ""; // set to empty string which leads to default from ZeebeClientBuilderImpl being used in ZeebeWorkerAnnotationProcessor
+  // ${zeebe.client.worker.default-type}" is configured) Implemented in
+  // ZeebeWorkerAnnotationProcessor
+
+  String name() default
+      ""; // set to empty string which leads to default from ZeebeClientBuilderImpl being used in
+
+  // ZeebeWorkerAnnotationProcessor
 
   long timeout() default -1L;
 
@@ -31,19 +37,22 @@ public @interface ZeebeWorker {
   String[] fetchVariables() default {};
 
   /**
-   * Set to true, all variables are fetched independent of any other configuration
-   * via fetchVariables or @ZeebeVariable.
+   * Set to true, all variables are fetched independent of any other configuration via
+   * fetchVariables or @ZeebeVariable.
    */
   boolean forceFetchAllVariables() default false;
 
   /**
-   * If set to true, the job is automatically completed after the worker code has finished.
-   * In this case, your worker code is not allowed to complete the job itself.
+   * If set to true, the job is automatically completed after the worker code has finished. In this
+   * case, your worker code is not allowed to complete the job itself.
    *
-   *  You can still throw exceptions if you want to raise a problem instead of job completion.
-   *  You could also raise a BPMN problem throwing a {@link io.camunda.zeebe.spring.client.exception.ZeebeBpmnError}
+   * <p>You can still throw exceptions if you want to raise a problem instead of job completion. You
+   * could also raise a BPMN problem throwing a {@link
+   * io.camunda.zeebe.spring.client.exception.ZeebeBpmnError}
    */
   boolean autoComplete() default false;
 
   boolean enabled() default true;
+
+  String[] tenantIds() default {};
 }

--- a/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/EnableZeebeClient.java
+++ b/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/EnableZeebeClient.java
@@ -6,16 +6,15 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.context.annotation.Import;
 
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Inherited
-@Deprecated // This annotation has no effect any more and will be removed in some later version of spring-zeebe, see https://github.com/camunda-community-hub/spring-zeebe/issues/275
+@Deprecated // This annotation has no effect any more and will be removed in some later version of
+// spring-zeebe, see https://github.com/camunda-community-hub/spring-zeebe/issues/275
 /**
- *  @deprecated This annotation does not have any effect any more from 8.2.x on and can simply be removed
+ * @deprecated This annotation does not have any effect any more from 8.2.x on and can simply be
+ *     removed
  */
-public @interface EnableZeebeClient {
-
-}
+public @interface EnableZeebeClient {}

--- a/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/annotation/customizer/ZeebeWorkerValueCustomizer.java
+++ b/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/annotation/customizer/ZeebeWorkerValueCustomizer.java
@@ -3,9 +3,12 @@ package io.camunda.zeebe.spring.client.annotation.customizer;
 import io.camunda.zeebe.spring.client.annotation.value.ZeebeWorkerValue;
 
 /**
- * This interface could be used to customize the {@link io.camunda.zeebe.spring.client.annotation.ZeebeWorker} annotation's values.
- * Just implement it and put it into to the {@link org.springframework.context.ApplicationContext} to make it work.
- * But be careful: these customizers are applied sequentially and if you need to change the order of these customizers use the {@link org.springframework.core.annotation.Order} annotation or the {@link org.springframework.core.Ordered} interface.
+ * This interface could be used to customize the {@link
+ * io.camunda.zeebe.spring.client.annotation.ZeebeWorker} annotation's values. Just implement it and
+ * put it into to the {@link org.springframework.context.ApplicationContext} to make it work. But be
+ * careful: these customizers are applied sequentially and if you need to change the order of these
+ * customizers use the {@link org.springframework.core.annotation.Order} annotation or the {@link
+ * org.springframework.core.Ordered} interface.
  *
  * @see io.camunda.zeebe.spring.client.properties.PropertyBasedZeebeWorkerValueCustomizer
  */

--- a/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/annotation/processor/AbstractZeebeAnnotationProcessor.java
+++ b/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/annotation/processor/AbstractZeebeAnnotationProcessor.java
@@ -18,7 +18,10 @@ public abstract class AbstractZeebeAnnotationProcessor implements BeanNameAware 
   }
 
   public abstract boolean isApplicableFor(ClassInfo beanInfo);
+
   public abstract void configureFor(final ClassInfo beanInfo);
+
   public abstract void start(ZeebeClient zeebeClient);
+
   public abstract void stop(ZeebeClient zeebeClient);
 }

--- a/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/annotation/processor/AnnotationProcessorConfiguration.java
+++ b/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/annotation/processor/AnnotationProcessorConfiguration.java
@@ -2,20 +2,20 @@ package io.camunda.zeebe.spring.client.annotation.processor;
 
 import io.camunda.zeebe.spring.client.annotation.customizer.ZeebeWorkerValueCustomizer;
 import io.camunda.zeebe.spring.client.jobhandling.JobWorkerManager;
-import org.springframework.context.annotation.Bean;
-import org.springframework.core.env.Environment;
-
 import java.util.List;
+import org.springframework.context.annotation.Bean;
 
 public class AnnotationProcessorConfiguration {
 
   @Bean
-  public ZeebeAnnotationProcessorRegistry zeebeAnnotationProcessorRegistry(final List<AbstractZeebeAnnotationProcessor> processors) {
+  public ZeebeAnnotationProcessorRegistry zeebeAnnotationProcessorRegistry(
+      final List<AbstractZeebeAnnotationProcessor> processors) {
     return new ZeebeAnnotationProcessorRegistry(processors);
   }
 
   @Bean
-  public ZeebeClientEventListener zeebeClientEventListener(final ZeebeAnnotationProcessorRegistry zeebeAnnotationProcessorRegistry) {
+  public ZeebeClientEventListener zeebeClientEventListener(
+      final ZeebeAnnotationProcessorRegistry zeebeAnnotationProcessorRegistry) {
     return new ZeebeClientEventListener(zeebeAnnotationProcessorRegistry);
   }
 
@@ -25,12 +25,9 @@ public class AnnotationProcessorConfiguration {
   }
 
   @Bean
-  public ZeebeWorkerAnnotationProcessor zeebeWorkerPostProcessor(final JobWorkerManager jobWorkerManager,
-                                                                 final List<ZeebeWorkerValueCustomizer> zeebeWorkerValueCustomizers,
-                                                                 final Environment environment) { // can#t use @Value because it is only evaluated after constructors are executed
-    String defaultWorkerType = environment.getProperty("zeebe.client.worker.default-type", (String)null);
-    String defaultJobWorkerName = environment.getProperty("zeebe.client.worker.default-name", (String)null);
-    return new ZeebeWorkerAnnotationProcessor(jobWorkerManager, zeebeWorkerValueCustomizers, defaultWorkerType, defaultJobWorkerName);
+  public ZeebeWorkerAnnotationProcessor zeebeWorkerPostProcessor(
+      final JobWorkerManager jobWorkerManager,
+      final List<ZeebeWorkerValueCustomizer> zeebeWorkerValueCustomizers) {
+    return new ZeebeWorkerAnnotationProcessor(jobWorkerManager, zeebeWorkerValueCustomizers);
   }
-
 }

--- a/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/annotation/processor/ZeebeAnnotationProcessorRegistry.java
+++ b/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/annotation/processor/ZeebeAnnotationProcessorRegistry.java
@@ -2,16 +2,15 @@ package io.camunda.zeebe.spring.client.annotation.processor;
 
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.spring.client.bean.ClassInfo;
+import java.util.List;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.core.Ordered;
 
-import java.util.List;
-
 /**
  * Always created by {@link AnnotationProcessorConfiguration}
  *
- * Keeps a list of all annotations and reads them after all Spring beans are initialized
+ * <p>Keeps a list of all annotations and reads them after all Spring beans are initialized
  */
 public class ZeebeAnnotationProcessorRegistry implements BeanPostProcessor, Ordered {
 
@@ -22,7 +21,8 @@ public class ZeebeAnnotationProcessorRegistry implements BeanPostProcessor, Orde
   }
 
   @Override
-  public Object postProcessAfterInitialization(final Object bean, final String beanName) throws BeansException {
+  public Object postProcessAfterInitialization(final Object bean, final String beanName)
+      throws BeansException {
     final ClassInfo beanInfo = ClassInfo.builder().bean(bean).beanName(beanName).build();
 
     for (final AbstractZeebeAnnotationProcessor zeebePostProcessor : processors) {

--- a/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/annotation/processor/ZeebeClientEventListener.java
+++ b/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/annotation/processor/ZeebeClientEventListener.java
@@ -8,7 +8,8 @@ public class ZeebeClientEventListener {
 
   private final ZeebeAnnotationProcessorRegistry zeebeAnnotationProcessorRegistry;
 
-  public ZeebeClientEventListener(ZeebeAnnotationProcessorRegistry zeebeAnnotationProcessorRegistry) {
+  public ZeebeClientEventListener(
+      ZeebeAnnotationProcessorRegistry zeebeAnnotationProcessorRegistry) {
     this.zeebeAnnotationProcessorRegistry = zeebeAnnotationProcessorRegistry;
   }
 
@@ -21,5 +22,4 @@ public class ZeebeClientEventListener {
   public void handleStop(ZeebeClientClosingEvent evt) {
     zeebeAnnotationProcessorRegistry.stopAll(evt.getClient());
   }
-
 }

--- a/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/annotation/processor/ZeebeWorkerAnnotationProcessor.java
+++ b/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/annotation/processor/ZeebeWorkerAnnotationProcessor.java
@@ -1,5 +1,7 @@
 package io.camunda.zeebe.spring.client.annotation.processor;
 
+import static org.springframework.util.ReflectionUtils.doWithMethods;
+
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.spring.client.annotation.JobWorker;
 import io.camunda.zeebe.spring.client.annotation.ZeebeWorker;
@@ -8,46 +10,43 @@ import io.camunda.zeebe.spring.client.annotation.value.ZeebeWorkerValue;
 import io.camunda.zeebe.spring.client.bean.ClassInfo;
 import io.camunda.zeebe.spring.client.bean.MethodInfo;
 import io.camunda.zeebe.spring.client.jobhandling.JobWorkerManager;
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.ReflectionUtils;
 
-import java.lang.invoke.MethodHandles;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-
-import static org.springframework.util.ReflectionUtils.doWithMethods;
-
 /**
  * Always created by {@link AnnotationProcessorConfiguration}
  *
- * Triggered by {@link ZeebeAnnotationProcessorRegistry#postProcessAfterInitialization(Object, String)} to add Handler subscriptions for {@link ZeebeWorker}
+ * <p>Triggered by {@link ZeebeAnnotationProcessorRegistry#postProcessAfterInitialization(Object,
+ * String)} to add Handler subscriptions for {@link ZeebeWorker} and {@link JobWorker}
  * method-annotations.
  */
 public class ZeebeWorkerAnnotationProcessor extends AbstractZeebeAnnotationProcessor {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   private final JobWorkerManager jobWorkerManager;
 
   private final List<ZeebeWorkerValue> zeebeWorkerValues = new ArrayList<>();
   private final List<ZeebeWorkerValueCustomizer> zeebeWorkerValueCustomizers;
-  private String defaultWorkerType;
-  private String defaultWorkerName;
 
-  public ZeebeWorkerAnnotationProcessor(final JobWorkerManager jobWorkerFactory,
-                                        final List<ZeebeWorkerValueCustomizer> zeebeWorkerValueCustomizers,
-                                        final String defaultWorkerType, final String defaultJobWorkerName) {
+  public ZeebeWorkerAnnotationProcessor(
+      final JobWorkerManager jobWorkerFactory,
+      final List<ZeebeWorkerValueCustomizer> zeebeWorkerValueCustomizers) {
     this.jobWorkerManager = jobWorkerFactory;
     this.zeebeWorkerValueCustomizers = zeebeWorkerValueCustomizers;
-    this.defaultWorkerType = defaultWorkerType;
-    this.defaultWorkerName = defaultJobWorkerName;
   }
 
   @Override
   public boolean isApplicableFor(ClassInfo beanInfo) {
-    return beanInfo.hasMethodAnnotation(JobWorker.class) || beanInfo.hasMethodAnnotation(ZeebeWorker.class);
+    return beanInfo.hasMethodAnnotation(JobWorker.class)
+        || beanInfo.hasMethodAnnotation(ZeebeWorker.class);
   }
 
   @Override
@@ -55,11 +54,17 @@ public class ZeebeWorkerAnnotationProcessor extends AbstractZeebeAnnotationProce
     List<ZeebeWorkerValue> newZeebeWorkerValues = new ArrayList<>();
 
     doWithMethods(
-      beanInfo.getTargetClass(),
-      method -> readJobWorkerAnnotationForMethod(beanInfo.toMethodInfo(method)).ifPresent(newZeebeWorkerValues::add),
-      ReflectionUtils.USER_DECLARED_METHODS);
+        beanInfo.getTargetClass(),
+        method ->
+            readJobWorkerAnnotationForMethod(beanInfo.toMethodInfo(method))
+                .ifPresent(newZeebeWorkerValues::add),
+        ReflectionUtils.USER_DECLARED_METHODS);
 
-    LOGGER.info("Configuring {} Zeebe worker(s) of bean '{}': {}", newZeebeWorkerValues.size(), beanInfo.getBeanName(), newZeebeWorkerValues);
+    LOGGER.info(
+        "Configuring {} Zeebe worker(s) of bean '{}': {}",
+        newZeebeWorkerValues.size(),
+        beanInfo.getBeanName(),
+        newZeebeWorkerValues);
     zeebeWorkerValues.addAll(newZeebeWorkerValues);
   }
 
@@ -67,38 +72,38 @@ public class ZeebeWorkerAnnotationProcessor extends AbstractZeebeAnnotationProce
     Optional<JobWorker> methodAnnotation = methodInfo.getAnnotation(JobWorker.class);
     if (methodAnnotation.isPresent()) {
       JobWorker annotation = methodAnnotation.get();
-      return Optional.of(new ZeebeWorkerValue()
-            .setMethodInfo(methodInfo)
-            .setType(annotation.type())
-            .setTimeout(annotation.timeout())
-            .setMaxJobsActive(annotation.maxJobsActive())
-            .setPollInterval(annotation.pollInterval())
-            .setAutoComplete(annotation.autoComplete())
-            .setRequestTimeout(annotation.requestTimeout())
-            .setEnabled(annotation.enabled())
-
-            // TODO Get rid of those initialize methods but add the attributes as values onto the worker and then auto-initialize stuff when opening the worker
-            .initializeName(annotation.name(), methodInfo, defaultWorkerName)
-            .initializeFetchVariables(annotation.fetchAllVariables(), annotation.fetchVariables(), methodInfo)
-            .initializeJobType(annotation.type(), methodInfo, defaultWorkerType));
+      return Optional.of(
+          new ZeebeWorkerValue(
+              annotation.type(),
+              annotation.name(),
+              annotation.timeout(),
+              annotation.maxJobsActive(),
+              annotation.requestTimeout(),
+              annotation.pollInterval(),
+              annotation.autoComplete(),
+              annotation.fetchVariables(),
+              annotation.enabled(),
+              methodInfo,
+              Arrays.asList(annotation.tenantIds()),
+              annotation.fetchAllVariables()));
     } else {
       Optional<ZeebeWorker> legacyAnnotation = methodInfo.getAnnotation(ZeebeWorker.class);
       if (legacyAnnotation.isPresent()) {
         ZeebeWorker annotation = legacyAnnotation.get();
-        return Optional.of(new ZeebeWorkerValue()
-          .setMethodInfo(methodInfo)
-          .setType(annotation.type())
-          .setTimeout(annotation.timeout())
-          .setMaxJobsActive(annotation.maxJobsActive())
-          .setPollInterval(annotation.pollInterval())
-          .setAutoComplete(annotation.autoComplete())
-          .setRequestTimeout(annotation.requestTimeout())
-          .setEnabled(annotation.enabled())
-
-          // TODO Get rid of those initialize methods but add the attributes as values onto the worker and then auto-initialize stuff when opening the worker
-          .initializeName(annotation.name(), methodInfo, defaultWorkerName)
-          .initializeFetchVariables(annotation.forceFetchAllVariables(), annotation.fetchVariables(), methodInfo)
-          .initializeJobType(annotation.type(), methodInfo, defaultWorkerType));
+        return Optional.of(
+            new ZeebeWorkerValue(
+                annotation.type(),
+                annotation.name(),
+                annotation.timeout(),
+                annotation.maxJobsActive(),
+                annotation.requestTimeout(),
+                annotation.pollInterval(),
+                annotation.autoComplete(),
+                annotation.fetchVariables(),
+                annotation.enabled(),
+                methodInfo,
+                Arrays.asList(annotation.tenantIds()),
+                annotation.forceFetchAllVariables()));
       }
     }
     return Optional.empty();
@@ -106,19 +111,20 @@ public class ZeebeWorkerAnnotationProcessor extends AbstractZeebeAnnotationProce
 
   @Override
   public void start(ZeebeClient client) {
-    zeebeWorkerValues
-      .stream()
-      .peek(zeebeWorkerValue -> zeebeWorkerValueCustomizers.forEach(customizer -> customizer.customize(zeebeWorkerValue)))
-      .filter(ZeebeWorkerValue::getEnabled)
-      .forEach(
-        zeebeWorkerValue -> {
-          jobWorkerManager.openWorker(client, zeebeWorkerValue);
-        });
+    zeebeWorkerValues.stream()
+        .peek(
+            zeebeWorkerValue ->
+                zeebeWorkerValueCustomizers.forEach(
+                    customizer -> customizer.customize(zeebeWorkerValue)))
+        .filter(ZeebeWorkerValue::getEnabled)
+        .forEach(
+            zeebeWorkerValue -> {
+              jobWorkerManager.openWorker(client, zeebeWorkerValue);
+            });
   }
 
   @Override
   public void stop(ZeebeClient zeebeClient) {
     jobWorkerManager.closeAllOpenWorkers();
   }
-
 }

--- a/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/annotation/value/ZeebeAnnotationValue.java
+++ b/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/annotation/value/ZeebeAnnotationValue.java
@@ -6,7 +6,7 @@ import io.camunda.zeebe.spring.client.bean.BeanInfo;
  * Common type for all annotation values.
  *
  * @param <B> either {@link io.camunda.zeebe.spring.client.bean.ClassInfo} or {@link
- * io.camunda.zeebe.spring.client.bean.MethodInfo}.
+ *     io.camunda.zeebe.spring.client.bean.MethodInfo}.
  */
 public interface ZeebeAnnotationValue<B extends BeanInfo> {
 

--- a/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/annotation/value/ZeebeDeploymentValue.java
+++ b/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/annotation/value/ZeebeDeploymentValue.java
@@ -29,8 +29,7 @@ public class ZeebeDeploymentValue implements ZeebeAnnotationValue<ClassInfo> {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     ZeebeDeploymentValue that = (ZeebeDeploymentValue) o;
-    return Objects.equals(resources, that.resources) &&
-      Objects.equals(beanInfo, that.beanInfo);
+    return Objects.equals(resources, that.resources) && Objects.equals(beanInfo, that.beanInfo);
   }
 
   @Override
@@ -40,10 +39,7 @@ public class ZeebeDeploymentValue implements ZeebeAnnotationValue<ClassInfo> {
 
   @Override
   public String toString() {
-    return "ZeebeDeploymentValue{" +
-      "resources=" + resources +
-      ", beanInfo=" + beanInfo +
-      '}';
+    return "ZeebeDeploymentValue{" + "resources=" + resources + ", beanInfo=" + beanInfo + '}';
   }
 
   public static ZeebeDeploymentValueBuilder builder() {
@@ -55,8 +51,7 @@ public class ZeebeDeploymentValue implements ZeebeAnnotationValue<ClassInfo> {
     private List<String> resources;
     private ClassInfo beanInfo;
 
-    private ZeebeDeploymentValueBuilder() {
-    }
+    private ZeebeDeploymentValueBuilder() {}
 
     public ZeebeDeploymentValueBuilder resources(List<String> resources) {
       this.resources = resources;

--- a/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/annotation/value/ZeebeWorkerValue.java
+++ b/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/annotation/value/ZeebeWorkerValue.java
@@ -1,22 +1,12 @@
 package io.camunda.zeebe.spring.client.annotation.value;
 
-import io.camunda.zeebe.spring.client.annotation.Variable;
-import io.camunda.zeebe.spring.client.annotation.ZeebeVariable;
-import io.camunda.zeebe.spring.client.bean.CopyNotNullBeanUtilsBean;
 import io.camunda.zeebe.spring.client.bean.MethodInfo;
-import io.camunda.zeebe.spring.client.bean.ParameterInfo;
-
-import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 public class ZeebeWorkerValue implements ZeebeAnnotationValue<MethodInfo> {
 
-  private static final CopyNotNullBeanUtilsBean BEAN_UTILS_BEAN = new CopyNotNullBeanUtilsBean();
   private String type;
 
   private String name;
@@ -36,22 +26,24 @@ public class ZeebeWorkerValue implements ZeebeAnnotationValue<MethodInfo> {
   private Boolean enabled;
 
   private MethodInfo methodInfo;
+  private List<String> tenantIds;
+  private boolean forceFetchAllVariables;
 
-  public ZeebeWorkerValue() {
-  }
+  public ZeebeWorkerValue() {}
 
-  private ZeebeWorkerValue(String type,
-                           String name,
-                           long timeout,
-                           int maxJobsActive,
-                           long requestTimeout,
-                           long pollInterval,
-                           String[] fetchVariables,
-                           boolean forceFetchAllVariables,
-                           List<ParameterInfo> variableParameters,
-                           boolean autoComplete,
-                           MethodInfo methodInfo,
-                           final boolean enabled) {
+  public ZeebeWorkerValue(
+      String type,
+      String name,
+      Long timeout,
+      Integer maxJobsActive,
+      Long requestTimeout,
+      Long pollInterval,
+      Boolean autoComplete,
+      String[] fetchVariables,
+      Boolean enabled,
+      MethodInfo methodInfo,
+      List<String> tenantIds,
+      boolean forceFetchAllVariables) {
     this.type = type;
     this.name = name;
     this.timeout = timeout;
@@ -59,132 +51,144 @@ public class ZeebeWorkerValue implements ZeebeAnnotationValue<MethodInfo> {
     this.requestTimeout = requestTimeout;
     this.pollInterval = pollInterval;
     this.autoComplete = autoComplete;
-    this.methodInfo = methodInfo;
+    this.fetchVariables = fetchVariables;
     this.enabled = enabled;
+    this.methodInfo = methodInfo;
+    this.tenantIds = tenantIds;
+    this.forceFetchAllVariables = forceFetchAllVariables;
   }
 
   public String getType() {
     return type;
   }
 
+  public void setType(String type) {
+    this.type = type;
+  }
+
   public String getName() {
     return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
   }
 
   public Long getTimeout() {
     return timeout;
   }
 
+  public void setTimeout(Long timeout) {
+    this.timeout = timeout;
+  }
+
   public Integer getMaxJobsActive() {
     return maxJobsActive;
+  }
+
+  public void setMaxJobsActive(Integer maxJobsActive) {
+    this.maxJobsActive = maxJobsActive;
   }
 
   public Long getRequestTimeout() {
     return requestTimeout;
   }
 
+  public void setRequestTimeout(Long requestTimeout) {
+    this.requestTimeout = requestTimeout;
+  }
+
   public Long getPollInterval() {
     return pollInterval;
   }
 
-  public String[] getFetchVariables() {
-    return fetchVariables;
+  public void setPollInterval(Long pollInterval) {
+    this.pollInterval = pollInterval;
   }
 
   public Boolean getAutoComplete() {
     return autoComplete;
   }
 
-  public MethodInfo getMethodInfo() {
-    return methodInfo;
+  public void setAutoComplete(Boolean autoComplete) {
+    this.autoComplete = autoComplete;
   }
 
-  @Override
-  public MethodInfo getBeanInfo() {
-    return getMethodInfo();
+  public String[] getFetchVariables() {
+    return fetchVariables;
+  }
+
+  public void setFetchVariables(String[] fetchVariables) {
+    this.fetchVariables = fetchVariables;
   }
 
   public Boolean getEnabled() {
     return enabled;
   }
 
-  public ZeebeWorkerValue setEnabled(Boolean enabled) {
+  public void setEnabled(Boolean enabled) {
     this.enabled = enabled;
-    return this;
   }
 
-  public ZeebeWorkerValue setType(String type) {
-    this.type = type;
-    // You can only set a type of a worker - in this case the name is set equals to the type
-    if (name==null) {
-      setName(type);
-    }
-    return this;
+  public MethodInfo getMethodInfo() {
+    return methodInfo;
   }
 
-  public ZeebeWorkerValue setName(String name) {
-    this.name = name;
-    return this;
-  }
-
-  public ZeebeWorkerValue setTimeout(Long timeout) {
-    this.timeout = timeout;
-    return this;
-  }
-
-  public ZeebeWorkerValue setMaxJobsActive(Integer maxJobsActive) {
-    this.maxJobsActive = maxJobsActive;
-    return this;
-  }
-
-  public ZeebeWorkerValue setRequestTimeout(Long requestTimeout) {
-    this.requestTimeout = requestTimeout;
-    return this;
-  }
-
-  public ZeebeWorkerValue setPollInterval(Long pollInterval) {
-    this.pollInterval = pollInterval;
-    return this;
-  }
-
-  public ZeebeWorkerValue setAutoComplete(Boolean autoComplete) {
-    this.autoComplete = autoComplete;
-    return this;
-  }
-
-  public ZeebeWorkerValue setFetchVariables(String[] fetchVariables) {
-    this.fetchVariables = fetchVariables;
-    return this;
-  }
-
-  public ZeebeWorkerValue setMethodInfo(MethodInfo methodInfo) {
+  public void setMethodInfo(MethodInfo methodInfo) {
     this.methodInfo = methodInfo;
-    return this;
   }
 
-  public ZeebeWorkerValue merge(ZeebeWorkerValue other) {
-    try {
-      BEAN_UTILS_BEAN.copyProperties(this, other);
-    } catch (IllegalAccessException | InvocationTargetException e) {
-      throw new RuntimeException(e);
-    }
-    return this;
+  public List<String> getTenantIds() {
+    return tenantIds;
+  }
+
+  public void setTenantIds(List<String> tenantIds) {
+    this.tenantIds = tenantIds;
+  }
+
+  public boolean isForceFetchAllVariables() {
+    return forceFetchAllVariables;
+  }
+
+  public void setForceFetchAllVariables(boolean forceFetchAllVariables) {
+    this.forceFetchAllVariables = forceFetchAllVariables;
+  }
+
+  @Override
+  public MethodInfo getBeanInfo() {
+    return methodInfo;
   }
 
   @Override
   public String toString() {
-    return "ZeebeWorkerValue{" +
-      "type='" + type + '\'' +
-      ", name='" + name + '\'' +
-      ", timeout=" + timeout +
-      ", maxJobsActive=" + maxJobsActive +
-      ", requestTimeout=" + requestTimeout +
-      ", pollInterval=" + pollInterval +
-      ", autoComplete=" + autoComplete +
-      ", fetchVariables=" + Arrays.toString(fetchVariables) +
-      ", enabled=" + enabled +
-      ", methodInfo=" + methodInfo +
-      '}';
+    return "ZeebeWorkerValue{"
+        + "type='"
+        + type
+        + '\''
+        + ", name='"
+        + name
+        + '\''
+        + ", timeout="
+        + timeout
+        + ", maxJobsActive="
+        + maxJobsActive
+        + ", requestTimeout="
+        + requestTimeout
+        + ", pollInterval="
+        + pollInterval
+        + ", autoComplete="
+        + autoComplete
+        + ", fetchVariables="
+        + Arrays.toString(fetchVariables)
+        + ", enabled="
+        + enabled
+        + ", methodInfo="
+        + methodInfo
+        + ", tenantIds="
+        + tenantIds
+        + ", forceFetchAllVariables="
+        + forceFetchAllVariables
+        + '}';
   }
 
   @Override
@@ -192,69 +196,36 @@ public class ZeebeWorkerValue implements ZeebeAnnotationValue<MethodInfo> {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     ZeebeWorkerValue that = (ZeebeWorkerValue) o;
-    return Objects.equals(type, that.type) &&
-      Objects.equals(name, that.name) &&
-      Objects.equals(timeout, that.timeout) &&
-      Objects.equals(maxJobsActive, that.maxJobsActive) &&
-      Objects.equals(requestTimeout, that.requestTimeout) &&
-      Objects.equals(pollInterval, that.pollInterval) &&
-      Objects.equals(autoComplete, that.autoComplete) &&
-      Arrays.equals(fetchVariables, that.fetchVariables) &&
-      Objects.equals(enabled, that.enabled) &&
-      Objects.equals(methodInfo, that.methodInfo);
+    return forceFetchAllVariables == that.forceFetchAllVariables
+        && Objects.equals(type, that.type)
+        && Objects.equals(name, that.name)
+        && Objects.equals(timeout, that.timeout)
+        && Objects.equals(maxJobsActive, that.maxJobsActive)
+        && Objects.equals(requestTimeout, that.requestTimeout)
+        && Objects.equals(pollInterval, that.pollInterval)
+        && Objects.equals(autoComplete, that.autoComplete)
+        && Arrays.equals(fetchVariables, that.fetchVariables)
+        && Objects.equals(enabled, that.enabled)
+        && Objects.equals(methodInfo, that.methodInfo)
+        && Objects.equals(tenantIds, that.tenantIds);
   }
 
   @Override
   public int hashCode() {
-    int result = Objects.hash(type, name, timeout, maxJobsActive, requestTimeout, pollInterval, autoComplete, enabled, methodInfo);
+    int result =
+        Objects.hash(
+            type,
+            name,
+            timeout,
+            maxJobsActive,
+            requestTimeout,
+            pollInterval,
+            autoComplete,
+            enabled,
+            methodInfo,
+            tenantIds,
+            forceFetchAllVariables);
     result = 31 * result + Arrays.hashCode(fetchVariables);
     return result;
-  }
-
-  // TODO Get rid of those initialize methods but add the attributes as values onto the worker and then auto-initialize stuff when opening the worker maybe via one method
-  public ZeebeWorkerValue initializeName(String name, MethodInfo methodInfo, String defaultJobWorkerName) {
-    // Set name only if configured (default from Java Client library is used only if null - not if empty string)
-    if (name != null && name.length() > 0) {
-      this.name = name;
-    } else if (null != defaultJobWorkerName) {
-      // otherwise, default name from Spring config if set ([would be done automatically anyway])
-      this.name = defaultJobWorkerName;
-    } else {
-      // otherwise, bean/method name combo
-      this.name = methodInfo.getBeanName() + "#" + methodInfo.getMethodName();
-    }
-    return this;
-  }
-
-  public ZeebeWorkerValue initializeFetchVariables(boolean forceFetchAllVariables, String[] fetchVariables, MethodInfo methodInfo) {
-    if (forceFetchAllVariables) {
-      // this overwrites any other setting
-      setFetchVariables(new String[0]);
-    } else {
-      // make sure variables configured and annotated parameters are both fetched, use a set to avoid duplicates
-      Set<String> variables = new HashSet<>();
-      variables.addAll(Arrays.asList(fetchVariables));
-      variables.addAll(readZeebeVariableParameters(methodInfo).stream().map(ParameterInfo::getParameterName).collect(Collectors.toList()));
-      setFetchVariables(variables.toArray(new String[0]));
-    }
-    return this;
-  }
-
-  private List<ParameterInfo> readZeebeVariableParameters(MethodInfo methodInfo) {
-    List<ParameterInfo> result = methodInfo.getParametersFilteredByAnnotation(Variable.class);
-    result.addAll(methodInfo.getParametersFilteredByAnnotation(ZeebeVariable.class));
-    return result;
-  }
-
-  public ZeebeWorkerValue initializeJobType(String jobType, MethodInfo methodInfo, String defaultWorkerType) {
-    if (jobType!=null && jobType.length() > 0) {
-      setType(jobType);
-    } else if (defaultWorkerType!=null) {
-      setType(defaultWorkerType);
-    } else {
-      setType( methodInfo.getMethodName() );
-    }
-
-    return this;
   }
 }

--- a/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/bean/BeanInfo.java
+++ b/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/bean/BeanInfo.java
@@ -27,6 +27,6 @@ public interface BeanInfo {
 
   default boolean hasMethodAnnotation(final Class<? extends Annotation> type) {
     return Stream.of(getAllDeclaredMethods(getTargetClass()))
-      .anyMatch(m -> m.isAnnotationPresent(type));
+        .anyMatch(m -> m.isAnnotationPresent(type));
   }
 }

--- a/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/bean/ClassInfo.java
+++ b/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/bean/ClassInfo.java
@@ -43,8 +43,7 @@ public class ClassInfo implements BeanInfo {
     private Object bean;
     private String beanName;
 
-    public ClassInfoBuilder() {
-    }
+    public ClassInfoBuilder() {}
 
     public ClassInfoBuilder bean(Object bean) {
       this.bean = bean;

--- a/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/bean/CopyNotNullBeanUtilsBean.java
+++ b/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/bean/CopyNotNullBeanUtilsBean.java
@@ -1,13 +1,13 @@
 package io.camunda.zeebe.spring.client.bean;
 
-import org.apache.commons.beanutils.BeanUtilsBean;
-
 import java.lang.reflect.InvocationTargetException;
+import org.apache.commons.beanutils.BeanUtilsBean;
 
 public class CopyNotNullBeanUtilsBean extends BeanUtilsBean {
 
   @Override
-  public void copyProperty(Object bean, String name, Object value) throws IllegalAccessException, InvocationTargetException {
+  public void copyProperty(Object bean, String name, Object value)
+      throws IllegalAccessException, InvocationTargetException {
     if (value != null) {
       super.copyProperty(bean, name, value);
     }

--- a/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/bean/MethodInfo.java
+++ b/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/bean/MethodInfo.java
@@ -1,6 +1,6 @@
 package io.camunda.zeebe.spring.client.bean;
 
-import org.springframework.core.StandardReflectionParameterNameDiscoverer;
+import static org.springframework.core.annotation.AnnotationUtils.findAnnotation;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
@@ -9,12 +9,12 @@ import java.lang.reflect.Parameter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-
-import static org.springframework.core.annotation.AnnotationUtils.findAnnotation;
+import org.springframework.core.StandardReflectionParameterNameDiscoverer;
 
 public class MethodInfo implements BeanInfo {
 
-  private static final StandardReflectionParameterNameDiscoverer parameterNameDiscoverer = new StandardReflectionParameterNameDiscoverer();
+  private static final StandardReflectionParameterNameDiscoverer parameterNameDiscoverer =
+      new StandardReflectionParameterNameDiscoverer();
 
   protected ClassInfo classInfo;
   protected Method method;
@@ -50,8 +50,7 @@ public class MethodInfo implements BeanInfo {
       final Throwable targetException = e.getTargetException();
       if (targetException instanceof Exception) {
         throw (Exception) targetException;
-      }
-      else {
+      } else {
         throw new RuntimeException("Failed to invoke method: " + method.getName(), targetException);
       }
     } catch (IllegalAccessException e) {
@@ -96,8 +95,7 @@ public class MethodInfo implements BeanInfo {
     private ClassInfo classInfo;
     private Method method;
 
-    private MethodInfoBuilder() {
-    }
+    private MethodInfoBuilder() {}
 
     public MethodInfoBuilder classInfo(ClassInfo classInfo) {
       this.classInfo = classInfo;

--- a/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/bean/ParameterInfo.java
+++ b/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/bean/ParameterInfo.java
@@ -9,7 +9,7 @@ public class ParameterInfo {
   private Parameter parameterInfo;
 
   public ParameterInfo(Parameter param, String paramName) {
-    if (paramName==null) {
+    if (paramName == null) {
       parameterName = param.getName();
     } else {
       this.parameterName = paramName;
@@ -24,5 +24,4 @@ public class ParameterInfo {
   public String getParameterName() {
     return parameterName;
   }
-
 }

--- a/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/event/ClientStartedEvent.java
+++ b/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/event/ClientStartedEvent.java
@@ -1,6 +1,4 @@
 package io.camunda.zeebe.spring.client.event;
 
 @Deprecated
-public class ClientStartedEvent {
-
-}
+public class ClientStartedEvent {}

--- a/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/event/ClientStoppedEvent.java
+++ b/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/event/ClientStoppedEvent.java
@@ -1,6 +1,4 @@
 package io.camunda.zeebe.spring.client.event;
 
 @Deprecated
-public class ClientStoppedEvent {
-
-}
+public class ClientStoppedEvent {}

--- a/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/event/ZeebeClientClosingEvent.java
+++ b/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/event/ZeebeClientClosingEvent.java
@@ -4,9 +4,9 @@ import io.camunda.zeebe.client.ZeebeClient;
 import org.springframework.context.ApplicationEvent;
 
 /**
- * Emitted when the ZeebeClient is about to close. Typically, during application shutdown,
- * but maybe more often in test case or never if the ZeebeClient is disabled, see
- * {@link ZeebeClientCreatedEvent} for more details
+ * Emitted when the ZeebeClient is about to close. Typically, during application shutdown, but maybe
+ * more often in test case or never if the ZeebeClient is disabled, see {@link
+ * ZeebeClientCreatedEvent} for more details
  */
 public class ZeebeClientClosingEvent extends ApplicationEvent {
 

--- a/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/event/ZeebeClientCreatedEvent.java
+++ b/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/event/ZeebeClientCreatedEvent.java
@@ -4,14 +4,16 @@ import io.camunda.zeebe.client.ZeebeClient;
 import org.springframework.context.ApplicationEvent;
 
 /**
- * Event which is triggered when the ZeebeClient was created.
- * This can be used to register further work that should be done, like starting job workers or doing deployments.
+ * Event which is triggered when the ZeebeClient was created. This can be used to register further
+ * work that should be done, like starting job workers or doing deployments.
  *
- * In a normal production application this event is simply fired once during startup when the ZeebeClient is created and thus ready to use.
- * However, in test cases it might be fired multiple times, as every test case gets its own dedicated engine also leading to new ZeebeClients being created
- * (at least logically, as the ZeebeClient Spring bean might simply be a proxy always pointing to the right client automatically to avoid problems with @Autowire).
+ * <p>In a normal production application this event is simply fired once during startup when the
+ * ZeebeClient is created and thus ready to use. However, in test cases it might be fired multiple
+ * times, as every test case gets its own dedicated engine also leading to new ZeebeClients being
+ * created (at least logically, as the ZeebeClient Spring bean might simply be a proxy always
+ * pointing to the right client automatically to avoid problems with @Autowire).
  *
- * Furthermore, when `zeebe.client.enabled=false`, the event might not be fired ever
+ * <p>Furthermore, when `zeebe.client.enabled=false`, the event might not be fired ever
  */
 public class ZeebeClientCreatedEvent extends ApplicationEvent {
 

--- a/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/exception/ZeebeBpmnError.java
+++ b/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/exception/ZeebeBpmnError.java
@@ -3,8 +3,8 @@ package io.camunda.zeebe.spring.client.exception;
 import java.util.Map;
 
 /**
- * Indicates an error in sense of BPMN occured, that should be handled by the BPMN process,
- * see https://docs.camunda.io/docs/reference/bpmn-processes/error-events/error-events/
+ * Indicates an error in sense of BPMN occured, that should be handled by the BPMN process, see
+ * https://docs.camunda.io/docs/reference/bpmn-processes/error-events/error-events/
  */
 public class ZeebeBpmnError extends RuntimeException {
 

--- a/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/jobhandling/CommandExceptionHandlingStrategy.java
+++ b/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/jobhandling/CommandExceptionHandlingStrategy.java
@@ -3,5 +3,4 @@ package io.camunda.zeebe.spring.client.jobhandling;
 public interface CommandExceptionHandlingStrategy {
 
   public void handleCommandError(CommandWrapper command, Throwable throwable);
-
 }

--- a/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/jobhandling/DefaultCommandExceptionHandlingStrategy.java
+++ b/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/jobhandling/DefaultCommandExceptionHandlingStrategy.java
@@ -3,56 +3,62 @@ package io.camunda.zeebe.spring.client.jobhandling;
 import io.camunda.zeebe.client.api.worker.BackoffSupplier;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.lang.invoke.MethodHandles;
 import java.util.EnumSet;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DefaultCommandExceptionHandlingStrategy implements CommandExceptionHandlingStrategy {
 
   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  public static final Set<Status.Code> SUCCESS_CODES = EnumSet.of(
-    Status.Code.OK,
-    Status.Code.ALREADY_EXISTS);
-  public static final Set<Status.Code> RETRIABLE_CODES = EnumSet.of(
-    Status.Code.CANCELLED,
-    Status.Code.DEADLINE_EXCEEDED,
-    Status.Code.RESOURCE_EXHAUSTED,
-    Status.Code.ABORTED,
-    Status.Code.UNAVAILABLE,
-    Status.Code.DATA_LOSS);
-  public static final Set<Status.Code> IGNORABLE_FAILURE_CODES = EnumSet.of(
-    Status.Code.NOT_FOUND);
-  public static final Set<Status.Code> FAILURE_CODES = EnumSet.of(
-    Status.Code.INVALID_ARGUMENT,
-    Status.Code.PERMISSION_DENIED,
-    Status.Code.FAILED_PRECONDITION,
-    Status.Code.OUT_OF_RANGE,
-    Status.Code.UNIMPLEMENTED,
-    Status.Code.INTERNAL,
-    Status.Code.UNAUTHENTICATED);
+  public static final Set<Status.Code> SUCCESS_CODES =
+      EnumSet.of(Status.Code.OK, Status.Code.ALREADY_EXISTS);
+  public static final Set<Status.Code> RETRIABLE_CODES =
+      EnumSet.of(
+          Status.Code.CANCELLED,
+          Status.Code.DEADLINE_EXCEEDED,
+          Status.Code.RESOURCE_EXHAUSTED,
+          Status.Code.ABORTED,
+          Status.Code.UNAVAILABLE,
+          Status.Code.DATA_LOSS);
+  public static final Set<Status.Code> IGNORABLE_FAILURE_CODES = EnumSet.of(Status.Code.NOT_FOUND);
+  public static final Set<Status.Code> FAILURE_CODES =
+      EnumSet.of(
+          Status.Code.INVALID_ARGUMENT,
+          Status.Code.PERMISSION_DENIED,
+          Status.Code.FAILED_PRECONDITION,
+          Status.Code.OUT_OF_RANGE,
+          Status.Code.UNIMPLEMENTED,
+          Status.Code.INTERNAL,
+          Status.Code.UNAUTHENTICATED);
 
   private BackoffSupplier backoffSupplier;
   private ScheduledExecutorService scheduledExecutorService;
 
-  public DefaultCommandExceptionHandlingStrategy(BackoffSupplier backoffSupplier, ScheduledExecutorService scheduledExecutorService) {
+  public DefaultCommandExceptionHandlingStrategy(
+      BackoffSupplier backoffSupplier, ScheduledExecutorService scheduledExecutorService) {
     this.backoffSupplier = backoffSupplier;
     this.scheduledExecutorService = scheduledExecutorService;
   }
 
   public void handleCommandError(CommandWrapper command, Throwable throwable) {
     if (StatusRuntimeException.class.isAssignableFrom(throwable.getClass())) {
-      StatusRuntimeException exception = (StatusRuntimeException)throwable;
+      StatusRuntimeException exception = (StatusRuntimeException) throwable;
       Status.Code code = exception.getStatus().getCode();
 
       // Success codes should not lead to an exception!
-      if (IGNORABLE_FAILURE_CODES.contains( code )) {
-        LOG.warn("Ignoring the error of type '" + code + "' during "+command+". Job might have been canceled or already completed.");
-        // TODO: IS Ignorance really a good idea? Think of some local transaction that might need to be marked for rollback! But for sure, retry does not help at all
+      if (IGNORABLE_FAILURE_CODES.contains(code)) {
+        LOG.warn(
+            "Ignoring the error of type '"
+                + code
+                + "' during "
+                + command
+                + ". Job might have been canceled or already completed.");
+        // TODO: IS Ignorance really a good idea? Think of some local transaction that might need to
+        // be marked for rollback! But for sure, retry does not help at all
         return;
       } else if (RETRIABLE_CODES.contains(code)) {
         if (command.hasMoreRetries()) {
@@ -61,14 +67,22 @@ public class DefaultCommandExceptionHandlingStrategy implements CommandException
           command.scheduleExecutionUsing(scheduledExecutorService);
           return;
         } else {
-          throw new RuntimeException("Could not execute " + command + " due to error of type '" + code + "' and no retries are left", throwable);
+          throw new RuntimeException(
+              "Could not execute "
+                  + command
+                  + " due to error of type '"
+                  + code
+                  + "' and no retries are left",
+              throwable);
         }
       } else if (FAILURE_CODES.contains(code)) {
-        throw new RuntimeException("Could not execute " + command + " due to error of type '" + code + "'", throwable);
+        throw new RuntimeException(
+            "Could not execute " + command + " due to error of type '" + code + "'", throwable);
       }
     }
 
     // if it wasn't handled yet, throw an exception
-    throw new RuntimeException("Could not execute " + command + " due to exception: " + throwable.getMessage(), throwable);
+    throw new RuntimeException(
+        "Could not execute " + command + " due to exception: " + throwable.getMessage(), throwable);
   }
 }

--- a/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/jobhandling/JobHandlerInvokingSpringBeans.java
+++ b/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/jobhandling/JobHandlerInvokingSpringBeans.java
@@ -11,19 +11,16 @@ import io.camunda.zeebe.client.impl.Loggers;
 import io.camunda.zeebe.spring.client.annotation.*;
 import io.camunda.zeebe.spring.client.annotation.value.ZeebeWorkerValue;
 import io.camunda.zeebe.spring.client.bean.ParameterInfo;
-import io.camunda.zeebe.spring.client.metrics.MetricsRecorder;
 import io.camunda.zeebe.spring.client.exception.ZeebeBpmnError;
-import org.slf4j.Logger;
-
+import io.camunda.zeebe.spring.client.metrics.MetricsRecorder;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import org.slf4j.Logger;
 
-/**
- * Zeebe JobHandler that invokes a Spring bean
- */
+/** Zeebe JobHandler that invokes a Spring bean */
 public class JobHandlerInvokingSpringBeans implements JobHandler {
 
   private static final Logger LOG = Loggers.JOB_WORKER_LOGGER;
@@ -32,10 +29,11 @@ public class JobHandlerInvokingSpringBeans implements JobHandler {
   private final JsonMapper jsonMapper;
   private final MetricsRecorder metricsRecorder;
 
-  public JobHandlerInvokingSpringBeans(ZeebeWorkerValue workerValue,
-                                       CommandExceptionHandlingStrategy commandExceptionHandlingStrategy,
-                                       JsonMapper jsonMapper,
-                                       MetricsRecorder metricsRecorder) {
+  public JobHandlerInvokingSpringBeans(
+      ZeebeWorkerValue workerValue,
+      CommandExceptionHandlingStrategy commandExceptionHandlingStrategy,
+      JsonMapper jsonMapper,
+      MetricsRecorder metricsRecorder) {
     this.workerValue = workerValue;
     this.commandExceptionHandlingStrategy = commandExceptionHandlingStrategy;
     this.jsonMapper = jsonMapper;
@@ -44,16 +42,20 @@ public class JobHandlerInvokingSpringBeans implements JobHandler {
 
   @Override
   public void handle(JobClient jobClient, ActivatedJob job) throws Exception {
-    // TODO: Figuring out parameters and assignments could probably also done only once in the beginning to save some computing time on each invocation
-    List<Object> args = createParameters(jobClient, job, workerValue.getMethodInfo().getParameters());
+    // TODO: Figuring out parameters and assignments could probably also done only once in the
+    // beginning to save some computing time on each invocation
+    List<Object> args =
+        createParameters(jobClient, job, workerValue.getMethodInfo().getParameters());
     LOG.trace("Handle {} and invoke worker {}", job, workerValue);
     try {
-      metricsRecorder.increase(MetricsRecorder.METRIC_NAME_JOB, MetricsRecorder.ACTION_ACTIVATED, job.getType());
+      metricsRecorder.increase(
+          MetricsRecorder.METRIC_NAME_JOB, MetricsRecorder.ACTION_ACTIVATED, job.getType());
       Object result = null;
       try {
         result = workerValue.getMethodInfo().invoke(args.toArray());
       } catch (Throwable t) {
-        metricsRecorder.increase(MetricsRecorder.METRIC_NAME_JOB, MetricsRecorder.ACTION_FAILED, job.getType());
+        metricsRecorder.increase(
+            MetricsRecorder.METRIC_NAME_JOB, MetricsRecorder.ACTION_FAILED, job.getType());
         // normal exceptions are handled by JobRunnableFactory
         // (https://github.com/camunda-cloud/zeebe/blob/develop/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobRunnableFactory.java#L45)
         // which leads to retrying
@@ -62,28 +64,34 @@ public class JobHandlerInvokingSpringBeans implements JobHandler {
 
       if (workerValue.getAutoComplete()) {
         LOG.trace("Auto completing {}", job);
-        // TODO: We should probably move the metrics recording to the callback of a successful command execution to avoid wrong counts
-        metricsRecorder.increase(MetricsRecorder.METRIC_NAME_JOB, MetricsRecorder.ACTION_COMPLETED, job.getType());
-        CommandWrapper command = new CommandWrapper(
-          createCompleteCommand(jobClient, job, result),
-          job,
-          commandExceptionHandlingStrategy);
+        // TODO: We should probably move the metrics recording to the callback of a successful
+        // command execution to avoid wrong counts
+        metricsRecorder.increase(
+            MetricsRecorder.METRIC_NAME_JOB, MetricsRecorder.ACTION_COMPLETED, job.getType());
+        CommandWrapper command =
+            new CommandWrapper(
+                createCompleteCommand(jobClient, job, result),
+                job,
+                commandExceptionHandlingStrategy);
         command.executeAsync();
       }
-    }
-    catch (ZeebeBpmnError bpmnError) {
+    } catch (ZeebeBpmnError bpmnError) {
       LOG.trace("Catched BPMN error on {}", job);
-      // TODO: We should probably move the metrics recording to the callback of a successful command execution to avoid wrong counts
-      metricsRecorder.increase(MetricsRecorder.METRIC_NAME_JOB, MetricsRecorder.ACTION_BPMN_ERROR, job.getType());
-      CommandWrapper command = new CommandWrapper(
-        createThrowErrorCommand(jobClient, job, bpmnError),
-        job,
-        commandExceptionHandlingStrategy);
+      // TODO: We should probably move the metrics recording to the callback of a successful command
+      // execution to avoid wrong counts
+      metricsRecorder.increase(
+          MetricsRecorder.METRIC_NAME_JOB, MetricsRecorder.ACTION_BPMN_ERROR, job.getType());
+      CommandWrapper command =
+          new CommandWrapper(
+              createThrowErrorCommand(jobClient, job, bpmnError),
+              job,
+              commandExceptionHandlingStrategy);
       command.executeAsync();
     }
   }
 
-  private List<Object> createParameters(JobClient jobClient, ActivatedJob job, List<ParameterInfo> parameters) {
+  private List<Object> createParameters(
+      JobClient jobClient, ActivatedJob job, List<ParameterInfo> parameters) {
     List<Object> args = new ArrayList<>();
     for (ParameterInfo param : parameters) {
       Object arg = null; // parameter default null
@@ -93,26 +101,48 @@ public class JobHandlerInvokingSpringBeans implements JobHandler {
         arg = jobClient;
       } else if (ActivatedJob.class.isAssignableFrom(clazz)) {
         arg = job;
-      } else if (param.getParameterInfo().isAnnotationPresent(Variable.class) || param.getParameterInfo().isAnnotationPresent(ZeebeVariable.class)) {
+      } else if (param.getParameterInfo().isAnnotationPresent(Variable.class)
+          || param.getParameterInfo().isAnnotationPresent(ZeebeVariable.class)) {
         String paramName = getVariableName(param);
         Object variableValue = job.getVariablesAsMap().get(paramName);
         try {
           arg = mapZeebeVariable(variableValue, param.getParameterInfo().getType());
+        } catch (ClassCastException | IllegalArgumentException ex) {
+          throw new RuntimeException(
+              "Cannot assign process variable '"
+                  + paramName
+                  + "' to parameter when executing job '"
+                  + job.getType()
+                  + "', invalid type found: "
+                  + ex.getMessage());
         }
-        catch (ClassCastException | IllegalArgumentException ex) {
-          throw new RuntimeException("Cannot assign process variable '" + paramName + "' to parameter when executing job '"+job.getType()+"', invalid type found: " + ex.getMessage());
-        }
-      } else if (param.getParameterInfo().isAnnotationPresent(VariablesAsType.class) || param.getParameterInfo().isAnnotationPresent(ZeebeVariablesAsType.class)) {
+      } else if (param.getParameterInfo().isAnnotationPresent(VariablesAsType.class)
+          || param.getParameterInfo().isAnnotationPresent(ZeebeVariablesAsType.class)) {
         try {
           arg = job.getVariablesAsType(clazz);
         } catch (RuntimeException e) {
-          throw new RuntimeException("Cannot assign process variables to type '" + clazz.getName() + "' when executing job '"+job.getType()+"', cause is: " + e.getMessage(), e);
+          throw new RuntimeException(
+              "Cannot assign process variables to type '"
+                  + clazz.getName()
+                  + "' when executing job '"
+                  + job.getType()
+                  + "', cause is: "
+                  + e.getMessage(),
+              e);
         }
-      } else if (param.getParameterInfo().isAnnotationPresent(CustomHeaders.class) || param.getParameterInfo().isAnnotationPresent(ZeebeCustomHeaders.class)) {
+      } else if (param.getParameterInfo().isAnnotationPresent(CustomHeaders.class)
+          || param.getParameterInfo().isAnnotationPresent(ZeebeCustomHeaders.class)) {
         try {
           arg = job.getCustomHeaders();
         } catch (RuntimeException e) {
-          throw new RuntimeException("Cannot assign headers '" + param.getParameterName() + "' to parameter when executing job '"+job.getType()+"', cause is: " + e.getMessage(), e);
+          throw new RuntimeException(
+              "Cannot assign headers '"
+                  + param.getParameterName()
+                  + "' to parameter when executing job '"
+                  + job.getType()
+                  + "', cause is: "
+                  + e.getMessage(),
+              e);
         }
       }
       args.add(arg);
@@ -137,15 +167,16 @@ public class JobHandlerInvokingSpringBeans implements JobHandler {
     return param.getParameterName();
   }
 
-  public static FinalCommandStep createCompleteCommand(JobClient jobClient, ActivatedJob job, Object result) {
+  public static FinalCommandStep createCompleteCommand(
+      JobClient jobClient, ActivatedJob job, Object result) {
     CompleteJobCommandStep1 completeCommand = jobClient.newCompleteCommand(job.getKey());
     if (result != null) {
       if (result.getClass().isAssignableFrom(Map.class)) {
         completeCommand = completeCommand.variables((Map) result);
       } else if (result.getClass().isAssignableFrom(String.class)) {
-        completeCommand = completeCommand.variables((String)result);
+        completeCommand = completeCommand.variables((String) result);
       } else if (result.getClass().isAssignableFrom(InputStream.class)) {
-        completeCommand = completeCommand.variables((InputStream)result);
+        completeCommand = completeCommand.variables((InputStream) result);
       } else {
         completeCommand = completeCommand.variables(result);
       }
@@ -153,25 +184,27 @@ public class JobHandlerInvokingSpringBeans implements JobHandler {
     return completeCommand;
   }
 
-  private FinalCommandStep<Void> createThrowErrorCommand(JobClient jobClient, ActivatedJob job, ZeebeBpmnError bpmnError) {
-    ThrowErrorCommandStep2 command = jobClient.newThrowErrorCommand(job.getKey()) // TODO: PR for taking a job only in command chain
-      .errorCode(bpmnError.getErrorCode())
-      .errorMessage(bpmnError.getErrorMessage());
-    if(bpmnError.getVariables() != null){
+  private FinalCommandStep<Void> createThrowErrorCommand(
+      JobClient jobClient, ActivatedJob job, ZeebeBpmnError bpmnError) {
+    ThrowErrorCommandStep2 command =
+        jobClient
+            .newThrowErrorCommand(job.getKey()) // TODO: PR for taking a job only in command chain
+            .errorCode(bpmnError.getErrorCode())
+            .errorMessage(bpmnError.getErrorMessage());
+    if (bpmnError.getVariables() != null) {
       command.variables(bpmnError.getVariables());
     }
     return command;
   }
 
-  private <T>T mapZeebeVariable(Object toMap, Class<T> clazz) {
+  private <T> T mapZeebeVariable(Object toMap, Class<T> clazz) {
     if (toMap != null && !clazz.isInstance(toMap)) {
-//      if (jsonMapper != null) {
-        return jsonMapper.fromJson(jsonMapper.toJson(toMap), clazz);
-//      }
-//      return DEFAULT_OBJECT_MAPPER.convertValue(toMap, clazz);
+      //      if (jsonMapper != null) {
+      return jsonMapper.fromJson(jsonMapper.toJson(toMap), clazz);
+      //      }
+      //      return DEFAULT_OBJECT_MAPPER.convertValue(toMap, clazz);
     } else {
       return clazz.cast(toMap);
     }
   }
-
 }

--- a/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/jobhandling/JobWorkerManager.java
+++ b/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/jobhandling/JobWorkerManager.java
@@ -8,30 +8,30 @@ import io.camunda.zeebe.client.api.worker.JobWorkerBuilderStep1;
 import io.camunda.zeebe.spring.client.annotation.value.ZeebeWorkerValue;
 import io.camunda.zeebe.spring.client.metrics.MetricsRecorder;
 import io.camunda.zeebe.spring.client.metrics.ZeebeClientMetricsBridge;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.lang.invoke.MethodHandles;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class JobWorkerManager {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   private final CommandExceptionHandlingStrategy commandExceptionHandlingStrategy;
   private final JsonMapper jsonMapper;
   private final MetricsRecorder metricsRecorder;
 
-
   private List<JobWorker> openedWorkers = new ArrayList<>();
   private List<ZeebeWorkerValue> workerValues = new ArrayList<>();
 
-  public JobWorkerManager(CommandExceptionHandlingStrategy commandExceptionHandlingStrategy,
-                          JsonMapper jsonMapper,
-                          MetricsRecorder metricsRecorder) {
+  public JobWorkerManager(
+      CommandExceptionHandlingStrategy commandExceptionHandlingStrategy,
+      JsonMapper jsonMapper,
+      MetricsRecorder metricsRecorder) {
     this.commandExceptionHandlingStrategy = commandExceptionHandlingStrategy;
     this.jsonMapper = jsonMapper;
     this.metricsRecorder = metricsRecorder;
@@ -39,26 +39,29 @@ public class JobWorkerManager {
 
   public JobWorker openWorker(ZeebeClient client, ZeebeWorkerValue zeebeWorkerValue) {
     return openWorker(
-      client,
-      zeebeWorkerValue,
-      new JobHandlerInvokingSpringBeans(zeebeWorkerValue, commandExceptionHandlingStrategy, jsonMapper, metricsRecorder));
+        client,
+        zeebeWorkerValue,
+        new JobHandlerInvokingSpringBeans(
+            zeebeWorkerValue, commandExceptionHandlingStrategy, jsonMapper, metricsRecorder));
   }
 
-  public JobWorker openWorker(ZeebeClient client, ZeebeWorkerValue zeebeWorkerValue, JobHandler handler) {
+  public JobWorker openWorker(
+      ZeebeClient client, ZeebeWorkerValue zeebeWorkerValue, JobHandler handler) {
 
-	// TODO: Trigger initialization of  worker values and defaults here
+    // TODO: Trigger initialization of  worker values and defaults here
 
-    final JobWorkerBuilderStep1.JobWorkerBuilderStep3 builder = client
-      .newWorker()
-      .jobType(zeebeWorkerValue.getType())
-      .handler(handler)
-      .name(zeebeWorkerValue.getName())
-      .metrics(new ZeebeClientMetricsBridge(metricsRecorder, zeebeWorkerValue.getType()));
+    final JobWorkerBuilderStep1.JobWorkerBuilderStep3 builder =
+        client
+            .newWorker()
+            .jobType(zeebeWorkerValue.getType())
+            .handler(handler)
+            .name(zeebeWorkerValue.getName())
+            .metrics(new ZeebeClientMetricsBridge(metricsRecorder, zeebeWorkerValue.getType()));
 
     if (zeebeWorkerValue.getMaxJobsActive() != null && zeebeWorkerValue.getMaxJobsActive() > 0) {
       builder.maxJobsActive(zeebeWorkerValue.getMaxJobsActive());
     }
-    if (zeebeWorkerValue.getTimeout() !=null && zeebeWorkerValue.getTimeout()  > 0) {
+    if (zeebeWorkerValue.getTimeout() != null && zeebeWorkerValue.getTimeout() > 0) {
       builder.timeout(zeebeWorkerValue.getTimeout());
     }
     if (zeebeWorkerValue.getPollInterval() != null && zeebeWorkerValue.getPollInterval() > 0) {
@@ -67,7 +70,8 @@ public class JobWorkerManager {
     if (zeebeWorkerValue.getRequestTimeout() != null && zeebeWorkerValue.getRequestTimeout() > 0) {
       builder.requestTimeout(Duration.ofSeconds(zeebeWorkerValue.getRequestTimeout()));
     }
-    if (zeebeWorkerValue.getFetchVariables() != null && zeebeWorkerValue.getFetchVariables().length > 0) {
+    if (zeebeWorkerValue.getFetchVariables() != null
+        && zeebeWorkerValue.getFetchVariables().length > 0) {
       builder.fetchVariables(zeebeWorkerValue.getFetchVariables());
     }
 
@@ -91,10 +95,10 @@ public class JobWorkerManager {
   }
 
   public Optional<ZeebeWorkerValue> findJobWorkerConfigByName(String name) {
-    return workerValues.stream().filter( worker -> worker.getName().equals(name) ).findFirst();
+    return workerValues.stream().filter(worker -> worker.getName().equals(name)).findFirst();
   }
 
   public Optional<ZeebeWorkerValue> findJobWorkerConfigByType(String type) {
-    return workerValues.stream().filter( worker -> worker.getType().equals(type) ).findFirst();
+    return workerValues.stream().filter(worker -> worker.getType().equals(type)).findFirst();
   }
 }

--- a/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/jobhandling/JobWorkerManager.java
+++ b/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/jobhandling/JobWorkerManager.java
@@ -74,6 +74,9 @@ public class JobWorkerManager {
         && zeebeWorkerValue.getFetchVariables().length > 0) {
       builder.fetchVariables(zeebeWorkerValue.getFetchVariables());
     }
+    if (zeebeWorkerValue.getTenantIds() != null && !zeebeWorkerValue.getTenantIds().isEmpty()) {
+      builder.tenantIds(zeebeWorkerValue.getTenantIds());
+    }
 
     JobWorker jobWorker = builder.open();
     openedWorkers.add(jobWorker);

--- a/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/jobhandling/ZeebeClientExecutorService.java
+++ b/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/jobhandling/ZeebeClientExecutorService.java
@@ -4,11 +4,11 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
 /**
- * Wrapper bean for {@link ScheduledExecutorService} required in Spring Zeebe for
- * Job Handling, Retry Management and so on.
+ * Wrapper bean for {@link ScheduledExecutorService} required in Spring Zeebe for Job Handling,
+ * Retry Management and so on.
  *
- * This is wrapped so you can have multiple executor services in the Spring context and
- * qualify the right one.
+ * <p>This is wrapped so you can have multiple executor services in the Spring context and qualify
+ * the right one.
  */
 public class ZeebeClientExecutorService {
 

--- a/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/metrics/DefaultNoopMetricsRecorder.java
+++ b/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/metrics/DefaultNoopMetricsRecorder.java
@@ -1,10 +1,9 @@
 package io.camunda.zeebe.spring.client.metrics;
 
 /**
- * Default implementation for MetricsRecorder
- * simply ignoring the counts.
- * Typically you will replace this by a proper Micrometer implementation
- * as you can find in the starter module (activated if Actuator is on the classpath)
+ * Default implementation for MetricsRecorder simply ignoring the counts. Typically you will replace
+ * this by a proper Micrometer implementation as you can find in the starter module (activated if
+ * Actuator is on the classpath)
  */
 public class DefaultNoopMetricsRecorder implements MetricsRecorder {
 

--- a/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/metrics/MetricsRecorder.java
+++ b/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/metrics/MetricsRecorder.java
@@ -12,8 +12,8 @@ public interface MetricsRecorder {
    * Increase the counter for the given metric name, action and type
    *
    * @param metricName - the name of the metric
-   * @param action     - event type within the metric, e.g. activated, completed, failed, bpmn-error
-   * @param type       - type of the job the metric is for
+   * @param action - event type within the metric, e.g. activated, completed, failed, bpmn-error
+   * @param type - type of the job the metric is for
    */
   default void increase(String metricName, String action, String type) {
     increase(metricName, action, type, 1);
@@ -23,18 +23,19 @@ public interface MetricsRecorder {
    * Increase the counter for the given metric name, action and type
    *
    * @param metricName - the name of the metric
-   * @param action     - event type within the metric, e.g. activated, completed, failed, bpmn-error
-   * @param type       - type of the job the metric is for
-   * @param count      - the amount to increase the metric by
+   * @param action - event type within the metric, e.g. activated, completed, failed, bpmn-error
+   * @param type - type of the job the metric is for
+   * @param count - the amount to increase the metric by
    */
   void increase(String metricName, String action, String type, int count);
 
   /**
    * Execute the given runnable and measure the execution time
+   *
    * <p>Note: the provided runnable is executed synchronously
    *
-   * @param metricName      - the name of the metric
-   * @param jobType         - type of the job the metric is for
+   * @param metricName - the name of the metric
+   * @param jobType - type of the job the metric is for
    * @param methodToExecute - the method to execute
    */
   void executeWithTimer(String metricName, String jobType, Runnable methodToExecute);

--- a/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/metrics/SimpleMetricsRecorder.java
+++ b/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/metrics/SimpleMetricsRecorder.java
@@ -3,10 +3,7 @@ package io.camunda.zeebe.spring.client.metrics;
 import java.util.HashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
-/**
- * Super simple class to record metrics in memory.
- * Typically used for test cases
- */
+/** Super simple class to record metrics in memory. Typically used for test cases */
 public class SimpleMetricsRecorder implements MetricsRecorder {
 
   public HashMap<String, AtomicLong> counters = new HashMap<>();

--- a/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/metrics/ZeebeClientMetricsBridge.java
+++ b/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/metrics/ZeebeClientMetricsBridge.java
@@ -3,8 +3,8 @@ package io.camunda.zeebe.spring.client.metrics;
 import io.camunda.zeebe.client.api.worker.JobWorkerMetrics;
 
 /**
- * Bridge between spring-zeebe metrics and zeebe-client metrics.
- * One way flow where zeebe-client metrics get propagated to MetricRecorder format in Spring.
+ * Bridge between spring-zeebe metrics and zeebe-client metrics. One way flow where zeebe-client
+ * metrics get propagated to MetricRecorder format in Spring.
  */
 public class ZeebeClientMetricsBridge implements JobWorkerMetrics {
 

--- a/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/testsupport/SpringZeebeTestContext.java
+++ b/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/testsupport/SpringZeebeTestContext.java
@@ -1,7 +1,7 @@
 package io.camunda.zeebe.spring.client.testsupport;
 
 /**
- * Marker bean, if present in Spring context we are running in a test environment and might want to adjustcertain lifecycle handlings
+ * Marker bean, if present in Spring context we are running in a test environment and might want to
+ * adjustcertain lifecycle handlings
  */
-public class SpringZeebeTestContext {
-}
+public class SpringZeebeTestContext {}

--- a/spring-client-zeebe/src/test/java/io/camunda/zeebe/spring/client/bean/ClassInfoTest.java
+++ b/spring-client-zeebe/src/test/java/io/camunda/zeebe/spring/client/bean/ClassInfoTest.java
@@ -3,45 +3,45 @@ package io.camunda.zeebe.spring.client.bean;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.spring.client.annotation.*;
-import org.junit.jupiter.api.Test;
-
 import java.beans.Introspector;
+import org.junit.jupiter.api.Test;
 
 public class ClassInfoTest {
 
   @Deployment(resources = "classpath*:/1.bpmn")
-  public static class WithDeploymentAnnotation {
+  public static class WithDeploymentAnnotation {}
 
-  }
-
-  public static class WithoutDeploymentAnnotation {
-
-  }
+  public static class WithoutDeploymentAnnotation {}
 
   public static class WithZeebeWorker {
 
     @JobWorker(type = "bar", timeout = 100L, name = "kermit", autoComplete = false)
-    public void handle() {
-    }
+    public void handle() {}
   }
 
   public static class WithZeebeWorkerAllValues {
 
-    @JobWorker(type = "bar", timeout = 100L, name = "kermit", requestTimeout = 500L, pollInterval = 1_000L, maxJobsActive = 3, fetchVariables = { "foo"}, autoComplete = true, enabled = true)
-    public void handle() {
-    }
+    @JobWorker(
+        type = "bar",
+        timeout = 100L,
+        name = "kermit",
+        requestTimeout = 500L,
+        pollInterval = 1_000L,
+        maxJobsActive = 3,
+        fetchVariables = {"foo"},
+        autoComplete = true,
+        enabled = true)
+    public void handle() {}
   }
 
   public static class WithZeebeWorkerVariables {
     @JobWorker(type = "bar", timeout = 100L, fetchVariables = "var3", autoComplete = false)
-    public void handle(@Variable String var1, @Variable int var2) {
-    }
+    public void handle(@Variable String var1, @Variable int var2) {}
   }
 
   public static class WithDisabledZeebeWorker {
     @JobWorker(type = "bar", enabled = false, autoComplete = false)
-    public void handle(@Variable String var1, @Variable int var2) {
-    }
+    public void handle(@Variable String var1, @Variable int var2) {}
   }
 
   public static class WithZeebeWorkerVariablesComplexType {
@@ -49,15 +49,14 @@ public class ClassInfoTest {
       private String var1;
       private String var2;
     }
+
     @JobWorker(type = "bar", timeout = 100L, fetchVariables = "var2", autoComplete = false)
-    public void handle(@Variable String var1, @Variable ComplexTypeDTO var2) {
-    }
+    public void handle(@Variable String var1, @Variable ComplexTypeDTO var2) {}
   }
 
   public static class NoPropertiesSet {
     @JobWorker
-    public void handle() {
-    }
+    public void handle() {}
   }
 
   @Test
@@ -74,14 +73,13 @@ public class ClassInfoTest {
   @Test
   public void hasZeebeeDeploymentAnnotation() throws Exception {
     assertThat(beanInfo(new WithDeploymentAnnotation()).hasClassAnnotation(Deployment.class))
-      .isTrue();
+        .isTrue();
   }
 
   @Test
   public void hasNoZeebeeDeploymentAnnotation() throws Exception {
-    assertThat(
-      beanInfo(new WithoutDeploymentAnnotation()).hasClassAnnotation(Deployment.class))
-      .isFalse();
+    assertThat(beanInfo(new WithoutDeploymentAnnotation()).hasClassAnnotation(Deployment.class))
+        .isFalse();
   }
 
   @Test
@@ -95,6 +93,9 @@ public class ClassInfoTest {
   }
 
   private ClassInfo beanInfo(final Object bean) {
-    return ClassInfo.builder().bean(bean).beanName(Introspector.decapitalize(bean.getClass().getSimpleName())).build();
+    return ClassInfo.builder()
+        .bean(bean)
+        .beanName(Introspector.decapitalize(bean.getClass().getSimpleName()))
+        .build();
   }
 }

--- a/spring-client-zeebe/src/test/java/io/camunda/zeebe/spring/client/bean/ClassInfoTest.java
+++ b/spring-client-zeebe/src/test/java/io/camunda/zeebe/spring/client/bean/ClassInfoTest.java
@@ -8,57 +8,6 @@ import org.junit.jupiter.api.Test;
 
 public class ClassInfoTest {
 
-  @Deployment(resources = "classpath*:/1.bpmn")
-  public static class WithDeploymentAnnotation {}
-
-  public static class WithoutDeploymentAnnotation {}
-
-  public static class WithZeebeWorker {
-
-    @JobWorker(type = "bar", timeout = 100L, name = "kermit", autoComplete = false)
-    public void handle() {}
-  }
-
-  public static class WithZeebeWorkerAllValues {
-
-    @JobWorker(
-        type = "bar",
-        timeout = 100L,
-        name = "kermit",
-        requestTimeout = 500L,
-        pollInterval = 1_000L,
-        maxJobsActive = 3,
-        fetchVariables = {"foo"},
-        autoComplete = true,
-        enabled = true)
-    public void handle() {}
-  }
-
-  public static class WithZeebeWorkerVariables {
-    @JobWorker(type = "bar", timeout = 100L, fetchVariables = "var3", autoComplete = false)
-    public void handle(@Variable String var1, @Variable int var2) {}
-  }
-
-  public static class WithDisabledZeebeWorker {
-    @JobWorker(type = "bar", enabled = false, autoComplete = false)
-    public void handle(@Variable String var1, @Variable int var2) {}
-  }
-
-  public static class WithZeebeWorkerVariablesComplexType {
-    public static class ComplexTypeDTO {
-      private String var1;
-      private String var2;
-    }
-
-    @JobWorker(type = "bar", timeout = 100L, fetchVariables = "var2", autoComplete = false)
-    public void handle(@Variable String var1, @Variable ComplexTypeDTO var2) {}
-  }
-
-  public static class NoPropertiesSet {
-    @JobWorker
-    public void handle() {}
-  }
-
   @Test
   public void getBeanInfo() throws Exception {
     final WithDeploymentAnnotation withDeploymentAnnotation = new WithDeploymentAnnotation();
@@ -97,5 +46,61 @@ public class ClassInfoTest {
         .bean(bean)
         .beanName(Introspector.decapitalize(bean.getClass().getSimpleName()))
         .build();
+  }
+
+  @Deployment(resources = "classpath*:/1.bpmn")
+  public static class WithDeploymentAnnotation {}
+
+  public static class WithoutDeploymentAnnotation {}
+
+  public static class WithZeebeWorker {
+
+    @JobWorker(type = "bar", timeout = 100L, name = "kermit", autoComplete = false)
+    public void handle() {}
+  }
+
+  public static class WithZeebeWorkerAllValues {
+
+    @JobWorker(
+        type = "bar",
+        timeout = 100L,
+        name = "kermit",
+        requestTimeout = 500L,
+        pollInterval = 1_000L,
+        maxJobsActive = 3,
+        fetchVariables = {"foo"},
+        autoComplete = true,
+        enabled = true)
+    public void handle() {}
+  }
+
+  public static class WithZeebeWorkerVariables {
+    @JobWorker(type = "bar", timeout = 100L, fetchVariables = "var3", autoComplete = false)
+    public void handle(@Variable String var1, @Variable int var2) {}
+  }
+
+  public static class WithDisabledZeebeWorker {
+    @JobWorker(type = "bar", enabled = false, autoComplete = false)
+    public void handle(@Variable String var1, @Variable int var2) {}
+  }
+
+  public static class WithZeebeWorkerVariablesComplexType {
+    @JobWorker(type = "bar", timeout = 100L, fetchVariables = "var2", autoComplete = false)
+    public void handle(@Variable String var1, @Variable ComplexTypeDTO var2) {}
+
+    public static class ComplexTypeDTO {
+      private String var1;
+      private String var2;
+    }
+  }
+
+  public static class NoPropertiesSet {
+    @JobWorker
+    public void handle() {}
+  }
+
+  public static class TenantBound {
+    @JobWorker(tenantIds = "tenant-1")
+    public void handle() {}
   }
 }

--- a/spring-client-zeebe/src/test/java/io/camunda/zeebe/spring/client/bean/CopyNotNullBeanUtilsBeanTest.java
+++ b/spring-client-zeebe/src/test/java/io/camunda/zeebe/spring/client/bean/CopyNotNullBeanUtilsBeanTest.java
@@ -1,12 +1,11 @@
 package io.camunda.zeebe.spring.client.bean;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.Objects;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 class CopyNotNullBeanUtilsBeanTest {
 
@@ -55,8 +54,7 @@ class CopyNotNullBeanUtilsBeanTest {
       this.third = third;
     }
 
-    public ForTestWithBoolean() {
-    }
+    public ForTestWithBoolean() {}
 
     public Boolean getFirst() {
       return first;
@@ -87,7 +85,9 @@ class CopyNotNullBeanUtilsBeanTest {
       if (this == o) return true;
       if (o == null || getClass() != o.getClass()) return false;
       ForTestWithBoolean that = (ForTestWithBoolean) o;
-      return second == that.second && Objects.equals(first, that.first) && Objects.equals(third, that.third);
+      return second == that.second
+          && Objects.equals(first, that.first)
+          && Objects.equals(third, that.third);
     }
 
     @Override
@@ -97,11 +97,14 @@ class CopyNotNullBeanUtilsBeanTest {
 
     @Override
     public String toString() {
-      return "ForTestWithBoolean{" +
-        "first=" + first +
-        ", second=" + second +
-        ", third=" + third +
-        '}';
+      return "ForTestWithBoolean{"
+          + "first="
+          + first
+          + ", second="
+          + second
+          + ", third="
+          + third
+          + '}';
     }
   }
 
@@ -145,7 +148,9 @@ class CopyNotNullBeanUtilsBeanTest {
       if (this == o) return true;
       if (o == null || getClass() != o.getClass()) return false;
       ForTest forTest = (ForTest) o;
-      return Objects.equals(first, forTest.first) && Objects.equals(second, forTest.second) && Objects.equals(third, forTest.third);
+      return Objects.equals(first, forTest.first)
+          && Objects.equals(second, forTest.second)
+          && Objects.equals(third, forTest.third);
     }
 
     @Override
@@ -155,11 +160,17 @@ class CopyNotNullBeanUtilsBeanTest {
 
     @Override
     public String toString() {
-      return "ForTest{" +
-        "first='" + first + '\'' +
-        ", second='" + second + '\'' +
-        ", third='" + third + '\'' +
-        '}';
+      return "ForTest{"
+          + "first='"
+          + first
+          + '\''
+          + ", second='"
+          + second
+          + '\''
+          + ", third='"
+          + third
+          + '\''
+          + '}';
     }
   }
 }

--- a/spring-client-zeebe/src/test/java/io/camunda/zeebe/spring/client/bean/value/factory/ReadZeebeDeploymentValueTest.java
+++ b/spring-client-zeebe/src/test/java/io/camunda/zeebe/spring/client/bean/value/factory/ReadZeebeDeploymentValueTest.java
@@ -1,19 +1,18 @@
 package io.camunda.zeebe.spring.client.bean.value.factory;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import io.camunda.zeebe.spring.client.annotation.Deployment;
 import io.camunda.zeebe.spring.client.annotation.ZeebeDeployment;
 import io.camunda.zeebe.spring.client.annotation.processor.ZeebeDeploymentAnnotationProcessor;
-import io.camunda.zeebe.spring.client.bean.ClassInfo;
 import io.camunda.zeebe.spring.client.annotation.value.ZeebeDeploymentValue;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.mockito.MockitoAnnotations;
-
+import io.camunda.zeebe.spring.client.bean.ClassInfo;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
 
 public class ReadZeebeDeploymentValueTest {
 
@@ -27,94 +26,81 @@ public class ReadZeebeDeploymentValueTest {
 
   @Test
   public void shouldReadSingleClassPathResourceTest() {
-    //given
-    ClassInfo classInfo = ClassInfo.builder()
-      .bean(new WithSingleClassPathResource())
-      .build();
+    // given
+    ClassInfo classInfo = ClassInfo.builder().bean(new WithSingleClassPathResource()).build();
 
-    ZeebeDeploymentValue expectedDeploymentValue = ZeebeDeploymentValue.builder()
-      .beanInfo(classInfo)
-      .resources(Collections.singletonList("classpath*:/1.bpmn"))
-      .build();
+    ZeebeDeploymentValue expectedDeploymentValue =
+        ZeebeDeploymentValue.builder()
+            .beanInfo(classInfo)
+            .resources(Collections.singletonList("classpath*:/1.bpmn"))
+            .build();
 
-    //when
+    // when
     Optional<ZeebeDeploymentValue> valueForClass = annotationProcessor.readAnnotation(classInfo);
 
-    //then
+    // then
     assertTrue(valueForClass.isPresent());
     assertEquals(expectedDeploymentValue, valueForClass.get());
   }
 
   @Test
   public void shouldReadMultipleClassPathResourcesTest() {
-    //given
-    ClassInfo classInfo = ClassInfo.builder()
-      .bean(new WithMultipleClassPathResource())
-      .build();
+    // given
+    ClassInfo classInfo = ClassInfo.builder().bean(new WithMultipleClassPathResource()).build();
 
-    ZeebeDeploymentValue expectedDeploymentValue = ZeebeDeploymentValue.builder()
-      .beanInfo(classInfo)
-      .resources(Arrays.asList("classpath*:/1.bpmn", "classpath*:/2.bpmn"))
-      .build();
+    ZeebeDeploymentValue expectedDeploymentValue =
+        ZeebeDeploymentValue.builder()
+            .beanInfo(classInfo)
+            .resources(Arrays.asList("classpath*:/1.bpmn", "classpath*:/2.bpmn"))
+            .build();
 
-    //when
+    // when
     Optional<ZeebeDeploymentValue> valueForClass = annotationProcessor.readAnnotation(classInfo);
 
-    //then
+    // then
     assertTrue(valueForClass.isPresent());
     assertEquals(expectedDeploymentValue, valueForClass.get());
   }
 
   @Test
   public void shouldReadNoClassPathResourcesTest() {
-    //given
-    ClassInfo classInfo = ClassInfo.builder()
-      .bean(new WithoutAnnotation())
-      .build();
+    // given
+    ClassInfo classInfo = ClassInfo.builder().bean(new WithoutAnnotation()).build();
 
-    //when
+    // when
     Optional<ZeebeDeploymentValue> valueForClass = annotationProcessor.readAnnotation(classInfo);
 
-    //then
+    // then
     assertFalse(valueForClass.isPresent());
   }
 
   @Test
   public void shouldReadDeprecatedClassPathResourceTest() {
-    //given
-    ClassInfo classInfo = ClassInfo.builder()
-      .bean(new WithDeprecatedPathResource())
-      .build();
+    // given
+    ClassInfo classInfo = ClassInfo.builder().bean(new WithDeprecatedPathResource()).build();
 
-    ZeebeDeploymentValue expectedDeploymentValue = ZeebeDeploymentValue.builder()
-      .beanInfo(classInfo)
-      .resources(Collections.singletonList("classpath*:/1.bpmn"))
-      .build();
+    ZeebeDeploymentValue expectedDeploymentValue =
+        ZeebeDeploymentValue.builder()
+            .beanInfo(classInfo)
+            .resources(Collections.singletonList("classpath*:/1.bpmn"))
+            .build();
 
-    //when
+    // when
     Optional<ZeebeDeploymentValue> valueForClass = annotationProcessor.readAnnotation(classInfo);
 
-    //then
+    // then
     assertTrue(valueForClass.isPresent());
     assertEquals(expectedDeploymentValue, valueForClass.get());
   }
 
   @Deployment(resources = "classpath*:/1.bpmn")
-  private static class WithSingleClassPathResource {
-
-  }
+  private static class WithSingleClassPathResource {}
 
   @ZeebeDeployment(classPathResources = "/1.bpmn")
-  private static class WithDeprecatedPathResource {
-
-  }
+  private static class WithDeprecatedPathResource {}
 
   @Deployment(resources = {"classpath*:/1.bpmn", "classpath*:/2.bpmn"})
-  private static class WithMultipleClassPathResource {
+  private static class WithMultipleClassPathResource {}
 
-  }
-
-  private static class WithoutAnnotation {
-
-  }
+  private static class WithoutAnnotation {}
 }

--- a/spring-client-zeebe/src/test/java/io/camunda/zeebe/spring/client/bean/value/factory/ReadZeebeWorkerValueTest.java
+++ b/spring-client-zeebe/src/test/java/io/camunda/zeebe/spring/client/bean/value/factory/ReadZeebeWorkerValueTest.java
@@ -1,21 +1,20 @@
 package io.camunda.zeebe.spring.client.bean.value.factory;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import io.camunda.zeebe.spring.client.annotation.processor.ZeebeWorkerAnnotationProcessor;
 import io.camunda.zeebe.spring.client.annotation.value.ZeebeWorkerValue;
 import io.camunda.zeebe.spring.client.bean.ClassInfo;
 import io.camunda.zeebe.spring.client.bean.ClassInfoTest;
 import io.camunda.zeebe.spring.client.bean.MethodInfo;
-import org.junit.jupiter.api.Test;
-
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
 public class ReadZeebeWorkerValueTest {
 
@@ -24,14 +23,15 @@ public class ReadZeebeWorkerValueTest {
 
   @Test
   public void applyOnWithZeebeWorker() {
-    //given
+    // given
     final ZeebeWorkerAnnotationProcessor annotationProcessor = createDefaultAnnotationProcessor();
     final MethodInfo methodInfo = extract(ClassInfoTest.WithZeebeWorker.class);
 
-    //when
-    final Optional<ZeebeWorkerValue> zeebeWorkerValue = annotationProcessor.readJobWorkerAnnotationForMethod(methodInfo);
+    // when
+    final Optional<ZeebeWorkerValue> zeebeWorkerValue =
+        annotationProcessor.readJobWorkerAnnotationForMethod(methodInfo);
 
-    //then
+    // then
     assertTrue(zeebeWorkerValue.isPresent());
     assertEquals("bar", zeebeWorkerValue.get().getType());
     assertEquals("kermit", zeebeWorkerValue.get().getName());
@@ -46,14 +46,15 @@ public class ReadZeebeWorkerValueTest {
 
   @Test
   public void applyOnWithZeebeWorkerAllValues() {
-    //given
+    // given
     final ZeebeWorkerAnnotationProcessor annotationProcessor = createDefaultAnnotationProcessor();
     final MethodInfo methodInfo = extract(ClassInfoTest.WithZeebeWorkerAllValues.class);
 
-    //when
-    final Optional<ZeebeWorkerValue> zeebeWorkerValue = annotationProcessor.readJobWorkerAnnotationForMethod(methodInfo);
+    // when
+    final Optional<ZeebeWorkerValue> zeebeWorkerValue =
+        annotationProcessor.readJobWorkerAnnotationForMethod(methodInfo);
 
-    //then
+    // then
     assertTrue(zeebeWorkerValue.isPresent());
     assertEquals("bar", zeebeWorkerValue.get().getType());
     assertEquals("kermit", zeebeWorkerValue.get().getName());
@@ -62,122 +63,121 @@ public class ReadZeebeWorkerValueTest {
     assertEquals(500L, zeebeWorkerValue.get().getRequestTimeout());
     assertEquals(1_000L, zeebeWorkerValue.get().getPollInterval());
     assertEquals(true, zeebeWorkerValue.get().getAutoComplete());
-    assertArrayEquals(new String[] { "foo"}, zeebeWorkerValue.get().getFetchVariables());
+    assertArrayEquals(new String[] {"foo"}, zeebeWorkerValue.get().getFetchVariables());
     assertEquals(methodInfo, zeebeWorkerValue.get().getMethodInfo());
   }
 
   @Test
   public void applyOnWithZeebeWorkerVariables() {
-    //given
+    // given
     final ZeebeWorkerAnnotationProcessor annotationProcessor = createDefaultAnnotationProcessor();
     final MethodInfo methodInfo = extract(ClassInfoTest.WithZeebeWorkerVariables.class);
 
-    //when
-    final Optional<ZeebeWorkerValue> zeebeWorkerValue = annotationProcessor.readJobWorkerAnnotationForMethod(methodInfo);
+    // when
+    final Optional<ZeebeWorkerValue> zeebeWorkerValue =
+        annotationProcessor.readJobWorkerAnnotationForMethod(methodInfo);
 
-    //then
+    // then
     assertTrue(zeebeWorkerValue.isPresent());
-    assertThat(Arrays.asList("var1", "var2", "var3" )).hasSameElementsAs(Arrays.asList(zeebeWorkerValue.get().getFetchVariables()));
+    assertThat(Arrays.asList("var1", "var2", "var3"))
+        .hasSameElementsAs(Arrays.asList(zeebeWorkerValue.get().getFetchVariables()));
     assertEquals(methodInfo, zeebeWorkerValue.get().getMethodInfo());
   }
 
   @Test
   public void applyOnZeebeWorkerWithNoTypeSet() {
-    //given
-    final ZeebeWorkerAnnotationProcessor annotationProcessor = new ZeebeWorkerAnnotationProcessor(
-      null,
-      new ArrayList<>(),
-      null,
-      DEFAULT_WORKER_NAME);
+    // given
+    final ZeebeWorkerAnnotationProcessor annotationProcessor =
+        new ZeebeWorkerAnnotationProcessor(null, new ArrayList<>());
     final MethodInfo methodInfo = extract(ClassInfoTest.NoPropertiesSet.class);
 
-    //when
-    final Optional<ZeebeWorkerValue> zeebeWorkerValue = annotationProcessor.readJobWorkerAnnotationForMethod(methodInfo);
+    // when
+    final Optional<ZeebeWorkerValue> zeebeWorkerValue =
+        annotationProcessor.readJobWorkerAnnotationForMethod(methodInfo);
 
-    //then
+    // then
     assertTrue(zeebeWorkerValue.isPresent());
     assertEquals("handle", zeebeWorkerValue.get().getType());
   }
 
   @Test
-  // MAybe valuidate via own test class with @TestPropertySource(properties = {"zeebe.client.worker.default-type=defaultWorkerType"})
+  // MAybe valuidate via own test class with @TestPropertySource(properties =
+  // {"zeebe.client.worker.default-type=defaultWorkerType"})
   public void applyOnZeebeWorkerWithNoTypeSetUsingDefault() {
-    //given
+    // given
     final ZeebeWorkerAnnotationProcessor annotationProcessor = createDefaultAnnotationProcessor();
     final MethodInfo methodInfo = extract(ClassInfoTest.NoPropertiesSet.class);
 
-    //when
-    final Optional<ZeebeWorkerValue> zeebeWorkerValue = annotationProcessor.readJobWorkerAnnotationForMethod(methodInfo);
+    // when
+    final Optional<ZeebeWorkerValue> zeebeWorkerValue =
+        annotationProcessor.readJobWorkerAnnotationForMethod(methodInfo);
 
-    //then
+    // then
     assertTrue(zeebeWorkerValue.isPresent());
     assertEquals(DEFAULT_WORKER_TYPE, zeebeWorkerValue.get().getType());
   }
 
   @Test
   public void applyOnZeebeWorkerWithNoNameSetUsingDefault() {
-    //given
+    // given
     final ZeebeWorkerAnnotationProcessor annotationProcessor = createDefaultAnnotationProcessor();
     final MethodInfo methodInfo = extract(ClassInfoTest.NoPropertiesSet.class);
 
-    //when
-    final Optional<ZeebeWorkerValue> zeebeWorkerValue = annotationProcessor.readJobWorkerAnnotationForMethod(methodInfo);
+    // when
+    final Optional<ZeebeWorkerValue> zeebeWorkerValue =
+        annotationProcessor.readJobWorkerAnnotationForMethod(methodInfo);
 
-    //then
+    // then
     assertTrue(zeebeWorkerValue.isPresent());
     assertEquals(DEFAULT_WORKER_NAME, zeebeWorkerValue.get().getName());
   }
 
   @Test
   public void applyOnZeebeWorkerWithNoNameNoDefault() {
-    //given
-    final ZeebeWorkerAnnotationProcessor annotationProcessor = new ZeebeWorkerAnnotationProcessor(
-      null,
-      new ArrayList<>(),
-      DEFAULT_WORKER_TYPE,
-      null);
+    // given
+    final ZeebeWorkerAnnotationProcessor annotationProcessor =
+        new ZeebeWorkerAnnotationProcessor(null, new ArrayList<>());
     final MethodInfo methodInfo = extract(ClassInfoTest.NoPropertiesSet.class);
 
-    //when
-    final Optional<ZeebeWorkerValue> zeebeWorkerValue = annotationProcessor.readJobWorkerAnnotationForMethod(methodInfo);
+    // when
+    final Optional<ZeebeWorkerValue> zeebeWorkerValue =
+        annotationProcessor.readJobWorkerAnnotationForMethod(methodInfo);
 
-    //then
+    // then
     assertTrue(zeebeWorkerValue.isPresent());
     // we are not using beans here - so beanName is null
     assertEquals("null#handle", zeebeWorkerValue.get().getName());
   }
 
   private ZeebeWorkerAnnotationProcessor createDefaultAnnotationProcessor() {
-    return new ZeebeWorkerAnnotationProcessor(
-      null,
-      new ArrayList<>(),
-      DEFAULT_WORKER_TYPE,
-      DEFAULT_WORKER_NAME);
+    return new ZeebeWorkerAnnotationProcessor(null, new ArrayList<>());
   }
 
   @Test
   public void applyOnWithZeebeWorkerVariablesComplexType() {
-    //given
+    // given
     final ZeebeWorkerAnnotationProcessor annotationProcessor = createDefaultAnnotationProcessor();
     final MethodInfo methodInfo = extract(ClassInfoTest.WithZeebeWorkerVariablesComplexType.class);
 
-    //when
-    final Optional<ZeebeWorkerValue> zeebeWorkerValue = annotationProcessor.readJobWorkerAnnotationForMethod(methodInfo);
+    // when
+    final Optional<ZeebeWorkerValue> zeebeWorkerValue =
+        annotationProcessor.readJobWorkerAnnotationForMethod(methodInfo);
 
-    //then
+    // then
     assertTrue(zeebeWorkerValue.isPresent());
-    assertThat(Arrays.asList("var1", "var2")).hasSameElementsAs(Arrays.asList(zeebeWorkerValue.get().getFetchVariables()));
+    assertThat(Arrays.asList("var1", "var2"))
+        .hasSameElementsAs(Arrays.asList(zeebeWorkerValue.get().getFetchVariables()));
     assertEquals(methodInfo, zeebeWorkerValue.get().getMethodInfo());
   }
 
   private MethodInfo extract(Class<?> clazz) {
 
-    final Method method = Arrays.stream(clazz.getMethods()).filter(m -> m.getName().equals("handle")).findFirst().get();
-    final ClassInfo classInfo = ClassInfo.builder()
-      .build();
-    return MethodInfo.builder()
-      .classInfo(classInfo)
-      .method(method)
-      .build();
+    final Method method =
+        Arrays.stream(clazz.getMethods())
+            .filter(m -> m.getName().equals("handle"))
+            .findFirst()
+            .get();
+    final ClassInfo classInfo = ClassInfo.builder().build();
+    return MethodInfo.builder().classInfo(classInfo).method(method).build();
   }
 }

--- a/spring-client-zeebe/src/test/java/io/camunda/zeebe/spring/client/bean/value/factory/ReadZeebeWorkerValueTest.java
+++ b/spring-client-zeebe/src/test/java/io/camunda/zeebe/spring/client/bean/value/factory/ReadZeebeWorkerValueTest.java
@@ -1,5 +1,6 @@
 package io.camunda.zeebe.spring.client.bean.value.factory;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -41,6 +42,21 @@ public class ReadZeebeWorkerValueTest {
     assertEquals(false, zeebeWorkerValue.get().getAutoComplete());
     assertArrayEquals(new String[] {}, zeebeWorkerValue.get().getFetchVariables());
     assertEquals(methodInfo, zeebeWorkerValue.get().getMethodInfo());
+  }
+
+  @Test
+  void shouldReadTenantIds() {
+    // given
+    final ZeebeWorkerAnnotationProcessor annotationProcessor = createDefaultAnnotationProcessor();
+    final MethodInfo methodInfo = extract(ClassInfoTest.TenantBound.class);
+
+    // when
+    final Optional<ZeebeWorkerValue> zeebeWorkerValue =
+        annotationProcessor.readJobWorkerAnnotationForMethod(methodInfo);
+
+    // then
+    assertTrue(zeebeWorkerValue.isPresent());
+    assertThat(zeebeWorkerValue.get().getTenantIds()).containsOnly("tenant-1");
   }
 
   @Test

--- a/spring-client-zeebe/src/test/java/io/camunda/zeebe/spring/client/bean/value/factory/ReadZeebeWorkerValueTest.java
+++ b/spring-client-zeebe/src/test/java/io/camunda/zeebe/spring/client/bean/value/factory/ReadZeebeWorkerValueTest.java
@@ -1,6 +1,5 @@
 package io.camunda.zeebe.spring.client.bean.value.factory;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -67,107 +66,8 @@ public class ReadZeebeWorkerValueTest {
     assertEquals(methodInfo, zeebeWorkerValue.get().getMethodInfo());
   }
 
-  @Test
-  public void applyOnWithZeebeWorkerVariables() {
-    // given
-    final ZeebeWorkerAnnotationProcessor annotationProcessor = createDefaultAnnotationProcessor();
-    final MethodInfo methodInfo = extract(ClassInfoTest.WithZeebeWorkerVariables.class);
-
-    // when
-    final Optional<ZeebeWorkerValue> zeebeWorkerValue =
-        annotationProcessor.readJobWorkerAnnotationForMethod(methodInfo);
-
-    // then
-    assertTrue(zeebeWorkerValue.isPresent());
-    assertThat(Arrays.asList("var1", "var2", "var3"))
-        .hasSameElementsAs(Arrays.asList(zeebeWorkerValue.get().getFetchVariables()));
-    assertEquals(methodInfo, zeebeWorkerValue.get().getMethodInfo());
-  }
-
-  @Test
-  public void applyOnZeebeWorkerWithNoTypeSet() {
-    // given
-    final ZeebeWorkerAnnotationProcessor annotationProcessor =
-        new ZeebeWorkerAnnotationProcessor(null, new ArrayList<>());
-    final MethodInfo methodInfo = extract(ClassInfoTest.NoPropertiesSet.class);
-
-    // when
-    final Optional<ZeebeWorkerValue> zeebeWorkerValue =
-        annotationProcessor.readJobWorkerAnnotationForMethod(methodInfo);
-
-    // then
-    assertTrue(zeebeWorkerValue.isPresent());
-    assertEquals("handle", zeebeWorkerValue.get().getType());
-  }
-
-  @Test
-  // MAybe valuidate via own test class with @TestPropertySource(properties =
-  // {"zeebe.client.worker.default-type=defaultWorkerType"})
-  public void applyOnZeebeWorkerWithNoTypeSetUsingDefault() {
-    // given
-    final ZeebeWorkerAnnotationProcessor annotationProcessor = createDefaultAnnotationProcessor();
-    final MethodInfo methodInfo = extract(ClassInfoTest.NoPropertiesSet.class);
-
-    // when
-    final Optional<ZeebeWorkerValue> zeebeWorkerValue =
-        annotationProcessor.readJobWorkerAnnotationForMethod(methodInfo);
-
-    // then
-    assertTrue(zeebeWorkerValue.isPresent());
-    assertEquals(DEFAULT_WORKER_TYPE, zeebeWorkerValue.get().getType());
-  }
-
-  @Test
-  public void applyOnZeebeWorkerWithNoNameSetUsingDefault() {
-    // given
-    final ZeebeWorkerAnnotationProcessor annotationProcessor = createDefaultAnnotationProcessor();
-    final MethodInfo methodInfo = extract(ClassInfoTest.NoPropertiesSet.class);
-
-    // when
-    final Optional<ZeebeWorkerValue> zeebeWorkerValue =
-        annotationProcessor.readJobWorkerAnnotationForMethod(methodInfo);
-
-    // then
-    assertTrue(zeebeWorkerValue.isPresent());
-    assertEquals(DEFAULT_WORKER_NAME, zeebeWorkerValue.get().getName());
-  }
-
-  @Test
-  public void applyOnZeebeWorkerWithNoNameNoDefault() {
-    // given
-    final ZeebeWorkerAnnotationProcessor annotationProcessor =
-        new ZeebeWorkerAnnotationProcessor(null, new ArrayList<>());
-    final MethodInfo methodInfo = extract(ClassInfoTest.NoPropertiesSet.class);
-
-    // when
-    final Optional<ZeebeWorkerValue> zeebeWorkerValue =
-        annotationProcessor.readJobWorkerAnnotationForMethod(methodInfo);
-
-    // then
-    assertTrue(zeebeWorkerValue.isPresent());
-    // we are not using beans here - so beanName is null
-    assertEquals("null#handle", zeebeWorkerValue.get().getName());
-  }
-
   private ZeebeWorkerAnnotationProcessor createDefaultAnnotationProcessor() {
     return new ZeebeWorkerAnnotationProcessor(null, new ArrayList<>());
-  }
-
-  @Test
-  public void applyOnWithZeebeWorkerVariablesComplexType() {
-    // given
-    final ZeebeWorkerAnnotationProcessor annotationProcessor = createDefaultAnnotationProcessor();
-    final MethodInfo methodInfo = extract(ClassInfoTest.WithZeebeWorkerVariablesComplexType.class);
-
-    // when
-    final Optional<ZeebeWorkerValue> zeebeWorkerValue =
-        annotationProcessor.readJobWorkerAnnotationForMethod(methodInfo);
-
-    // then
-    assertTrue(zeebeWorkerValue.isPresent());
-    assertThat(Arrays.asList("var1", "var2"))
-        .hasSameElementsAs(Arrays.asList(zeebeWorkerValue.get().getFetchVariables()));
-    assertEquals(methodInfo, zeebeWorkerValue.get().getMethodInfo());
   }
 
   private MethodInfo extract(Class<?> clazz) {

--- a/test/common/src/main/java/io/camunda/zeebe/spring/test/CamundaTestAutoConfiguration.java
+++ b/test/common/src/main/java/io/camunda/zeebe/spring/test/CamundaTestAutoConfiguration.java
@@ -9,7 +9,6 @@ import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 
-
 @TestConfiguration
 @ImportAutoConfiguration({
   TestProxyConfiguration.class,
@@ -24,5 +23,4 @@ public class CamundaTestAutoConfiguration {
     // add marker bean to Spring context that we are running in a test case
     return new SpringZeebeTestContext();
   }
-
 }

--- a/test/common/src/main/java/io/camunda/zeebe/spring/test/ZeebeTestThreadSupport.java
+++ b/test/common/src/main/java/io/camunda/zeebe/spring/test/ZeebeTestThreadSupport.java
@@ -1,27 +1,23 @@
 package io.camunda.zeebe.spring.test;
 
+import static io.camunda.zeebe.process.test.assertions.BpmnAssert.assertThat;
+
 import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
 import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
 import io.camunda.zeebe.process.test.assertions.BpmnAssert;
 import io.camunda.zeebe.process.test.filters.RecordStream;
 import io.camunda.zeebe.process.test.inspections.model.InspectedProcessInstance;
-import org.awaitility.Awaitility;
-
-
 import java.time.Duration;
 import java.util.Objects;
+import org.awaitility.Awaitility;
 
-import static io.camunda.zeebe.process.test.assertions.BpmnAssert.assertThat;
-
-/**
- * Helper to wait in the multithreaded environment for the worker to execute.
- */
+/** Helper to wait in the multithreaded environment for the worker to execute. */
 public class ZeebeTestThreadSupport {
 
-  private final static ThreadLocal<ZeebeTestEngine> ENGINES = new ThreadLocal<>();
-  private final static Duration DEFAULT_DURATION = Duration.ofMillis(5000);
-  private final static Integer DEFAULT_TIMES_PASSED = 1;
-  private final static Long DEFAULT_INTERVAL_MILLIS = 100L;
+  private static final ThreadLocal<ZeebeTestEngine> ENGINES = new ThreadLocal<>();
+  private static final Duration DEFAULT_DURATION = Duration.ofMillis(5000);
+  private static final Integer DEFAULT_TIMES_PASSED = 1;
+  private static final Long DEFAULT_INTERVAL_MILLIS = 100L;
 
   public static void setEngineForCurrentThread(ZeebeTestEngine engine) {
     ENGINES.set(engine);
@@ -35,78 +31,105 @@ public class ZeebeTestThreadSupport {
     waitForProcessInstanceCompleted(processInstance.getProcessInstanceKey(), DEFAULT_DURATION);
   }
 
-  public static void waitForProcessInstanceCompleted(ProcessInstanceEvent processInstance, Duration duration) {
+  public static void waitForProcessInstanceCompleted(
+      ProcessInstanceEvent processInstance, Duration duration) {
     waitForProcessInstanceCompleted(processInstance.getProcessInstanceKey(), duration);
   }
 
   public static void waitForProcessInstanceCompleted(long processInstanceKey) {
-    waitForProcessInstanceCompleted(new InspectedProcessInstance(processInstanceKey), DEFAULT_DURATION);
+    waitForProcessInstanceCompleted(
+        new InspectedProcessInstance(processInstanceKey), DEFAULT_DURATION);
   }
 
   public static void waitForProcessInstanceCompleted(long processInstanceKey, Duration duration) {
     waitForProcessInstanceCompleted(new InspectedProcessInstance(processInstanceKey), duration);
   }
 
-  public static void waitForProcessInstanceCompleted(InspectedProcessInstance inspectedProcessInstance) {
+  public static void waitForProcessInstanceCompleted(
+      InspectedProcessInstance inspectedProcessInstance) {
     waitForProcessInstanceCompleted(inspectedProcessInstance, DEFAULT_DURATION);
   }
 
-  public static void waitForProcessInstanceCompleted(InspectedProcessInstance inspectedProcessInstance, Duration duration) {
+  public static void waitForProcessInstanceCompleted(
+      InspectedProcessInstance inspectedProcessInstance, Duration duration) {
     // get it in the thread of the test
     final ZeebeTestEngine engine = ENGINES.get();
     if (engine == null) {
-      throw new IllegalStateException("No Zeebe engine is initialized for the current thread, annotate the test with @ZeebeSpringTest");
+      throw new IllegalStateException(
+          "No Zeebe engine is initialized for the current thread, annotate the test with @ZeebeSpringTest");
     }
     if (duration == null) {
       duration = DEFAULT_DURATION;
     }
-    Awaitility.await().atMost(duration).untilAsserted(() -> {
-      // allow the worker to work
-      Thread.sleep(DEFAULT_INTERVAL_MILLIS);
-      BpmnAssert.initRecordStream(
-        RecordStream.of(Objects.requireNonNull(engine).getRecordStreamSource()));
-      // use inside the awaitility thread
-      assertThat(inspectedProcessInstance).isCompleted();
-    });
+    Awaitility.await()
+        .atMost(duration)
+        .untilAsserted(
+            () -> {
+              // allow the worker to work
+              Thread.sleep(DEFAULT_INTERVAL_MILLIS);
+              BpmnAssert.initRecordStream(
+                  RecordStream.of(Objects.requireNonNull(engine).getRecordStreamSource()));
+              // use inside the awaitility thread
+              assertThat(inspectedProcessInstance).isCompleted();
+            });
   }
 
-  public static void waitForProcessInstanceHasPassedElement(ProcessInstanceEvent processInstance, String elementId) {
-    waitForProcessInstanceHasPassedElement(processInstance.getProcessInstanceKey(), elementId, DEFAULT_DURATION);
+  public static void waitForProcessInstanceHasPassedElement(
+      ProcessInstanceEvent processInstance, String elementId) {
+    waitForProcessInstanceHasPassedElement(
+        processInstance.getProcessInstanceKey(), elementId, DEFAULT_DURATION);
   }
 
-  public static void waitForProcessInstanceHasPassedElement(ProcessInstanceEvent processInstance, String elementId, Duration duration) {
-    waitForProcessInstanceHasPassedElement(processInstance.getProcessInstanceKey(), elementId, duration);
+  public static void waitForProcessInstanceHasPassedElement(
+      ProcessInstanceEvent processInstance, String elementId, Duration duration) {
+    waitForProcessInstanceHasPassedElement(
+        processInstance.getProcessInstanceKey(), elementId, duration);
   }
 
-  public static void waitForProcessInstanceHasPassedElement(long processInstanceKey, String elementId) {
-    waitForProcessInstanceHasPassedElement(new InspectedProcessInstance(processInstanceKey), elementId, DEFAULT_DURATION);
+  public static void waitForProcessInstanceHasPassedElement(
+      long processInstanceKey, String elementId) {
+    waitForProcessInstanceHasPassedElement(
+        new InspectedProcessInstance(processInstanceKey), elementId, DEFAULT_DURATION);
   }
 
-  public static void waitForProcessInstanceHasPassedElement(long processInstanceKey, String elementId, Duration duration) {
-    waitForProcessInstanceHasPassedElement(new InspectedProcessInstance(processInstanceKey), elementId, duration);
+  public static void waitForProcessInstanceHasPassedElement(
+      long processInstanceKey, String elementId, Duration duration) {
+    waitForProcessInstanceHasPassedElement(
+        new InspectedProcessInstance(processInstanceKey), elementId, duration);
   }
 
-  public static void waitForProcessInstanceHasPassedElement(InspectedProcessInstance inspectedProcessInstance, String elementId) {
+  public static void waitForProcessInstanceHasPassedElement(
+      InspectedProcessInstance inspectedProcessInstance, String elementId) {
     waitForProcessInstanceHasPassedElement(inspectedProcessInstance, elementId, DEFAULT_DURATION);
   }
 
-  public static void waitForProcessInstanceHasPassedElement(InspectedProcessInstance inspectedProcessInstance, String elementId, Duration duration) {
-    waitForProcessInstanceHasPassedElement(inspectedProcessInstance, elementId, duration, DEFAULT_TIMES_PASSED);
+  public static void waitForProcessInstanceHasPassedElement(
+      InspectedProcessInstance inspectedProcessInstance, String elementId, Duration duration) {
+    waitForProcessInstanceHasPassedElement(
+        inspectedProcessInstance, elementId, duration, DEFAULT_TIMES_PASSED);
   }
 
-  public static void waitForProcessInstanceHasPassedElement(InspectedProcessInstance inspectedProcessInstance, String elementId, Duration duration, final int times) {
+  public static void waitForProcessInstanceHasPassedElement(
+      InspectedProcessInstance inspectedProcessInstance,
+      String elementId,
+      Duration duration,
+      final int times) {
     final ZeebeTestEngine engine = ENGINES.get();
     if (engine == null) {
-      throw new IllegalStateException("No Zeebe engine is initialized for the current thread, annotate the test with @ZeebeSpringTest");
+      throw new IllegalStateException(
+          "No Zeebe engine is initialized for the current thread, annotate the test with @ZeebeSpringTest");
     }
     if (duration == null) {
       duration = DEFAULT_DURATION;
     }
-    Awaitility.await().atMost(duration).untilAsserted(() -> {
-      Thread.sleep(DEFAULT_INTERVAL_MILLIS);
-      BpmnAssert.initRecordStream(
-        RecordStream.of(Objects.requireNonNull(engine).getRecordStreamSource()));
-      assertThat(inspectedProcessInstance).hasPassedElement(elementId, times);
-    });
+    Awaitility.await()
+        .atMost(duration)
+        .untilAsserted(
+            () -> {
+              Thread.sleep(DEFAULT_INTERVAL_MILLIS);
+              BpmnAssert.initRecordStream(
+                  RecordStream.of(Objects.requireNonNull(engine).getRecordStreamSource()));
+              assertThat(inspectedProcessInstance).hasPassedElement(elementId, times);
+            });
   }
 }

--- a/test/common/src/main/java/io/camunda/zeebe/spring/test/configuration/ZeebeTestDefaultConfiguration.java
+++ b/test/common/src/main/java/io/camunda/zeebe/spring/test/configuration/ZeebeTestDefaultConfiguration.java
@@ -1,17 +1,14 @@
 package io.camunda.zeebe.spring.test.configuration;
 
+import static io.camunda.zeebe.spring.client.CamundaAutoConfiguration.DEFAULT_OBJECT_MAPPER;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 
-import static io.camunda.zeebe.spring.client.CamundaAutoConfiguration.DEFAULT_OBJECT_MAPPER;
-
-
-/**
- * Fallback values if certain beans are missing
- */
+/** Fallback values if certain beans are missing */
 public class ZeebeTestDefaultConfiguration {
 
   @Bean(name = "zeebeJsonMapper")
@@ -25,5 +22,4 @@ public class ZeebeTestDefaultConfiguration {
   public ObjectMapper objectMapper() {
     return DEFAULT_OBJECT_MAPPER;
   }
-
 }

--- a/test/common/src/main/java/io/camunda/zeebe/spring/test/proxy/AbstractInvocationHandler.java
+++ b/test/common/src/main/java/io/camunda/zeebe/spring/test/proxy/AbstractInvocationHandler.java
@@ -14,7 +14,7 @@ public abstract class AbstractInvocationHandler implements InvocationHandler {
   @Override
   @CheckForNull
   public final Object invoke(Object proxy, Method method, @CheckForNull @Nullable Object[] args)
-    throws Throwable {
+      throws Throwable {
     if (args == null) {
       args = NO_ARGS;
     }
@@ -22,8 +22,8 @@ public abstract class AbstractInvocationHandler implements InvocationHandler {
       return hashCode();
     }
     if (args.length == 1
-      && method.getName().equals("equals")
-      && method.getParameterTypes()[0] == Object.class) {
+        && method.getName().equals("equals")
+        && method.getParameterTypes()[0] == Object.class) {
       Object arg = args[0];
       if (arg == null) {
         return false;
@@ -32,7 +32,7 @@ public abstract class AbstractInvocationHandler implements InvocationHandler {
         return true;
       }
       return isProxyOfSameInterfaces(arg, proxy.getClass())
-        && equals(Proxy.getInvocationHandler(arg));
+          && equals(Proxy.getInvocationHandler(arg));
     }
     if (args.length == 0 && method.getName().equals("toString")) {
       return toString();
@@ -50,7 +50,7 @@ public abstract class AbstractInvocationHandler implements InvocationHandler {
    */
   @CheckForNull
   protected abstract Object handleInvocation(Object proxy, Method method, @Nullable Object[] args)
-    throws Throwable;
+      throws Throwable;
 
   /**
    * By default delegates to {@link Object#equals} so instances are only equal if they are
@@ -89,12 +89,12 @@ public abstract class AbstractInvocationHandler implements InvocationHandler {
 
   private static boolean isProxyOfSameInterfaces(Object arg, Class<?> proxyClass) {
     return proxyClass.isInstance(arg)
-      // Equal proxy instances should mostly be instance of proxyClass
-      // Under some edge cases (such as the proxy of JDK types serialized and then deserialized)
-      // the proxy type may not be the same.
-      // We first check isProxyClass() so that the common case of comparing with non-proxy objects
-      // is efficient.
-      || (Proxy.isProxyClass(arg.getClass())
-      && Arrays.equals(arg.getClass().getInterfaces(), proxyClass.getInterfaces()));
+        // Equal proxy instances should mostly be instance of proxyClass
+        // Under some edge cases (such as the proxy of JDK types serialized and then deserialized)
+        // the proxy type may not be the same.
+        // We first check isProxyClass() so that the common case of comparing with non-proxy objects
+        // is efficient.
+        || (Proxy.isProxyClass(arg.getClass())
+            && Arrays.equals(arg.getClass().getInterfaces(), proxyClass.getInterfaces()));
   }
 }

--- a/test/common/src/main/java/io/camunda/zeebe/spring/test/proxy/TestProxyConfiguration.java
+++ b/test/common/src/main/java/io/camunda/zeebe/spring/test/proxy/TestProxyConfiguration.java
@@ -2,15 +2,12 @@ package io.camunda.zeebe.spring.test.proxy;
 
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.BeansException;
-import org.springframework.beans.factory.ObjectFactory;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Primary;
-
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Proxy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
 
 public class TestProxyConfiguration {
   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -23,10 +20,9 @@ public class TestProxyConfiguration {
   @Bean
   @Primary
   public ZeebeClient proxiedZeebeClient(ZeebeClientProxy zeebeClientProxy) {
-    return (ZeebeClient) Proxy.newProxyInstance(
-      this.getClass().getClassLoader(),
-      new Class[] { ZeebeClient.class },
-      zeebeClientProxy);
+    return (ZeebeClient)
+        Proxy.newProxyInstance(
+            this.getClass().getClassLoader(), new Class[] {ZeebeClient.class}, zeebeClientProxy);
   }
 
   @Bean
@@ -36,9 +32,10 @@ public class TestProxyConfiguration {
 
   @Bean
   public ZeebeTestEngine proxiedZeebeTestEngine(final ZeebeTestEngineProxy zeebeTestEngineProxy) {
-    return (ZeebeTestEngine) Proxy.newProxyInstance(
-      this.getClass().getClassLoader(),
-      new Class[] { ZeebeTestEngine.class },
-      zeebeTestEngineProxy);
+    return (ZeebeTestEngine)
+        Proxy.newProxyInstance(
+            this.getClass().getClassLoader(),
+            new Class[] {ZeebeTestEngine.class},
+            zeebeTestEngineProxy);
   }
 }

--- a/test/common/src/main/java/io/camunda/zeebe/spring/test/proxy/ZeebeClientProxy.java
+++ b/test/common/src/main/java/io/camunda/zeebe/spring/test/proxy/ZeebeClientProxy.java
@@ -1,17 +1,15 @@
 package io.camunda.zeebe.spring.test.proxy;
 
 import io.camunda.zeebe.client.ZeebeClient;
+import java.lang.reflect.Method;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-import javax.annotation.CheckForNull;
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Method;
-
 /**
- * Dynamic proxy to delegate to a {@link ZeebeClient} which allows to swap the ZeebeClient object under the hood.
- * This is used in test environments, where the while Zeebe engine is re-initialized for every test case
+ * Dynamic proxy to delegate to a {@link ZeebeClient} which allows to swap the ZeebeClient object
+ * under the hood. This is used in test environments, where the while Zeebe engine is re-initialized
+ * for every test case
  */
-public class ZeebeClientProxy extends AbstractInvocationHandler  {
+public class ZeebeClientProxy extends AbstractInvocationHandler {
 
   private ZeebeClient delegate;
 
@@ -24,9 +22,13 @@ public class ZeebeClientProxy extends AbstractInvocationHandler  {
   }
 
   @Override
-  protected Object handleInvocation(Object proxy, Method method, @Nullable Object[] args) throws Throwable {
-    if (delegate==null) {
-      throw new RuntimeException("Cannot invoke " + method + " on ZeebeClient, as ZeebeClient is currently not initialized. Maybe you run outside of a testcase?");
+  protected Object handleInvocation(Object proxy, Method method, @Nullable Object[] args)
+      throws Throwable {
+    if (delegate == null) {
+      throw new RuntimeException(
+          "Cannot invoke "
+              + method
+              + " on ZeebeClient, as ZeebeClient is currently not initialized. Maybe you run outside of a testcase?");
     }
     return method.invoke(delegate, args);
   }

--- a/test/common/src/main/java/io/camunda/zeebe/spring/test/proxy/ZeebeTestEngineProxy.java
+++ b/test/common/src/main/java/io/camunda/zeebe/spring/test/proxy/ZeebeTestEngineProxy.java
@@ -1,17 +1,13 @@
 package io.camunda.zeebe.spring.test.proxy;
 
 import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
+import java.lang.reflect.Method;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-import javax.annotation.CheckForNull;
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
-import java.util.Arrays;
-
 /**
- * Dynamic proxy to delegate to a {@link ZeebeTestEngine} which allows to swap the {@link ZeebeTestEngine} object under the hood.
- * This is used in test environments, where the while ZeebeEngine is re-initialized for every test case
+ * Dynamic proxy to delegate to a {@link ZeebeTestEngine} which allows to swap the {@link
+ * ZeebeTestEngine} object under the hood. This is used in test environments, where the while
+ * ZeebeEngine is re-initialized for every test case
  */
 public class ZeebeTestEngineProxy extends AbstractInvocationHandler {
 
@@ -22,15 +18,18 @@ public class ZeebeTestEngineProxy extends AbstractInvocationHandler {
   }
 
   public void removeZeebeEngine() {
-  this.delegate = null;
-}
+    this.delegate = null;
+  }
 
   @Override
-  protected Object handleInvocation(Object proxy, Method method, @Nullable Object[] args) throws Throwable {
-    if (delegate==null) {
-      throw new RuntimeException("Cannot invoke " + method + " on ZeebeTestEngine, as ZeebeTestEngine is currently not initialized. Maybe you run outside of a testcase?");
+  protected Object handleInvocation(Object proxy, Method method, @Nullable Object[] args)
+      throws Throwable {
+    if (delegate == null) {
+      throw new RuntimeException(
+          "Cannot invoke "
+              + method
+              + " on ZeebeTestEngine, as ZeebeTestEngine is currently not initialized. Maybe you run outside of a testcase?");
     }
     return method.invoke(delegate, args);
   }
-
 }

--- a/test/embedded/src/main/java/io/camunda/zeebe/spring/test/ZeebeSpringTest.java
+++ b/test/embedded/src/main/java/io/camunda/zeebe/spring/test/ZeebeSpringTest.java
@@ -1,28 +1,23 @@
 package io.camunda.zeebe.spring.test;
 
-import io.camunda.zeebe.spring.client.CamundaAutoConfiguration;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
-import org.springframework.context.annotation.Import;
-import org.springframework.test.context.TestExecutionListeners;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestExecutionListeners;
 
-/**
- * Annotation for the Spring test.
- */
+/** Annotation for the Spring test. */
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
-// this pulls in the Configuration NOT as AutoConfiguration but directly creates beans, so the marker is present
+// this pulls in the Configuration NOT as AutoConfiguration but directly creates beans, so the
+// marker is present
 // when the normal CamundaAutoConfiguration is used by the normal meta-inf/services  way
 @Import({CamundaTestAutoConfiguration.class})
 // this listener hooks up into test execution
-@TestExecutionListeners(listeners = ZeebeTestExecutionListener.class, mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
-public @interface ZeebeSpringTest {
-
-}
+@TestExecutionListeners(
+    listeners = ZeebeTestExecutionListener.class,
+    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
+public @interface ZeebeSpringTest {}

--- a/test/embedded/src/main/java/io/camunda/zeebe/spring/test/ZeebeTestExecutionListener.java
+++ b/test/embedded/src/main/java/io/camunda/zeebe/spring/test/ZeebeTestExecutionListener.java
@@ -2,6 +2,7 @@ package io.camunda.zeebe.spring.test;
 
 import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
 import io.camunda.zeebe.process.test.engine.EngineFactory;
+import java.lang.invoke.MethodHandles;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.Ordered;
@@ -10,19 +11,20 @@ import org.springframework.test.context.TestContext;
 import org.springframework.test.context.TestExecutionListener;
 import org.springframework.test.util.TestSocketUtils;
 
-import java.lang.invoke.MethodHandles;
+/** Test execution listener binding the Zeebe engine to current test context. */
+public class ZeebeTestExecutionListener extends AbstractZeebeTestExecutionListener
+    implements TestExecutionListener, Ordered {
 
-/**
- * Test execution listener binding the Zeebe engine to current test context.
- */
-public class ZeebeTestExecutionListener extends AbstractZeebeTestExecutionListener implements TestExecutionListener, Ordered {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   private ZeebeTestEngine zeebeEngine;
 
   public void beforeTestMethod(@NonNull TestContext testContext) {
-    int randomPort = TestSocketUtils.findAvailableTcpPort(); // can be replaced with TestSocketUtils once available: https://github.com/spring-projects/spring-framework/pull/29132
+    int randomPort =
+        TestSocketUtils
+            .findAvailableTcpPort(); // can be replaced with TestSocketUtils once available:
+    // https://github.com/spring-projects/spring-framework/pull/29132
 
     LOGGER.info("Create Zeebe in-memory engine for test run on random port: " + randomPort + "...");
     zeebeEngine = EngineFactory.create(randomPort);

--- a/test/embedded/src/test/java/io/camunda/zeebe/spring/client/jobhandling/ZeebeClientDisabledInZeebeSpringTest.java
+++ b/test/embedded/src/test/java/io/camunda/zeebe/spring/client/jobhandling/ZeebeClientDisabledInZeebeSpringTest.java
@@ -1,5 +1,6 @@
 package io.camunda.zeebe.spring.client.jobhandling;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.process.test.api.ZeebeTestEngine;
@@ -9,24 +10,20 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 @SpringBootTest(
-  classes = {
-    ZeebeClientDisabledInZeebeSpringTest.class
-  },
-  properties = { "zeebe.client.enabled=false" }
-)
+    classes = {ZeebeClientDisabledInZeebeSpringTest.class},
+    properties = {"zeebe.client.enabled=false"})
 @ZeebeSpringTest
 public class ZeebeClientDisabledInZeebeSpringTest {
 
-  @Autowired
-  private ApplicationContext ctx;
+  @Autowired private ApplicationContext ctx;
 
   @Test
   public void testStartup() {
-    // a testcase with @ZeebeSpringTests ALWAYS creates a ZeebeEngine and a ZeebeClient (!), even when "zeebe.client.enabled=false" is configured
-    // In essence, this is an invalid configuration state - when you don't want to use ZeebeClient, don't use @ZeebeSpringTest
+    // a testcase with @ZeebeSpringTests ALWAYS creates a ZeebeEngine and a ZeebeClient (!), even
+    // when "zeebe.client.enabled=false" is configured
+    // In essence, this is an invalid configuration state - when you don't want to use ZeebeClient,
+    // don't use @ZeebeSpringTest
     assertEquals(1, ctx.getBeanNamesForType(ZeebeClient.class).length);
     assertEquals(1, ctx.getBeanNamesForType(ZeebeTestEngine.class).length);
   }

--- a/test/testcontainer/src/main/java/io/camunda/zeebe/spring/test/ZeebeSpringTest.java
+++ b/test/testcontainer/src/main/java/io/camunda/zeebe/spring/test/ZeebeSpringTest.java
@@ -1,25 +1,23 @@
 package io.camunda.zeebe.spring.test;
 
-import org.springframework.context.annotation.Import;
-import org.springframework.test.context.TestExecutionListeners;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestExecutionListeners;
 
-/**
- * Annotation for the Spring test.
- */
+/** Annotation for the Spring test. */
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
-// this pulls in the Configuration NOT as AutoConfiguration but directly creates beans, so the marker is present
+// this pulls in the Configuration NOT as AutoConfiguration but directly creates beans, so the
+// marker is present
 // when the normal CamundaAutoConfiguration is used by the normal meta-inf/services  way
 @Import({CamundaTestAutoConfiguration.class})
 // this listener hooks up into test execution
-@TestExecutionListeners(listeners = ZeebeTestExecutionListener.class, mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
-public @interface ZeebeSpringTest {
-
-}
+@TestExecutionListeners(
+    listeners = ZeebeTestExecutionListener.class,
+    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
+public @interface ZeebeSpringTest {}

--- a/test/testcontainer/src/main/java/io/camunda/zeebe/spring/test/ZeebeTestExecutionListener.java
+++ b/test/testcontainer/src/main/java/io/camunda/zeebe/spring/test/ZeebeTestExecutionListener.java
@@ -3,6 +3,7 @@ package io.camunda.zeebe.spring.test;
 import io.camunda.zeebe.process.test.extension.testcontainer.ContainerProperties;
 import io.camunda.zeebe.process.test.extension.testcontainer.ContainerizedEngine;
 import io.camunda.zeebe.process.test.extension.testcontainer.EngineContainer;
+import java.lang.invoke.MethodHandles;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.Ordered;
@@ -10,14 +11,12 @@ import org.springframework.lang.NonNull;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.TestExecutionListener;
 
-import java.lang.invoke.MethodHandles;
+/** Test execution listener binding the Zeebe engine to current test context. */
+public class ZeebeTestExecutionListener extends AbstractZeebeTestExecutionListener
+    implements TestExecutionListener, Ordered {
 
-/**
- * Test execution listener binding the Zeebe engine to current test context.
- */
-public class ZeebeTestExecutionListener extends AbstractZeebeTestExecutionListener implements TestExecutionListener, Ordered {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   private ContainerizedEngine containerizedEngine;
 
@@ -26,10 +25,11 @@ public class ZeebeTestExecutionListener extends AbstractZeebeTestExecutionListen
 
     final EngineContainer container = EngineContainer.getContainer();
     container.start();
-    containerizedEngine = new ContainerizedEngine(
-        container.getHost(),
-        container.getMappedPort(ContainerProperties.getContainerPort()),
-        container.getMappedPort(ContainerProperties.getGatewayPort()));
+    containerizedEngine =
+        new ContainerizedEngine(
+            container.getHost(),
+            container.getMappedPort(ContainerProperties.getContainerPort()),
+            container.getMappedPort(ContainerProperties.getGatewayPort()));
 
     LOGGER.info("...finished creating Zeebe Testcontainer");
   }


### PR DESCRIPTION
As of now, mulit-tenancy is only supported for the whole client.

This PR enables the usage of tenants on worker level.

This PR also refactors the annotation processor so that default job worker name and type are not injected from the spring environment. Instead, this was moved to the PropertyBasedZeebeWorkerValueCustomizer as here, the properties are available directly.

Hint: This PR also introduces the usage of a formatter in the maven build process. All formatter changes are in separate commits.

closes #501 