### PR TITLE
Revert to Java 17 compiled artefacts

### DIFF
--- a/.github/workflows/mvn-build.yml
+++ b/.github/workflows/mvn-build.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
+          java-version: '17'
           distribution: 'adopt'
       - name: Build with Maven
         run: mvn verify -PcheckFormat -B

--- a/.github/workflows/mvn-build.yml
+++ b/.github/workflows/mvn-build.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'adopt'
       - name: Build with Maven
         run: mvn verify -PcheckFormat -B

--- a/.github/workflows/mvn-release.yml
+++ b/.github/workflows/mvn-release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Java environment
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'adopt'
           cache: maven
           gpg-private-key: ${{ secrets.MAVEN_CENTRAL_GPG_SIGNING_KEY_SEC }}

--- a/.github/workflows/mvn-release.yml
+++ b/.github/workflows/mvn-release.yml
@@ -24,8 +24,8 @@ jobs:
       - name: Set up Java environment
         uses: actions/setup-java@v4
         with:
-          java-version: 21
-          distribution: zulu
+          java-version: '17'
+          distribution: 'adopt'
           cache: maven
           gpg-private-key: ${{ secrets.MAVEN_CENTRAL_GPG_SIGNING_KEY_SEC }}
           gpg-passphrase: MAVEN_CENTRAL_GPG_PASSPHRASE

--- a/camunda-sdk-java/java-client-operate/pom.xml
+++ b/camunda-sdk-java/java-client-operate/pom.xml
@@ -21,8 +21,6 @@
     </dependencies>
 
     <properties>
-        <maven.compiler.source>${java.version}</maven.compiler.source>
-        <maven.compiler.target>${java.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/camunda-sdk-java/java-common/pom.xml
+++ b/camunda-sdk-java/java-common/pom.xml
@@ -50,8 +50,6 @@
   </dependencies>
 
   <properties>
-    <maven.compiler.source>${java.version}</maven.compiler.source>
-    <maven.compiler.target>${java.version}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <mockito.version>5.9.0</mockito.version>
   </properties>

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -38,8 +38,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
           <compilerArgs>
             <arg>-parameters</arg>
           </compilerArgs>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <properties>
     <project.build.resourceEncoding>${project.build.sourceEncoding}</project.build.resourceEncoding>
-    <version.java>8</version.java>
+    <version.java>1.8</version.java>
     <java.version>${version.java}</java.version>
 
     <maven.compiler.source>${java.version}</maven.compiler.source>
@@ -201,11 +201,12 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.12.1</version>
-          <!-- available from Java 9, but we went back to jdk8 for building
           <configuration>
-            <release>${java.version}</release>
+            <source>${java.version}</source>
+            <target>${java.version}</target>
+            <compilerVersion>${java.version}</compilerVersion>
+            <fork>true</fork>
           </configuration>
-      	  -->
         </plugin>
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <properties>
     <project.build.resourceEncoding>${project.build.sourceEncoding}</project.build.resourceEncoding>
-    <version.java>1.8</version.java>
+    <version.java>17</version.java>
     <java.version>${version.java}</java.version>
 
     <maven.compiler.source>${java.version}</maven.compiler.source>

--- a/spring-boot-starter-camunda/pom.xml
+++ b/spring-boot-starter-camunda/pom.xml
@@ -7,7 +7,6 @@
     <version>8.4.0-alpha3-rc1-SNAPSHOT</version>
   </parent>
 
-  <groupId>io.camunda.spring</groupId>
   <artifactId>spring-boot-starter-camunda</artifactId>
 
   <dependencies>
@@ -78,8 +77,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
           <compilerArgs>
             <arg>-parameters</arg>
           </compilerArgs>

--- a/spring-client-annotations/pom.xml
+++ b/spring-client-annotations/pom.xml
@@ -7,9 +7,6 @@
     <version>8.4.0-alpha3-rc1-SNAPSHOT</version>
   </parent>
 
-  <groupId>io.camunda.spring</groupId>
   <artifactId>spring-client-annotations</artifactId>
 
-  <dependencies>
-  </dependencies>
 </project>

--- a/spring-client-common/pom.xml
+++ b/spring-client-common/pom.xml
@@ -7,7 +7,6 @@
     <version>8.4.0-alpha3-rc1-SNAPSHOT</version>
   </parent>
 
-  <groupId>io.camunda.spring</groupId>
   <artifactId>spring-client-common</artifactId>
 
   <dependencies>

--- a/spring-client-zeebe/pom.xml
+++ b/spring-client-zeebe/pom.xml
@@ -7,7 +7,6 @@
     <version>8.4.0-alpha3-rc1-SNAPSHOT</version>
   </parent>
 
-  <groupId>io.camunda.spring</groupId>
   <artifactId>spring-client-zeebe</artifactId>
 
   <dependencies>
@@ -59,8 +58,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
           <compilerArgs>
             <arg>-parameters</arg>
           </compilerArgs>


### PR DESCRIPTION
closes #623 
closes #558 

It seems that the majority of the artefacts is still built for Java 8!

This PR leaves Java 17 in place and enforces that the according compiler version is used.