### PR TITLE
backport/8.4: fix(common-authentication): Token not refreshed

### DIFF
--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/Authentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/Authentication.java
@@ -4,7 +4,6 @@ import java.util.Map;
 
 public interface Authentication {
 
-
   Map.Entry<String, String> getTokenHeader(Product product);
 
   void resetToken(Product product);

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/Authentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/Authentication.java
@@ -4,9 +4,12 @@ import java.util.Map;
 
 public interface Authentication {
 
-  Authentication build();
 
   Map.Entry<String, String> getTokenHeader(Product product);
 
   void resetToken(Product product);
+
+  interface AuthenticationBuilder {
+    Authentication build();
+  }
 }

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/DefaultNoopAuthentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/DefaultNoopAuthentication.java
@@ -17,10 +17,8 @@ public class DefaultNoopAuthentication implements Authentication {
   private final String errorMessage =
       "Unable to determine authentication. Please check your configuration";
 
-  @Override
-  public Authentication build() {
+  public DefaultNoopAuthentication() {
     LOG.error(errorMessage);
-    return this;
   }
 
   @Override

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/JwtAuthentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/JwtAuthentication.java
@@ -1,24 +1,23 @@
 package io.camunda.common.auth;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.lang.invoke.MethodHandles;
 import java.time.LocalDateTime;
 import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class JwtAuthentication implements Authentication {
-  private static final Logger LOG = LoggerFactory.getLogger(MethodHandles
-    .lookup().lookupClass());
+  private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   private final JwtConfig jwtConfig;
   private final Map<Product, JwtToken> tokens = new HashMap<>();
 
-  protected JwtAuthentication(JwtConfig jwtConfig) {this.jwtConfig = jwtConfig;}
+  protected JwtAuthentication(JwtConfig jwtConfig) {
+    this.jwtConfig = jwtConfig;
+  }
 
   public JwtConfig getJwtConfig() {
     return jwtConfig;
@@ -28,10 +27,11 @@ public abstract class JwtAuthentication implements Authentication {
   public final void resetToken(Product product) {
     tokens.remove(product);
   }
+
   @Override
   public final Entry<String, String> getTokenHeader(Product product) {
     if (!tokens.containsKey(product) || !isValid(tokens.get(product))) {
-      JwtToken newToken = generateToken(product,jwtConfig.getProduct(product));
+      JwtToken newToken = generateToken(product, jwtConfig.getProduct(product));
       tokens.put(product, newToken);
     }
     return authHeader(tokens.get(product).getToken());
@@ -39,7 +39,7 @@ public abstract class JwtAuthentication implements Authentication {
 
   protected abstract JwtToken generateToken(Product product, JwtCredential credential);
 
-  private Entry<String,String> authHeader(String token){
+  private Entry<String, String> authHeader(String token) {
     return new AbstractMap.SimpleEntry<>("Authorization", "Bearer " + token);
   }
 
@@ -47,8 +47,6 @@ public abstract class JwtAuthentication implements Authentication {
     // a token is only counted valid if it is only valid for at least 30 seconds
     return jwtToken.getExpiry().isAfter(LocalDateTime.now().minusSeconds(30));
   }
-
-
 
   protected static class JwtToken {
     private final String token;

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/JwtAuthentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/JwtAuthentication.java
@@ -1,7 +1,66 @@
 package io.camunda.common.auth;
 
-/**
- * TODO: Figure out common functionality between SaaS and Self Managed that can be inserted here to
- * reduce code duplication. If not, remove this class
- */
-public abstract class JwtAuthentication implements Authentication {}
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
+import java.time.LocalDateTime;
+import java.util.AbstractMap;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+
+public abstract class JwtAuthentication implements Authentication {
+  private static final Logger LOG = LoggerFactory.getLogger(MethodHandles
+    .lookup().lookupClass());
+
+  private final JwtConfig jwtConfig;
+  private final Map<Product, JwtToken> tokens = new HashMap<>();
+
+  protected JwtAuthentication(JwtConfig jwtConfig) {this.jwtConfig = jwtConfig;}
+
+  @Override
+  public final void resetToken(Product product) {
+    tokens.remove(product);
+  }
+  @Override
+  public final Entry<String, String> getTokenHeader(Product product) {
+    if (!tokens.containsKey(product) || !isValid(tokens.get(product))) {
+      JwtToken newToken = generateToken(product,jwtConfig.getProduct(product));
+      tokens.put(product, newToken);
+    }
+    return authHeader(tokens.get(product).getToken());
+  }
+
+  protected abstract JwtToken generateToken(Product product, JwtCredential credential);
+
+  private Entry<String,String> authHeader(String token){
+    return new AbstractMap.SimpleEntry<>("Authorization", "Bearer " + token);
+  }
+
+  private boolean isValid(JwtToken jwtToken) {
+    // a token is only counted valid if it is only valid for at least 30 seconds
+    return jwtToken.getExpiry().isAfter(LocalDateTime.now().minusSeconds(30));
+  }
+
+
+
+  protected static class JwtToken {
+    private final String token;
+    private final LocalDateTime expiry;
+
+    public JwtToken(String token, LocalDateTime expiry) {
+      this.token = token;
+      this.expiry = expiry;
+    }
+
+    public String getToken() {
+      return token;
+    }
+
+    public LocalDateTime getExpiry() {
+      return expiry;
+    }
+  }
+}

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/JwtAuthentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/JwtAuthentication.java
@@ -20,6 +20,10 @@ public abstract class JwtAuthentication implements Authentication {
 
   protected JwtAuthentication(JwtConfig jwtConfig) {this.jwtConfig = jwtConfig;}
 
+  public JwtConfig getJwtConfig() {
+    return jwtConfig;
+  }
+
   @Override
   public final void resetToken(Product product) {
     tokens.remove(product);

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/JwtAuthenticationBuilder.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/JwtAuthenticationBuilder.java
@@ -1,0 +1,22 @@
+package io.camunda.common.auth;
+
+import io.camunda.common.auth.Authentication.AuthenticationBuilder;
+
+public abstract class JwtAuthenticationBuilder<
+    T extends JwtAuthenticationBuilder<?>> implements AuthenticationBuilder {
+  private JwtConfig jwtConfig;
+
+  public final T withJwtConfig(JwtConfig jwtConfig) {
+    this.jwtConfig = jwtConfig;
+    return self();
+  }
+
+  @Override
+  public final Authentication build() {
+    return build(jwtConfig);
+  }
+
+  protected abstract T self();
+
+  protected abstract Authentication build(JwtConfig jwtConfig);
+}

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/JwtAuthenticationBuilder.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/JwtAuthenticationBuilder.java
@@ -2,8 +2,8 @@ package io.camunda.common.auth;
 
 import io.camunda.common.auth.Authentication.AuthenticationBuilder;
 
-public abstract class JwtAuthenticationBuilder<
-    T extends JwtAuthenticationBuilder<?>> implements AuthenticationBuilder {
+public abstract class JwtAuthenticationBuilder<T extends JwtAuthenticationBuilder<?>>
+    implements AuthenticationBuilder {
   private JwtConfig jwtConfig;
 
   public final T withJwtConfig(JwtConfig jwtConfig) {

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/JwtConfig.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/JwtConfig.java
@@ -6,7 +6,7 @@ import java.util.Map;
 /** Contains mapping between products and their JWT credentials */
 public class JwtConfig {
 
-  private Map<Product, JwtCredential> map;
+  private final Map<Product, JwtCredential> map;
 
   public JwtConfig() {
     map = new HashMap<>();

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SaaSAuthentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SaaSAuthentication.java
@@ -1,7 +1,8 @@
 package io.camunda.common.auth;
 
 import io.camunda.common.json.JsonMapper;
-import io.camunda.common.json.SdkObjectMapper;
+import java.lang.invoke.MethodHandles;
+import java.time.LocalDateTime;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
@@ -9,12 +10,6 @@ import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.lang.invoke.MethodHandles;
-import java.time.LocalDateTime;
-import java.util.AbstractMap;
-import java.util.HashMap;
-import java.util.Map;
 
 public class SaaSAuthentication extends JwtAuthentication {
 
@@ -30,7 +25,6 @@ public class SaaSAuthentication extends JwtAuthentication {
   public static SaaSAuthenticationBuilder builder() {
     return new SaaSAuthenticationBuilder();
   }
-
 
   private TokenResponse retrieveToken(Product product, JwtCredential jwtCredential) {
     try (CloseableHttpClient client = HttpClients.createDefault()) {
@@ -56,8 +50,6 @@ public class SaaSAuthentication extends JwtAuthentication {
     httpPost.setEntity(new StringEntity(jsonMapper.toJson(tokenRequest)));
     return httpPost;
   }
-
-
 
   @Override
   protected JwtToken generateToken(Product product, JwtCredential credential) {

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SaaSAuthentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SaaSAuthentication.java
@@ -2,10 +2,6 @@ package io.camunda.common.auth;
 
 import io.camunda.common.json.JsonMapper;
 import io.camunda.common.json.SdkObjectMapper;
-import java.lang.invoke.MethodHandles;
-import java.util.AbstractMap;
-import java.util.HashMap;
-import java.util.Map;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
@@ -14,56 +10,39 @@ import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.invoke.MethodHandles;
+import java.time.LocalDateTime;
+import java.util.AbstractMap;
+import java.util.HashMap;
+import java.util.Map;
+
 public class SaaSAuthentication extends JwtAuthentication {
 
   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-  private JwtConfig jwtConfig;
-  private Map<Product, String> tokens;
 
-  // TODO: have a single object mapper to be used all throughout the SDK, i.e.bean injection
-  private JsonMapper jsonMapper = new SdkObjectMapper();
+  private final JsonMapper jsonMapper;
 
-  public SaaSAuthentication() {
-    tokens = new HashMap<>();
+  public SaaSAuthentication(JwtConfig jwtConfig, JsonMapper jsonMapper) {
+    super(jwtConfig);
+    this.jsonMapper = jsonMapper;
   }
 
   public static SaaSAuthenticationBuilder builder() {
     return new SaaSAuthenticationBuilder();
   }
 
-  public JwtConfig getJwtConfig() {
-    return jwtConfig;
-  }
 
-  public void setJwtConfig(JwtConfig jwtConfig) {
-    this.jwtConfig = jwtConfig;
-  }
-
-  @Override
-  public Authentication build() {
-    return this;
-  }
-
-  @Override
-  public void resetToken(Product product) {
-    tokens.remove(product);
-  }
-
-  private String retrieveToken(Product product, JwtCredential jwtCredential) {
+  private TokenResponse retrieveToken(Product product, JwtCredential jwtCredential) {
     try (CloseableHttpClient client = HttpClients.createDefault()) {
       HttpPost request = buildRequest(jwtCredential);
-      TokenResponse tokenResponse =
-          client.execute(
-              request,
-              response ->
-                  jsonMapper.fromJson(
-                      EntityUtils.toString(response.getEntity()), TokenResponse.class));
-      tokens.put(product, tokenResponse.getAccessToken());
+      return client.execute(
+          request,
+          response ->
+              jsonMapper.fromJson(EntityUtils.toString(response.getEntity()), TokenResponse.class));
     } catch (Exception e) {
       LOG.error("Authenticating for " + product + " failed due to " + e);
       throw new RuntimeException("Unable to authenticate", e);
     }
-    return tokens.get(product);
   }
 
   private HttpPost buildRequest(JwtCredential jwtCredential) {
@@ -78,15 +57,13 @@ public class SaaSAuthentication extends JwtAuthentication {
     return httpPost;
   }
 
+
+
   @Override
-  public Map.Entry<String, String> getTokenHeader(Product product) {
-    String token;
-    if (tokens.containsKey(product)) {
-      token = tokens.get(product);
-    } else {
-      JwtCredential jwtCredential = jwtConfig.getProduct(product);
-      token = retrieveToken(product, jwtCredential);
-    }
-    return new AbstractMap.SimpleEntry<>("Authorization", "Bearer " + token);
+  protected JwtToken generateToken(Product product, JwtCredential credential) {
+    TokenResponse tokenResponse = retrieveToken(product, credential);
+    return new JwtToken(
+        tokenResponse.getAccessToken(),
+        LocalDateTime.now().plusSeconds(tokenResponse.getExpiresIn()));
   }
 }

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SaaSAuthenticationBuilder.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SaaSAuthenticationBuilder.java
@@ -1,19 +1,22 @@
 package io.camunda.common.auth;
 
-public class SaaSAuthenticationBuilder {
+import io.camunda.common.json.JsonMapper;
 
-  SaaSAuthentication saaSAuthentication;
+public class SaaSAuthenticationBuilder extends JwtAuthenticationBuilder<SaaSAuthenticationBuilder> {
+  private JsonMapper jsonMapper;
 
-  SaaSAuthenticationBuilder() {
-    saaSAuthentication = new SaaSAuthentication();
-  }
-
-  public SaaSAuthenticationBuilder jwtConfig(JwtConfig jwtConfig) {
-    saaSAuthentication.setJwtConfig(jwtConfig);
+  public SaaSAuthenticationBuilder withJsonMapper(JsonMapper jsonMapper) {
+    this.jsonMapper = jsonMapper;
     return this;
   }
 
-  public Authentication build() {
-    return saaSAuthentication.build();
+  @Override
+  protected SaaSAuthenticationBuilder self() {
+    return this;
+  }
+
+  @Override
+  protected SaaSAuthentication build(JwtConfig jwtConfig) {
+    return new SaaSAuthentication(jwtConfig, jsonMapper);
   }
 }

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SelfManagedAuthentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SelfManagedAuthentication.java
@@ -4,6 +4,7 @@ import io.camunda.common.auth.identity.IdentityConfig;
 import io.camunda.identity.sdk.Identity;
 import io.camunda.identity.sdk.authentication.Tokens;
 import java.lang.invoke.MethodHandles;
+import java.time.LocalDateTime;
 import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.Map;
@@ -13,60 +14,28 @@ import org.slf4j.LoggerFactory;
 public class SelfManagedAuthentication extends JwtAuthentication {
 
   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-  private JwtConfig jwtConfig;
-  private IdentityConfig identityConfig;
-  private Map<Product, String> tokens;
+  private final IdentityConfig identityConfig;
 
-  public SelfManagedAuthentication() {
-    tokens = new HashMap<>();
+  public SelfManagedAuthentication(JwtConfig jwtConfig, IdentityConfig identityConfig) {
+    super(jwtConfig);
+    this.identityConfig = identityConfig;
   }
 
   public static SelfManagedAuthenticationBuilder builder() {
     return new SelfManagedAuthenticationBuilder();
   }
 
-  public JwtConfig getJwtConfig() {
-    return jwtConfig;
-  }
-
-  public void setJwtConfig(JwtConfig jwtConfig) {
-    this.jwtConfig = jwtConfig;
-  }
-
-  public void setIdentityConfig(IdentityConfig identityConfig) {
-    this.identityConfig = identityConfig;
-  }
-
   @Override
-  public Authentication build() {
-    return this;
+  protected JwtToken generateToken(Product product, JwtCredential credential) {
+    Tokens token = getIdentityToken(product, credential);
+    return new JwtToken(
+        token.getAccessToken(), LocalDateTime.now().plusSeconds(token.getExpiresIn()));
   }
 
-  @Override
-  public void resetToken(Product product) {
-    tokens.remove(product);
-  }
-
-  @Override
-  public Map.Entry<String, String> getTokenHeader(Product product) {
-    String token;
-    if (tokens.containsKey(product)) {
-      token = tokens.get(product);
-    } else {
-      token = getIdentityToken(product);
-      saveToken(product, token);
-    }
-    return new AbstractMap.SimpleEntry<>("Authorization", "Bearer " + token);
-  }
-
-  private String getIdentityToken(Product product) {
+  private Tokens getIdentityToken(Product product, JwtCredential credential) {
     Identity identity = identityConfig.get(product).getIdentity();
-    String audience = jwtConfig.getProduct(product).getAudience();
-    Tokens identityTokens = identity.authentication().requestToken(audience);
-    return identityTokens.getAccessToken();
+    String audience = credential.getAudience();
+    return identity.authentication().requestToken(audience);
   }
 
-  private void saveToken(Product product, String token) {
-    tokens.put(product, token);
-  }
 }

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SelfManagedAuthentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SelfManagedAuthentication.java
@@ -5,9 +5,6 @@ import io.camunda.identity.sdk.Identity;
 import io.camunda.identity.sdk.authentication.Tokens;
 import java.lang.invoke.MethodHandles;
 import java.time.LocalDateTime;
-import java.util.AbstractMap;
-import java.util.HashMap;
-import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,5 +34,4 @@ public class SelfManagedAuthentication extends JwtAuthentication {
     String audience = credential.getAudience();
     return identity.authentication().requestToken(audience);
   }
-
 }

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SelfManagedAuthenticationBuilder.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SelfManagedAuthenticationBuilder.java
@@ -2,25 +2,22 @@ package io.camunda.common.auth;
 
 import io.camunda.common.auth.identity.IdentityConfig;
 
-public class SelfManagedAuthenticationBuilder {
+public class SelfManagedAuthenticationBuilder
+    extends JwtAuthenticationBuilder<SelfManagedAuthenticationBuilder> {
+  private IdentityConfig identityConfig;
 
-  SelfManagedAuthentication selfManagedAuthentication;
-
-  SelfManagedAuthenticationBuilder() {
-    selfManagedAuthentication = new SelfManagedAuthentication();
-  }
-
-  public SelfManagedAuthenticationBuilder jwtConfig(JwtConfig jwtConfig) {
-    selfManagedAuthentication.setJwtConfig(jwtConfig);
+  public SelfManagedAuthenticationBuilder withIdentityConfig(IdentityConfig identityConfig) {
+    this.identityConfig = identityConfig;
     return this;
   }
 
-  public SelfManagedAuthenticationBuilder identityConfig(IdentityConfig identityConfig) {
-    selfManagedAuthentication.setIdentityConfig(identityConfig);
+  @Override
+  protected SelfManagedAuthenticationBuilder self() {
     return this;
   }
 
-  public Authentication build() {
-    return selfManagedAuthentication.build();
+  @Override
+  protected Authentication build(JwtConfig jwtConfig) {
+    return new SelfManagedAuthentication(jwtConfig, identityConfig);
   }
 }

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SimpleAuthentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SimpleAuthentication.java
@@ -1,7 +1,5 @@
 package io.camunda.common.auth;
 
-import java.lang.invoke.MethodHandles;
-import java.util.*;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.entity.UrlEncodedFormEntity;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
@@ -12,60 +10,42 @@ import org.apache.hc.core5.http.message.BasicNameValuePair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.invoke.MethodHandles;
+import java.util.*;
+
 public class SimpleAuthentication implements Authentication {
 
   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  private String simpleUrl;
-  private SimpleConfig simpleConfig;
-  private Map<Product, String> tokens;
+  private final SimpleConfig simpleConfig;
+  private final Map<Product, String> tokens = new HashMap<>();
 
-  private String authUrl;
+  private final String authUrl;
 
-  public void setSimpleUrl(String simpleUrl) {
-    this.simpleUrl = simpleUrl;
-  }
-
-  public SimpleConfig getSimpleConfig() {
-    return simpleConfig;
-  }
-
-  public void setSimpleConfig(SimpleConfig simpleConfig) {
+  public SimpleAuthentication(String simpleUrl, SimpleConfig simpleConfig) {
     this.simpleConfig = simpleConfig;
+    this.authUrl = simpleUrl+"/api/login";
   }
 
-  public SimpleAuthentication() {
-    tokens = new HashMap<>();
-  }
+  public static SimpleAuthenticationBuilder builder() { return new SimpleAuthenticationBuilder(); }
 
-  public static SimpleAuthenticationBuilder builder() {
-    return new SimpleAuthenticationBuilder();
-  }
 
-  @Override
-  public Authentication build() {
-    authUrl = simpleUrl + "/api/login";
-    return this;
-  }
 
   private String retrieveToken(Product product, SimpleCredential simpleCredential) {
-    try (CloseableHttpClient client = HttpClients.createDefault()) {
+    try(CloseableHttpClient client = HttpClients.createDefault()) {
       HttpPost request = buildRequest(simpleCredential);
-      String cookie =
-          client.execute(
-              request,
-              response -> {
-                Header[] cookieHeaders = response.getHeaders("Set-Cookie");
-                String cookieCandidate = null;
-                String cookiePrefix = product.toString().toUpperCase() + "-SESSION";
-                for (Header cookieHeader : cookieHeaders) {
-                  if (cookieHeader.getValue().startsWith(cookiePrefix)) {
-                    cookieCandidate = response.getHeader("Set-Cookie").getValue();
-                    break;
-                  }
-                }
-                return cookieCandidate;
-              });
+      String cookie = client.execute(request, response -> {
+        Header[] cookieHeaders = response.getHeaders("Set-Cookie");
+        String cookieCandidate = null;
+        String cookiePrefix = product.toString().toUpperCase() + "-SESSION";
+        for (Header cookieHeader : cookieHeaders) {
+          if (cookieHeader.getValue().startsWith(cookiePrefix)) {
+            cookieCandidate = response.getHeader("Set-Cookie").getValue();
+            break;
+          }
+        }
+        return cookieCandidate;
+      });
       if (cookie == null) {
         throw new RuntimeException("Unable to authenticate due to missing Set-Cookie");
       }
@@ -86,7 +66,7 @@ public class SimpleAuthentication implements Authentication {
     return httpPost;
   }
 
-  @Override
+    @Override
   public Map.Entry<String, String> getTokenHeader(Product product) {
     String token;
     if (tokens.containsKey(product)) {

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SimpleAuthentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SimpleAuthentication.java
@@ -1,5 +1,7 @@
 package io.camunda.common.auth;
 
+import java.lang.invoke.MethodHandles;
+import java.util.*;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.entity.UrlEncodedFormEntity;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
@@ -9,9 +11,6 @@ import org.apache.hc.core5.http.NameValuePair;
 import org.apache.hc.core5.http.message.BasicNameValuePair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.lang.invoke.MethodHandles;
-import java.util.*;
 
 public class SimpleAuthentication implements Authentication {
 
@@ -24,30 +23,35 @@ public class SimpleAuthentication implements Authentication {
 
   public SimpleAuthentication(String simpleUrl, SimpleConfig simpleConfig) {
     this.simpleConfig = simpleConfig;
-    this.authUrl = simpleUrl+"/api/login";
+    this.authUrl = simpleUrl + "/api/login";
   }
 
-  public static SimpleAuthenticationBuilder builder() { return new SimpleAuthenticationBuilder(); }
+  public static SimpleAuthenticationBuilder builder() {
+    return new SimpleAuthenticationBuilder();
+  }
 
   public SimpleConfig getSimpleConfig() {
     return simpleConfig;
   }
 
   private String retrieveToken(Product product, SimpleCredential simpleCredential) {
-    try(CloseableHttpClient client = HttpClients.createDefault()) {
+    try (CloseableHttpClient client = HttpClients.createDefault()) {
       HttpPost request = buildRequest(simpleCredential);
-      String cookie = client.execute(request, response -> {
-        Header[] cookieHeaders = response.getHeaders("Set-Cookie");
-        String cookieCandidate = null;
-        String cookiePrefix = product.toString().toUpperCase() + "-SESSION";
-        for (Header cookieHeader : cookieHeaders) {
-          if (cookieHeader.getValue().startsWith(cookiePrefix)) {
-            cookieCandidate = response.getHeader("Set-Cookie").getValue();
-            break;
-          }
-        }
-        return cookieCandidate;
-      });
+      String cookie =
+          client.execute(
+              request,
+              response -> {
+                Header[] cookieHeaders = response.getHeaders("Set-Cookie");
+                String cookieCandidate = null;
+                String cookiePrefix = product.toString().toUpperCase() + "-SESSION";
+                for (Header cookieHeader : cookieHeaders) {
+                  if (cookieHeader.getValue().startsWith(cookiePrefix)) {
+                    cookieCandidate = response.getHeader("Set-Cookie").getValue();
+                    break;
+                  }
+                }
+                return cookieCandidate;
+              });
       if (cookie == null) {
         throw new RuntimeException("Unable to authenticate due to missing Set-Cookie");
       }
@@ -68,7 +72,7 @@ public class SimpleAuthentication implements Authentication {
     return httpPost;
   }
 
-    @Override
+  @Override
   public Map.Entry<String, String> getTokenHeader(Product product) {
     String token;
     if (tokens.containsKey(product)) {

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SimpleAuthentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SimpleAuthentication.java
@@ -29,7 +29,9 @@ public class SimpleAuthentication implements Authentication {
 
   public static SimpleAuthenticationBuilder builder() { return new SimpleAuthenticationBuilder(); }
 
-
+  public SimpleConfig getSimpleConfig() {
+    return simpleConfig;
+  }
 
   private String retrieveToken(Product product, SimpleCredential simpleCredential) {
     try(CloseableHttpClient client = HttpClients.createDefault()) {

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SimpleAuthenticationBuilder.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SimpleAuthenticationBuilder.java
@@ -1,24 +1,24 @@
 package io.camunda.common.auth;
 
-public class SimpleAuthenticationBuilder {
+import io.camunda.common.auth.Authentication.AuthenticationBuilder;
 
-  SimpleAuthentication simpleAuthentication;
+public class SimpleAuthenticationBuilder implements AuthenticationBuilder {
+  private String simpleUrl;
+  private SimpleConfig simpleConfig;
 
-  SimpleAuthenticationBuilder() {
-    simpleAuthentication = new SimpleAuthentication();
-  }
-
-  public SimpleAuthenticationBuilder simpleConfig(SimpleConfig simpleConfig) {
-    simpleAuthentication.setSimpleConfig(simpleConfig);
+  public SimpleAuthenticationBuilder withSimpleUrl(String simpleUrl){
+    this.simpleUrl = simpleUrl;
     return this;
   }
 
-  public SimpleAuthenticationBuilder simpleUrl(String simpleUrl) {
-    simpleAuthentication.setSimpleUrl(simpleUrl);
+  public SimpleAuthenticationBuilder withSimpleConfig(SimpleConfig simpleConfig){
+    this.simpleConfig = simpleConfig;
     return this;
   }
 
+
+  @Override
   public Authentication build() {
-    return simpleAuthentication.build();
+    return new SimpleAuthentication(simpleUrl,simpleConfig);
   }
 }

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SimpleAuthenticationBuilder.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SimpleAuthenticationBuilder.java
@@ -6,19 +6,18 @@ public class SimpleAuthenticationBuilder implements AuthenticationBuilder {
   private String simpleUrl;
   private SimpleConfig simpleConfig;
 
-  public SimpleAuthenticationBuilder withSimpleUrl(String simpleUrl){
+  public SimpleAuthenticationBuilder withSimpleUrl(String simpleUrl) {
     this.simpleUrl = simpleUrl;
     return this;
   }
 
-  public SimpleAuthenticationBuilder withSimpleConfig(SimpleConfig simpleConfig){
+  public SimpleAuthenticationBuilder withSimpleConfig(SimpleConfig simpleConfig) {
     this.simpleConfig = simpleConfig;
     return this;
   }
 
-
   @Override
   public Authentication build() {
-    return new SimpleAuthentication(simpleUrl,simpleConfig);
+    return new SimpleAuthentication(simpleUrl, simpleConfig);
   }
 }

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SimpleConfig.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SimpleConfig.java
@@ -6,7 +6,7 @@ import java.util.Map;
 /** Contains mapping between products and their Simple credentials */
 public class SimpleConfig {
 
-  private Map<Product, SimpleCredential> map;
+  private final Map<Product, SimpleCredential> map;
 
   public SimpleConfig() {
     map = new HashMap<>();

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/CamundaAutoConfiguration.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/CamundaAutoConfiguration.java
@@ -4,6 +4,7 @@ import static com.fasterxml.jackson.databind.DeserializationFeature.ACCEPT_EMPTY
 import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.common.json.SdkObjectMapper;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
@@ -36,18 +37,17 @@ import org.springframework.context.annotation.Configuration;
         .class) // make sure Spring created ObjectMapper is preferred if available
 public class CamundaAutoConfiguration {
 
-  private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-
   public static final ObjectMapper DEFAULT_OBJECT_MAPPER =
       new ObjectMapper()
           .configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
           .configure(ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT, true);
+  private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   @Bean
   @ConditionalOnMissingBean(
       SpringZeebeTestContext
           .class) // only run if we are not running in a test case - as otherwise the the lifecycle
-  // is controlled by the test
+                  // is controlled by the test
   public ZeebeLifecycleEventProducer zeebeLifecycleEventProducer(
       final ZeebeClient client, final ApplicationEventPublisher publisher) {
     return new ZeebeLifecycleEventProducer(client, publisher);
@@ -69,5 +69,12 @@ public class CamundaAutoConfiguration {
   @ConditionalOnMissingBean
   public JsonMapper jsonMapper(ObjectMapper objectMapper) {
     return new ZeebeObjectMapper(objectMapper);
+  }
+
+
+  @Bean(name = "commonJsonMapper")
+  @ConditionalOnMissingBean
+  public io.camunda.common.json.JsonMapper commonJsonMapper(ObjectMapper objectMapper) {
+    return new SdkObjectMapper(objectMapper);
   }
 }

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/CamundaAutoConfiguration.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/CamundaAutoConfiguration.java
@@ -47,7 +47,7 @@ public class CamundaAutoConfiguration {
   @ConditionalOnMissingBean(
       SpringZeebeTestContext
           .class) // only run if we are not running in a test case - as otherwise the the lifecycle
-                  // is controlled by the test
+  // is controlled by the test
   public ZeebeLifecycleEventProducer zeebeLifecycleEventProducer(
       final ZeebeClient client, final ApplicationEventPublisher publisher) {
     return new ZeebeLifecycleEventProducer(client, publisher);
@@ -70,7 +70,6 @@ public class CamundaAutoConfiguration {
   public JsonMapper jsonMapper(ObjectMapper objectMapper) {
     return new ZeebeObjectMapper(objectMapper);
   }
-
 
   @Bean(name = "commonJsonMapper")
   @ConditionalOnMissingBean

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/CommonClientConfiguration.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/CommonClientConfiguration.java
@@ -4,6 +4,7 @@ import io.camunda.common.auth.*;
 import io.camunda.common.auth.identity.IdentityContainer;
 import io.camunda.common.auth.identity.IdentityConfig;
 import io.camunda.common.exception.SdkException;
+import io.camunda.common.json.JsonMapper;
 import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.identity.sdk.Identity;
 import io.camunda.zeebe.spring.client.properties.*;
@@ -42,7 +43,7 @@ public class CommonClientConfiguration {
   private IdentityConfiguration identityConfigurationFromProperties;
 
   @Bean
-  public Authentication authentication() {
+  public Authentication authentication(JsonMapper jsonMapper) {
 
     // TODO: Refactor
     if (zeebeClientConfigurationProperties != null) {
@@ -50,6 +51,7 @@ public class CommonClientConfiguration {
       if (zeebeClientConfigurationProperties.getCloud().getClusterId() != null) {
         return SaaSAuthentication.builder()
           .withJwtConfig(configureJwtConfig())
+          .withJsonMapper(jsonMapper)
           .build();
       } else if (zeebeClientConfigurationProperties.getBroker().getGatewayAddress() != null || zeebeSelfManagedProperties.getGatewayAddress() != null) {
         // figure out if Self-Managed JWT or Self-Managed Basic

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/CommonClientConfiguration.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/CommonClientConfiguration.java
@@ -1,23 +1,21 @@
 package io.camunda.zeebe.spring.client.configuration;
 
-import static org.springframework.util.StringUtils.hasText;
-
 import io.camunda.common.auth.*;
-import io.camunda.common.auth.identity.IdentityConfig;
 import io.camunda.common.auth.identity.IdentityContainer;
+import io.camunda.common.auth.identity.IdentityConfig;
 import io.camunda.common.exception.SdkException;
-import io.camunda.identity.sdk.Identity;
 import io.camunda.identity.sdk.IdentityConfiguration;
+import io.camunda.identity.sdk.Identity;
 import io.camunda.zeebe.spring.client.properties.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 
-@EnableConfigurationProperties({
-  CommonConfigurationProperties.class,
-  ZeebeSelfManagedProperties.class
-})
+import static org.springframework.util.StringUtils.hasText;
+
+@EnableConfigurationProperties({CommonConfigurationProperties.class, ZeebeSelfManagedProperties.class})
 public class CommonClientConfiguration {
+
 
   @Autowired(required = false)
   CommonConfigurationProperties commonConfigurationProperties;
@@ -50,32 +48,28 @@ public class CommonClientConfiguration {
     if (zeebeClientConfigurationProperties != null) {
       // check if Zeebe has clusterId provided, then must be SaaS
       if (zeebeClientConfigurationProperties.getCloud().getClusterId() != null) {
-        return SaaSAuthentication.builder().jwtConfig(configureJwtConfig()).build();
-      } else if (zeebeClientConfigurationProperties.getBroker().getGatewayAddress() != null
-          || zeebeSelfManagedProperties.getGatewayAddress() != null) {
+        return SaaSAuthentication.builder()
+          .withJwtConfig(configureJwtConfig())
+          .build();
+      } else if (zeebeClientConfigurationProperties.getBroker().getGatewayAddress() != null || zeebeSelfManagedProperties.getGatewayAddress() != null) {
         // figure out if Self-Managed JWT or Self-Managed Basic
         // Operate Client props take first priority
         if (operateClientConfigurationProperties != null) {
-          if (hasText(operateClientConfigurationProperties.getKeycloakUrl())
-              || hasText(operateClientConfigurationProperties.getKeycloakTokenUrl())) {
+          if (hasText(operateClientConfigurationProperties.getKeycloakUrl()) || hasText(operateClientConfigurationProperties.getKeycloakTokenUrl())) {
             JwtConfig jwtConfig = configureJwtConfig();
             IdentityConfig identityConfig = configureIdentities(jwtConfig);
             return SelfManagedAuthentication.builder()
-                .jwtConfig(jwtConfig)
-                .identityConfig(identityConfig)
-                .build();
-          } else if (operateClientConfigurationProperties.getUsername() != null
-              && operateClientConfigurationProperties.getPassword() != null) {
+              .withJwtConfig(jwtConfig)
+              .withIdentityConfig(identityConfig)
+              .build();
+          } else if (operateClientConfigurationProperties.getUsername() != null && operateClientConfigurationProperties.getPassword() != null) {
             SimpleConfig simpleConfig = new SimpleConfig();
-            SimpleCredential simpleCredential =
-                new SimpleCredential(
-                    operateClientConfigurationProperties.getUsername(),
-                    operateClientConfigurationProperties.getPassword());
+            SimpleCredential simpleCredential = new SimpleCredential(operateClientConfigurationProperties.getUsername(), operateClientConfigurationProperties.getPassword());
             simpleConfig.addProduct(Product.OPERATE, simpleCredential);
             return SimpleAuthentication.builder()
-                .simpleConfig(simpleConfig)
-                .simpleUrl(operateClientConfigurationProperties.getUrl())
-                .build();
+              .withSimpleConfig(simpleConfig)
+              .withSimpleUrl(operateClientConfigurationProperties.getUrl())
+              .build();
           }
         }
 
@@ -85,9 +79,9 @@ public class CommonClientConfiguration {
             JwtConfig jwtConfig = configureJwtConfig();
             IdentityConfig identityConfig = configureIdentities(jwtConfig);
             return SelfManagedAuthentication.builder()
-                .jwtConfig(jwtConfig)
-                .identityConfig(identityConfig)
-                .build();
+              .withJwtConfig(jwtConfig)
+              .withIdentityConfig(identityConfig)
+              .build();
           }
         }
 
@@ -97,65 +91,55 @@ public class CommonClientConfiguration {
             JwtConfig jwtConfig = configureJwtConfig();
             IdentityConfig identityConfig = configureIdentities(jwtConfig);
             return SelfManagedAuthentication.builder()
-                .jwtConfig(jwtConfig)
-                .identityConfig(identityConfig)
-                .build();
+              .withJwtConfig(jwtConfig)
+              .withIdentityConfig(identityConfig)
+              .build();
           } else if (commonConfigurationProperties.getKeycloak().getTokenUrl() != null) {
             JwtConfig jwtConfig = configureJwtConfig();
             IdentityConfig identityConfig = configureIdentities(jwtConfig);
             return SelfManagedAuthentication.builder()
-                .jwtConfig(jwtConfig)
-                .identityConfig(identityConfig)
-                .build();
-          } else if (commonConfigurationProperties.getUsername() != null
-              && commonConfigurationProperties.getPassword() != null) {
+              .withJwtConfig(jwtConfig)
+              .withIdentityConfig(identityConfig)
+              .build();
+          } else if (commonConfigurationProperties.getUsername() != null && commonConfigurationProperties.getPassword() != null) {
             SimpleConfig simpleConfig = new SimpleConfig();
-            SimpleCredential simpleCredential =
-                new SimpleCredential(
-                    commonConfigurationProperties.getUsername(),
-                    commonConfigurationProperties.getPassword());
+            SimpleCredential simpleCredential = new SimpleCredential(commonConfigurationProperties.getUsername(), commonConfigurationProperties.getPassword());
             simpleConfig.addProduct(Product.OPERATE, simpleCredential);
             return SimpleAuthentication.builder()
-                .simpleConfig(simpleConfig)
-                .simpleUrl(commonConfigurationProperties.getUrl())
-                .build();
+              .withSimpleConfig(simpleConfig)
+              .withSimpleUrl(commonConfigurationProperties.getUrl())
+              .build();
           }
         }
       }
     }
-    return new DefaultNoopAuthentication().build();
+    return new DefaultNoopAuthentication();
   }
 
   private JwtConfig configureJwtConfig() {
     JwtConfig jwtConfig = new JwtConfig();
     // ZEEBE
-    if (zeebeClientConfigurationProperties.getCloud().getClientId() != null
-        && zeebeClientConfigurationProperties.getCloud().getClientSecret() != null) {
-      jwtConfig.addProduct(
-          Product.ZEEBE,
-          new JwtCredential(
-              zeebeClientConfigurationProperties.getCloud().getClientId(),
-              zeebeClientConfigurationProperties.getCloud().getClientSecret(),
-              zeebeClientConfigurationProperties.getCloud().getAudience(),
-              zeebeClientConfigurationProperties.getCloud().getAuthUrl()));
-    } else if (zeebeSelfManagedProperties.getClientId() != null
-        && zeebeSelfManagedProperties.getClientSecret() != null) {
-      jwtConfig.addProduct(
-          Product.ZEEBE,
-          new JwtCredential(
-              zeebeSelfManagedProperties.getClientId(),
-              zeebeSelfManagedProperties.getClientSecret(),
-              zeebeSelfManagedProperties.getAudience(),
-              zeebeSelfManagedProperties.getAuthServer()));
-    } else if (commonConfigurationProperties.getClientId() != null
-        && commonConfigurationProperties.getClientSecret() != null) {
-      jwtConfig.addProduct(
-          Product.ZEEBE,
-          new JwtCredential(
-              commonConfigurationProperties.getClientId(),
-              commonConfigurationProperties.getClientSecret(),
-              zeebeClientConfigurationProperties.getCloud().getAudience(),
-              zeebeClientConfigurationProperties.getCloud().getAuthUrl()));
+    if (zeebeClientConfigurationProperties.getCloud().getClientId() != null && zeebeClientConfigurationProperties.getCloud().getClientSecret() != null) {
+      jwtConfig.addProduct(Product.ZEEBE, new JwtCredential(
+        zeebeClientConfigurationProperties.getCloud().getClientId(),
+        zeebeClientConfigurationProperties.getCloud().getClientSecret(),
+        zeebeClientConfigurationProperties.getCloud().getAudience(),
+        zeebeClientConfigurationProperties.getCloud().getAuthUrl())
+      );
+    } else if (zeebeSelfManagedProperties.getClientId() != null && zeebeSelfManagedProperties.getClientSecret() != null) {
+      jwtConfig.addProduct(Product.ZEEBE, new JwtCredential(
+        zeebeSelfManagedProperties.getClientId(),
+        zeebeSelfManagedProperties.getClientSecret(),
+        zeebeSelfManagedProperties.getAudience(),
+        zeebeSelfManagedProperties.getAuthServer())
+      );
+    } else if (commonConfigurationProperties.getClientId() != null && commonConfigurationProperties.getClientSecret() != null) {
+      jwtConfig.addProduct(Product.ZEEBE, new JwtCredential(
+        commonConfigurationProperties.getClientId(),
+        commonConfigurationProperties.getClientSecret(),
+        zeebeClientConfigurationProperties.getCloud().getAudience(),
+        zeebeClientConfigurationProperties.getCloud().getAuthUrl())
+      );
     }
 
     // OPERATE
@@ -167,64 +151,30 @@ public class CommonClientConfiguration {
         operateAuthUrl = operateClientConfigurationProperties.getAuthUrl();
       } else if (hasText(operateClientConfigurationProperties.getKeycloakTokenUrl())) {
         operateAuthUrl = operateClientConfigurationProperties.getKeycloakTokenUrl();
-      } else if (hasText(operateClientConfigurationProperties.getKeycloakUrl())
-          && hasText(operateClientConfigurationProperties.getKeycloakRealm())) {
-        operateAuthUrl =
-            operateClientConfigurationProperties.getKeycloakUrl()
-                + "/auth/realms/"
-                + operateClientConfigurationProperties.getKeycloakRealm();
+      } else if (hasText(operateClientConfigurationProperties.getKeycloakUrl()) && hasText(operateClientConfigurationProperties.getKeycloakRealm())) {
+        operateAuthUrl = operateClientConfigurationProperties.getKeycloakUrl()+"/auth/realms/"+operateClientConfigurationProperties.getKeycloakRealm();
       }
 
       if (operateClientConfigurationProperties.getBaseUrl() != null) {
         operateAudience = operateClientConfigurationProperties.getBaseUrl();
       }
 
-      if (operateClientConfigurationProperties.getClientId() != null
-          && operateClientConfigurationProperties.getClientSecret() != null) {
-        jwtConfig.addProduct(
-            Product.OPERATE,
-            new JwtCredential(
-                operateClientConfigurationProperties.getClientId(),
-                operateClientConfigurationProperties.getClientSecret(),
-                operateAudience,
-                operateAuthUrl));
-      } else if (identityConfigurationFromProperties != null
-          && hasText(identityConfigurationFromProperties.getClientId())
-          && hasText(identityConfigurationFromProperties.getClientSecret())) {
-        jwtConfig.addProduct(
-            Product.OPERATE,
-            new JwtCredential(
-                identityConfigurationFromProperties.getClientId(),
-                identityConfigurationFromProperties.getClientSecret(),
-                identityConfigurationFromProperties.getAudience(),
-                identityConfigurationFromProperties.getIssuerBackendUrl()));
-      } else if (commonConfigurationProperties.getClientId() != null
-          && commonConfigurationProperties.getClientSecret() != null) {
-        jwtConfig.addProduct(
-            Product.OPERATE,
-            new JwtCredential(
-                commonConfigurationProperties.getClientId(),
-                commonConfigurationProperties.getClientSecret(),
-                operateAudience,
-                operateAuthUrl));
-      } else if (zeebeClientConfigurationProperties.getCloud().getClientId() != null
-          && zeebeClientConfigurationProperties.getCloud().getClientSecret() != null) {
-        jwtConfig.addProduct(
-            Product.OPERATE,
-            new JwtCredential(
-                zeebeClientConfigurationProperties.getCloud().getClientId(),
-                zeebeClientConfigurationProperties.getCloud().getClientSecret(),
-                operateAudience,
-                operateAuthUrl));
-      } else if (zeebeSelfManagedProperties.getClientId() != null
-          && zeebeSelfManagedProperties.getClientSecret() != null) {
-        jwtConfig.addProduct(
-            Product.OPERATE,
-            new JwtCredential(
-                zeebeSelfManagedProperties.getClientId(),
-                zeebeSelfManagedProperties.getClientSecret(),
-                operateAudience,
-                operateAuthUrl));
+      if (operateClientConfigurationProperties.getClientId() != null && operateClientConfigurationProperties.getClientSecret() != null) {
+        jwtConfig.addProduct(Product.OPERATE, new JwtCredential(operateClientConfigurationProperties.getClientId(), operateClientConfigurationProperties.getClientSecret(), operateAudience, operateAuthUrl));
+      } else if (identityConfigurationFromProperties != null && hasText(identityConfigurationFromProperties.getClientId()) && hasText(identityConfigurationFromProperties.getClientSecret())) {
+        jwtConfig.addProduct(Product.OPERATE, new JwtCredential(identityConfigurationFromProperties.getClientId(), identityConfigurationFromProperties.getClientSecret(), identityConfigurationFromProperties.getAudience(), identityConfigurationFromProperties.getIssuerBackendUrl()));
+      }
+      else if (commonConfigurationProperties.getClientId() != null && commonConfigurationProperties.getClientSecret() != null) {
+        jwtConfig.addProduct(Product.OPERATE, new JwtCredential(
+          commonConfigurationProperties.getClientId(),
+          commonConfigurationProperties.getClientSecret(),
+          operateAudience,
+          operateAuthUrl)
+        );
+      } else if (zeebeClientConfigurationProperties.getCloud().getClientId() != null && zeebeClientConfigurationProperties.getCloud().getClientSecret() != null) {
+        jwtConfig.addProduct(Product.OPERATE, new JwtCredential(zeebeClientConfigurationProperties.getCloud().getClientId(), zeebeClientConfigurationProperties.getCloud().getClientSecret(), operateAudience, operateAuthUrl));
+      } else if (zeebeSelfManagedProperties.getClientId() != null && zeebeSelfManagedProperties.getClientSecret() != null) {
+        jwtConfig.addProduct(Product.OPERATE, new JwtCredential(zeebeSelfManagedProperties.getClientId(), zeebeSelfManagedProperties.getClientSecret(), operateAudience, operateAuthUrl));
       } else {
         throw new SdkException("Unable to determine OPERATE credentials");
       }
@@ -245,9 +195,8 @@ public class CommonClientConfiguration {
   }
 
   /**
-   * Identity properties supplied by the user are optional, so if they don't exist, we have to
-   * backfill them from somewhere like the OperateClientConfigurationProperties.
-   *
+   * Identity properties supplied by the user are optional, so if they don't exist, we have to backfill them from somewhere
+   * like the OperateClientConfigurationProperties.
    * @param jwtConfig
    * @return
    */
@@ -266,16 +215,15 @@ public class CommonClientConfiguration {
       issuerBackendUrl = jwtConfig.getProduct(Product.OPERATE).getAuthUrl();
     }
 
-    IdentityConfiguration operateIdentityConfiguration =
-        new IdentityConfiguration.Builder()
-            .withBaseUrl(identityConfigurationFromProperties.getBaseUrl())
-            .withIssuer(issuer)
-            .withIssuerBackendUrl(issuerBackendUrl)
-            .withClientId(jwtConfig.getProduct(Product.OPERATE).getClientId())
-            .withClientSecret(jwtConfig.getProduct(Product.OPERATE).getClientSecret())
-            .withAudience(jwtConfig.getProduct(Product.OPERATE).getAudience())
-            .withType(identityConfigurationFromProperties.getType().name())
-            .build();
+    IdentityConfiguration operateIdentityConfiguration = new IdentityConfiguration.Builder()
+      .withBaseUrl(identityConfigurationFromProperties.getBaseUrl())
+      .withIssuer(issuer)
+      .withIssuerBackendUrl(issuerBackendUrl)
+      .withClientId(jwtConfig.getProduct(Product.OPERATE).getClientId())
+      .withClientSecret(jwtConfig.getProduct(Product.OPERATE).getClientSecret())
+      .withAudience(jwtConfig.getProduct(Product.OPERATE).getAudience())
+      .withType(identityConfigurationFromProperties.getType().name())
+      .build();
     Identity operateIdentity = new Identity(operateIdentityConfiguration);
     return new IdentityContainer(operateIdentity, operateIdentityConfiguration);
   }

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/CommonClientConfiguration.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/CommonClientConfiguration.java
@@ -1,22 +1,24 @@
 package io.camunda.zeebe.spring.client.configuration;
 
+import static org.springframework.util.StringUtils.hasText;
+
 import io.camunda.common.auth.*;
-import io.camunda.common.auth.identity.IdentityContainer;
 import io.camunda.common.auth.identity.IdentityConfig;
+import io.camunda.common.auth.identity.IdentityContainer;
 import io.camunda.common.exception.SdkException;
 import io.camunda.common.json.JsonMapper;
-import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.identity.sdk.Identity;
+import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.zeebe.spring.client.properties.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 
-import static org.springframework.util.StringUtils.hasText;
-
-@EnableConfigurationProperties({CommonConfigurationProperties.class, ZeebeSelfManagedProperties.class})
+@EnableConfigurationProperties({
+  CommonConfigurationProperties.class,
+  ZeebeSelfManagedProperties.class
+})
 public class CommonClientConfiguration {
-
 
   @Autowired(required = false)
   CommonConfigurationProperties commonConfigurationProperties;
@@ -50,28 +52,34 @@ public class CommonClientConfiguration {
       // check if Zeebe has clusterId provided, then must be SaaS
       if (zeebeClientConfigurationProperties.getCloud().getClusterId() != null) {
         return SaaSAuthentication.builder()
-          .withJwtConfig(configureJwtConfig())
-          .withJsonMapper(jsonMapper)
-          .build();
-      } else if (zeebeClientConfigurationProperties.getBroker().getGatewayAddress() != null || zeebeSelfManagedProperties.getGatewayAddress() != null) {
+            .withJwtConfig(configureJwtConfig())
+            .withJsonMapper(jsonMapper)
+            .build();
+      } else if (zeebeClientConfigurationProperties.getBroker().getGatewayAddress() != null
+          || zeebeSelfManagedProperties.getGatewayAddress() != null) {
         // figure out if Self-Managed JWT or Self-Managed Basic
         // Operate Client props take first priority
         if (operateClientConfigurationProperties != null) {
-          if (hasText(operateClientConfigurationProperties.getKeycloakUrl()) || hasText(operateClientConfigurationProperties.getKeycloakTokenUrl())) {
+          if (hasText(operateClientConfigurationProperties.getKeycloakUrl())
+              || hasText(operateClientConfigurationProperties.getKeycloakTokenUrl())) {
             JwtConfig jwtConfig = configureJwtConfig();
             IdentityConfig identityConfig = configureIdentities(jwtConfig);
             return SelfManagedAuthentication.builder()
-              .withJwtConfig(jwtConfig)
-              .withIdentityConfig(identityConfig)
-              .build();
-          } else if (operateClientConfigurationProperties.getUsername() != null && operateClientConfigurationProperties.getPassword() != null) {
+                .withJwtConfig(jwtConfig)
+                .withIdentityConfig(identityConfig)
+                .build();
+          } else if (operateClientConfigurationProperties.getUsername() != null
+              && operateClientConfigurationProperties.getPassword() != null) {
             SimpleConfig simpleConfig = new SimpleConfig();
-            SimpleCredential simpleCredential = new SimpleCredential(operateClientConfigurationProperties.getUsername(), operateClientConfigurationProperties.getPassword());
+            SimpleCredential simpleCredential =
+                new SimpleCredential(
+                    operateClientConfigurationProperties.getUsername(),
+                    operateClientConfigurationProperties.getPassword());
             simpleConfig.addProduct(Product.OPERATE, simpleCredential);
             return SimpleAuthentication.builder()
-              .withSimpleConfig(simpleConfig)
-              .withSimpleUrl(operateClientConfigurationProperties.getUrl())
-              .build();
+                .withSimpleConfig(simpleConfig)
+                .withSimpleUrl(operateClientConfigurationProperties.getUrl())
+                .build();
           }
         }
 
@@ -81,9 +89,9 @@ public class CommonClientConfiguration {
             JwtConfig jwtConfig = configureJwtConfig();
             IdentityConfig identityConfig = configureIdentities(jwtConfig);
             return SelfManagedAuthentication.builder()
-              .withJwtConfig(jwtConfig)
-              .withIdentityConfig(identityConfig)
-              .build();
+                .withJwtConfig(jwtConfig)
+                .withIdentityConfig(identityConfig)
+                .build();
           }
         }
 
@@ -93,24 +101,28 @@ public class CommonClientConfiguration {
             JwtConfig jwtConfig = configureJwtConfig();
             IdentityConfig identityConfig = configureIdentities(jwtConfig);
             return SelfManagedAuthentication.builder()
-              .withJwtConfig(jwtConfig)
-              .withIdentityConfig(identityConfig)
-              .build();
+                .withJwtConfig(jwtConfig)
+                .withIdentityConfig(identityConfig)
+                .build();
           } else if (commonConfigurationProperties.getKeycloak().getTokenUrl() != null) {
             JwtConfig jwtConfig = configureJwtConfig();
             IdentityConfig identityConfig = configureIdentities(jwtConfig);
             return SelfManagedAuthentication.builder()
-              .withJwtConfig(jwtConfig)
-              .withIdentityConfig(identityConfig)
-              .build();
-          } else if (commonConfigurationProperties.getUsername() != null && commonConfigurationProperties.getPassword() != null) {
+                .withJwtConfig(jwtConfig)
+                .withIdentityConfig(identityConfig)
+                .build();
+          } else if (commonConfigurationProperties.getUsername() != null
+              && commonConfigurationProperties.getPassword() != null) {
             SimpleConfig simpleConfig = new SimpleConfig();
-            SimpleCredential simpleCredential = new SimpleCredential(commonConfigurationProperties.getUsername(), commonConfigurationProperties.getPassword());
+            SimpleCredential simpleCredential =
+                new SimpleCredential(
+                    commonConfigurationProperties.getUsername(),
+                    commonConfigurationProperties.getPassword());
             simpleConfig.addProduct(Product.OPERATE, simpleCredential);
             return SimpleAuthentication.builder()
-              .withSimpleConfig(simpleConfig)
-              .withSimpleUrl(commonConfigurationProperties.getUrl())
-              .build();
+                .withSimpleConfig(simpleConfig)
+                .withSimpleUrl(commonConfigurationProperties.getUrl())
+                .build();
           }
         }
       }
@@ -121,27 +133,33 @@ public class CommonClientConfiguration {
   private JwtConfig configureJwtConfig() {
     JwtConfig jwtConfig = new JwtConfig();
     // ZEEBE
-    if (zeebeClientConfigurationProperties.getCloud().getClientId() != null && zeebeClientConfigurationProperties.getCloud().getClientSecret() != null) {
-      jwtConfig.addProduct(Product.ZEEBE, new JwtCredential(
-        zeebeClientConfigurationProperties.getCloud().getClientId(),
-        zeebeClientConfigurationProperties.getCloud().getClientSecret(),
-        zeebeClientConfigurationProperties.getCloud().getAudience(),
-        zeebeClientConfigurationProperties.getCloud().getAuthUrl())
-      );
-    } else if (zeebeSelfManagedProperties.getClientId() != null && zeebeSelfManagedProperties.getClientSecret() != null) {
-      jwtConfig.addProduct(Product.ZEEBE, new JwtCredential(
-        zeebeSelfManagedProperties.getClientId(),
-        zeebeSelfManagedProperties.getClientSecret(),
-        zeebeSelfManagedProperties.getAudience(),
-        zeebeSelfManagedProperties.getAuthServer())
-      );
-    } else if (commonConfigurationProperties.getClientId() != null && commonConfigurationProperties.getClientSecret() != null) {
-      jwtConfig.addProduct(Product.ZEEBE, new JwtCredential(
-        commonConfigurationProperties.getClientId(),
-        commonConfigurationProperties.getClientSecret(),
-        zeebeClientConfigurationProperties.getCloud().getAudience(),
-        zeebeClientConfigurationProperties.getCloud().getAuthUrl())
-      );
+    if (zeebeClientConfigurationProperties.getCloud().getClientId() != null
+        && zeebeClientConfigurationProperties.getCloud().getClientSecret() != null) {
+      jwtConfig.addProduct(
+          Product.ZEEBE,
+          new JwtCredential(
+              zeebeClientConfigurationProperties.getCloud().getClientId(),
+              zeebeClientConfigurationProperties.getCloud().getClientSecret(),
+              zeebeClientConfigurationProperties.getCloud().getAudience(),
+              zeebeClientConfigurationProperties.getCloud().getAuthUrl()));
+    } else if (zeebeSelfManagedProperties.getClientId() != null
+        && zeebeSelfManagedProperties.getClientSecret() != null) {
+      jwtConfig.addProduct(
+          Product.ZEEBE,
+          new JwtCredential(
+              zeebeSelfManagedProperties.getClientId(),
+              zeebeSelfManagedProperties.getClientSecret(),
+              zeebeSelfManagedProperties.getAudience(),
+              zeebeSelfManagedProperties.getAuthServer()));
+    } else if (commonConfigurationProperties.getClientId() != null
+        && commonConfigurationProperties.getClientSecret() != null) {
+      jwtConfig.addProduct(
+          Product.ZEEBE,
+          new JwtCredential(
+              commonConfigurationProperties.getClientId(),
+              commonConfigurationProperties.getClientSecret(),
+              zeebeClientConfigurationProperties.getCloud().getAudience(),
+              zeebeClientConfigurationProperties.getCloud().getAuthUrl()));
     }
 
     // OPERATE
@@ -153,30 +171,64 @@ public class CommonClientConfiguration {
         operateAuthUrl = operateClientConfigurationProperties.getAuthUrl();
       } else if (hasText(operateClientConfigurationProperties.getKeycloakTokenUrl())) {
         operateAuthUrl = operateClientConfigurationProperties.getKeycloakTokenUrl();
-      } else if (hasText(operateClientConfigurationProperties.getKeycloakUrl()) && hasText(operateClientConfigurationProperties.getKeycloakRealm())) {
-        operateAuthUrl = operateClientConfigurationProperties.getKeycloakUrl()+"/auth/realms/"+operateClientConfigurationProperties.getKeycloakRealm();
+      } else if (hasText(operateClientConfigurationProperties.getKeycloakUrl())
+          && hasText(operateClientConfigurationProperties.getKeycloakRealm())) {
+        operateAuthUrl =
+            operateClientConfigurationProperties.getKeycloakUrl()
+                + "/auth/realms/"
+                + operateClientConfigurationProperties.getKeycloakRealm();
       }
 
       if (operateClientConfigurationProperties.getBaseUrl() != null) {
         operateAudience = operateClientConfigurationProperties.getBaseUrl();
       }
 
-      if (operateClientConfigurationProperties.getClientId() != null && operateClientConfigurationProperties.getClientSecret() != null) {
-        jwtConfig.addProduct(Product.OPERATE, new JwtCredential(operateClientConfigurationProperties.getClientId(), operateClientConfigurationProperties.getClientSecret(), operateAudience, operateAuthUrl));
-      } else if (identityConfigurationFromProperties != null && hasText(identityConfigurationFromProperties.getClientId()) && hasText(identityConfigurationFromProperties.getClientSecret())) {
-        jwtConfig.addProduct(Product.OPERATE, new JwtCredential(identityConfigurationFromProperties.getClientId(), identityConfigurationFromProperties.getClientSecret(), identityConfigurationFromProperties.getAudience(), identityConfigurationFromProperties.getIssuerBackendUrl()));
-      }
-      else if (commonConfigurationProperties.getClientId() != null && commonConfigurationProperties.getClientSecret() != null) {
-        jwtConfig.addProduct(Product.OPERATE, new JwtCredential(
-          commonConfigurationProperties.getClientId(),
-          commonConfigurationProperties.getClientSecret(),
-          operateAudience,
-          operateAuthUrl)
-        );
-      } else if (zeebeClientConfigurationProperties.getCloud().getClientId() != null && zeebeClientConfigurationProperties.getCloud().getClientSecret() != null) {
-        jwtConfig.addProduct(Product.OPERATE, new JwtCredential(zeebeClientConfigurationProperties.getCloud().getClientId(), zeebeClientConfigurationProperties.getCloud().getClientSecret(), operateAudience, operateAuthUrl));
-      } else if (zeebeSelfManagedProperties.getClientId() != null && zeebeSelfManagedProperties.getClientSecret() != null) {
-        jwtConfig.addProduct(Product.OPERATE, new JwtCredential(zeebeSelfManagedProperties.getClientId(), zeebeSelfManagedProperties.getClientSecret(), operateAudience, operateAuthUrl));
+      if (operateClientConfigurationProperties.getClientId() != null
+          && operateClientConfigurationProperties.getClientSecret() != null) {
+        jwtConfig.addProduct(
+            Product.OPERATE,
+            new JwtCredential(
+                operateClientConfigurationProperties.getClientId(),
+                operateClientConfigurationProperties.getClientSecret(),
+                operateAudience,
+                operateAuthUrl));
+      } else if (identityConfigurationFromProperties != null
+          && hasText(identityConfigurationFromProperties.getClientId())
+          && hasText(identityConfigurationFromProperties.getClientSecret())) {
+        jwtConfig.addProduct(
+            Product.OPERATE,
+            new JwtCredential(
+                identityConfigurationFromProperties.getClientId(),
+                identityConfigurationFromProperties.getClientSecret(),
+                identityConfigurationFromProperties.getAudience(),
+                identityConfigurationFromProperties.getIssuerBackendUrl()));
+      } else if (commonConfigurationProperties.getClientId() != null
+          && commonConfigurationProperties.getClientSecret() != null) {
+        jwtConfig.addProduct(
+            Product.OPERATE,
+            new JwtCredential(
+                commonConfigurationProperties.getClientId(),
+                commonConfigurationProperties.getClientSecret(),
+                operateAudience,
+                operateAuthUrl));
+      } else if (zeebeClientConfigurationProperties.getCloud().getClientId() != null
+          && zeebeClientConfigurationProperties.getCloud().getClientSecret() != null) {
+        jwtConfig.addProduct(
+            Product.OPERATE,
+            new JwtCredential(
+                zeebeClientConfigurationProperties.getCloud().getClientId(),
+                zeebeClientConfigurationProperties.getCloud().getClientSecret(),
+                operateAudience,
+                operateAuthUrl));
+      } else if (zeebeSelfManagedProperties.getClientId() != null
+          && zeebeSelfManagedProperties.getClientSecret() != null) {
+        jwtConfig.addProduct(
+            Product.OPERATE,
+            new JwtCredential(
+                zeebeSelfManagedProperties.getClientId(),
+                zeebeSelfManagedProperties.getClientSecret(),
+                operateAudience,
+                operateAuthUrl));
       } else {
         throw new SdkException("Unable to determine OPERATE credentials");
       }
@@ -197,8 +249,9 @@ public class CommonClientConfiguration {
   }
 
   /**
-   * Identity properties supplied by the user are optional, so if they don't exist, we have to backfill them from somewhere
-   * like the OperateClientConfigurationProperties.
+   * Identity properties supplied by the user are optional, so if they don't exist, we have to
+   * backfill them from somewhere like the OperateClientConfigurationProperties.
+   *
    * @param jwtConfig
    * @return
    */
@@ -217,15 +270,16 @@ public class CommonClientConfiguration {
       issuerBackendUrl = jwtConfig.getProduct(Product.OPERATE).getAuthUrl();
     }
 
-    IdentityConfiguration operateIdentityConfiguration = new IdentityConfiguration.Builder()
-      .withBaseUrl(identityConfigurationFromProperties.getBaseUrl())
-      .withIssuer(issuer)
-      .withIssuerBackendUrl(issuerBackendUrl)
-      .withClientId(jwtConfig.getProduct(Product.OPERATE).getClientId())
-      .withClientSecret(jwtConfig.getProduct(Product.OPERATE).getClientSecret())
-      .withAudience(jwtConfig.getProduct(Product.OPERATE).getAudience())
-      .withType(identityConfigurationFromProperties.getType().name())
-      .build();
+    IdentityConfiguration operateIdentityConfiguration =
+        new IdentityConfiguration.Builder()
+            .withBaseUrl(identityConfigurationFromProperties.getBaseUrl())
+            .withIssuer(issuer)
+            .withIssuerBackendUrl(issuerBackendUrl)
+            .withClientId(jwtConfig.getProduct(Product.OPERATE).getClientId())
+            .withClientSecret(jwtConfig.getProduct(Product.OPERATE).getClientSecret())
+            .withAudience(jwtConfig.getProduct(Product.OPERATE).getAudience())
+            .withType(identityConfigurationFromProperties.getType().name())
+            .build();
     Identity operateIdentity = new Identity(operateIdentityConfiguration);
     return new IdentityContainer(operateIdentity, operateIdentityConfiguration);
   }

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientStarterAutoConfigurationCustomJsonMapperTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientStarterAutoConfigurationCustomJsonMapperTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.common.json.JsonMapper;
+import io.camunda.common.json.SdkObjectMapper;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
 import io.camunda.zeebe.spring.client.CamundaAutoConfiguration;
@@ -46,7 +48,10 @@ import org.springframework.test.util.ReflectionTestUtils;
 public class ZeebeClientStarterAutoConfigurationCustomJsonMapperTest {
 
   public static class TestConfig {
-
+    @Bean
+    public io.camunda.common.json.JsonMapper commonJsonMapper(){
+      return new SdkObjectMapper();
+    }
     @Primary
     @Bean(name = "overridingJsonMapper")
     public io.camunda.zeebe.client.api.JsonMapper zeebeJsonMapper() {

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientStarterAutoConfigurationCustomJsonMapperTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientStarterAutoConfigurationCustomJsonMapperTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.common.json.JsonMapper;
 import io.camunda.common.json.SdkObjectMapper;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
@@ -49,9 +48,10 @@ public class ZeebeClientStarterAutoConfigurationCustomJsonMapperTest {
 
   public static class TestConfig {
     @Bean
-    public io.camunda.common.json.JsonMapper commonJsonMapper(){
+    public io.camunda.common.json.JsonMapper commonJsonMapper() {
       return new SdkObjectMapper();
     }
+
     @Primary
     @Bean(name = "overridingJsonMapper")
     public io.camunda.zeebe.client.api.JsonMapper zeebeJsonMapper() {

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSaasOperateCredentialTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSaasOperateCredentialTest.java
@@ -1,5 +1,7 @@
 package io.camunda.zeebe.spring.client.config.authentication;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.camunda.common.auth.Authentication;
 import io.camunda.common.auth.JwtCredential;
 import io.camunda.common.auth.Product;
@@ -20,20 +22,17 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 @ExtendWith(SpringExtension.class)
 @TestPropertySource(
-  properties = {
-    "zeebe.client.cloud.region=syd-1",
-    "zeebe.client.cloud.clusterId=cluster-id",
-    "zeebe.client.cloud.clientId=client-id",
-    "zeebe.client.cloud.clientSecret=client-secret",
-    "camunda.operate.client.enabled=true",
-    "camunda.operate.client.client-id=operate-client-id",
-    "camunda.operate.client.client-secret=operate-client-secret"
-  }
-)
+    properties = {
+      "zeebe.client.cloud.region=syd-1",
+      "zeebe.client.cloud.clusterId=cluster-id",
+      "zeebe.client.cloud.clientId=client-id",
+      "zeebe.client.cloud.clientSecret=client-secret",
+      "camunda.operate.client.enabled=true",
+      "camunda.operate.client.client-id=operate-client-id",
+      "camunda.operate.client.client-secret=operate-client-secret"
+    })
 @ContextConfiguration(classes = OperateSaasOperateCredentialTest.TestConfig.class)
 public class OperateSaasOperateCredentialTest {
 
@@ -41,16 +40,14 @@ public class OperateSaasOperateCredentialTest {
   @EnableConfigurationProperties(ZeebeClientConfigurationProperties.class)
   public static class TestConfig {
     @Bean
-    public JsonMapper commonJsonMapper(){
+    public JsonMapper commonJsonMapper() {
       return new SdkObjectMapper();
     }
   }
 
-  @Autowired
-  private Authentication authentication;
+  @Autowired private Authentication authentication;
 
-  @Autowired
-  private CamundaOperateClient operateClient;
+  @Autowired private CamundaOperateClient operateClient;
 
   @Test
   public void testAuthentication() {

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSaasOperateCredentialTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSaasOperateCredentialTest.java
@@ -1,11 +1,11 @@
 package io.camunda.zeebe.spring.client.config.authentication;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import io.camunda.common.auth.Authentication;
 import io.camunda.common.auth.JwtCredential;
 import io.camunda.common.auth.Product;
 import io.camunda.common.auth.SaaSAuthentication;
+import io.camunda.common.json.JsonMapper;
+import io.camunda.common.json.SdkObjectMapper;
 import io.camunda.operate.CamundaOperateClient;
 import io.camunda.zeebe.spring.client.configuration.CommonClientConfiguration;
 import io.camunda.zeebe.spring.client.configuration.OperateClientConfiguration;
@@ -15,31 +15,42 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @ExtendWith(SpringExtension.class)
 @TestPropertySource(
-    properties = {
-      "zeebe.client.cloud.region=syd-1",
-      "zeebe.client.cloud.clusterId=cluster-id",
-      "zeebe.client.cloud.clientId=client-id",
-      "zeebe.client.cloud.clientSecret=client-secret",
-      "camunda.operate.client.enabled=true",
-      "camunda.operate.client.client-id=operate-client-id",
-      "camunda.operate.client.client-secret=operate-client-secret"
-    })
+  properties = {
+    "zeebe.client.cloud.region=syd-1",
+    "zeebe.client.cloud.clusterId=cluster-id",
+    "zeebe.client.cloud.clientId=client-id",
+    "zeebe.client.cloud.clientSecret=client-secret",
+    "camunda.operate.client.enabled=true",
+    "camunda.operate.client.client-id=operate-client-id",
+    "camunda.operate.client.client-secret=operate-client-secret"
+  }
+)
 @ContextConfiguration(classes = OperateSaasOperateCredentialTest.TestConfig.class)
 public class OperateSaasOperateCredentialTest {
 
   @ImportAutoConfiguration({CommonClientConfiguration.class, OperateClientConfiguration.class})
   @EnableConfigurationProperties(ZeebeClientConfigurationProperties.class)
-  public static class TestConfig {}
+  public static class TestConfig {
+    @Bean
+    public JsonMapper commonJsonMapper(){
+      return new SdkObjectMapper();
+    }
+  }
 
-  @Autowired private Authentication authentication;
+  @Autowired
+  private Authentication authentication;
 
-  @Autowired private CamundaOperateClient operateClient;
+  @Autowired
+  private CamundaOperateClient operateClient;
 
   @Test
   public void testAuthentication() {

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSaasZeebeCredentialTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSaasZeebeCredentialTest.java
@@ -1,8 +1,8 @@
 package io.camunda.zeebe.spring.client.config.authentication;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import io.camunda.common.auth.*;
+import io.camunda.common.json.JsonMapper;
+import io.camunda.common.json.SdkObjectMapper;
 import io.camunda.operate.CamundaOperateClient;
 import io.camunda.zeebe.spring.client.configuration.CommonClientConfiguration;
 import io.camunda.zeebe.spring.client.configuration.OperateClientConfiguration;
@@ -12,29 +12,40 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @ExtendWith(SpringExtension.class)
 @TestPropertySource(
-    properties = {
-      "zeebe.client.cloud.region=syd-1",
-      "zeebe.client.cloud.clusterId=cluster-id",
-      "zeebe.client.cloud.clientId=client-id",
-      "zeebe.client.cloud.clientSecret=client-secret",
-      "camunda.operate.client.enabled=true"
-    })
+  properties = {
+    "zeebe.client.cloud.region=syd-1",
+    "zeebe.client.cloud.clusterId=cluster-id",
+    "zeebe.client.cloud.clientId=client-id",
+    "zeebe.client.cloud.clientSecret=client-secret",
+    "camunda.operate.client.enabled=true"
+  }
+)
 @ContextConfiguration(classes = OperateSaasZeebeCredentialTest.TestConfig.class)
 public class OperateSaasZeebeCredentialTest {
 
   @ImportAutoConfiguration({CommonClientConfiguration.class, OperateClientConfiguration.class})
   @EnableConfigurationProperties(ZeebeClientConfigurationProperties.class)
-  public static class TestConfig {}
+  public static class TestConfig {
+    @Bean
+    public JsonMapper commonJsonMapper(){
+      return new SdkObjectMapper();
+    }
+  }
 
-  @Autowired private Authentication authentication;
+  @Autowired
+  private Authentication authentication;
 
-  @Autowired private CamundaOperateClient operateClient;
+  @Autowired
+  private CamundaOperateClient operateClient;
 
   @Test
   public void testAuthentication() {

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSaasZeebeCredentialTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSaasZeebeCredentialTest.java
@@ -1,5 +1,7 @@
 package io.camunda.zeebe.spring.client.config.authentication;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.camunda.common.auth.*;
 import io.camunda.common.json.JsonMapper;
 import io.camunda.common.json.SdkObjectMapper;
@@ -17,18 +19,15 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 @ExtendWith(SpringExtension.class)
 @TestPropertySource(
-  properties = {
-    "zeebe.client.cloud.region=syd-1",
-    "zeebe.client.cloud.clusterId=cluster-id",
-    "zeebe.client.cloud.clientId=client-id",
-    "zeebe.client.cloud.clientSecret=client-secret",
-    "camunda.operate.client.enabled=true"
-  }
-)
+    properties = {
+      "zeebe.client.cloud.region=syd-1",
+      "zeebe.client.cloud.clusterId=cluster-id",
+      "zeebe.client.cloud.clientId=client-id",
+      "zeebe.client.cloud.clientSecret=client-secret",
+      "camunda.operate.client.enabled=true"
+    })
 @ContextConfiguration(classes = OperateSaasZeebeCredentialTest.TestConfig.class)
 public class OperateSaasZeebeCredentialTest {
 
@@ -36,16 +35,14 @@ public class OperateSaasZeebeCredentialTest {
   @EnableConfigurationProperties(ZeebeClientConfigurationProperties.class)
   public static class TestConfig {
     @Bean
-    public JsonMapper commonJsonMapper(){
+    public JsonMapper commonJsonMapper() {
       return new SdkObjectMapper();
     }
   }
 
-  @Autowired
-  private Authentication authentication;
+  @Autowired private Authentication authentication;
 
-  @Autowired
-  private CamundaOperateClient operateClient;
+  @Autowired private CamundaOperateClient operateClient;
 
   @Test
   public void testAuthentication() {

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedBasicTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedBasicTest.java
@@ -1,5 +1,7 @@
 package io.camunda.zeebe.spring.client.config.authentication;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.camunda.common.auth.Authentication;
 import io.camunda.common.auth.Product;
 import io.camunda.common.auth.SimpleAuthentication;
@@ -21,34 +23,33 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 @ExtendWith(SpringExtension.class)
 @TestPropertySource(
-  properties = {
-    "zeebe.client.broker.gatewayAddress=localhost12345",
-    "camunda.operate.client.url=http://localhost:8081",
-    "camunda.operate.client.username=username",
-    "camunda.operate.client.password=password"
-  }
-)
+    properties = {
+      "zeebe.client.broker.gatewayAddress=localhost12345",
+      "camunda.operate.client.url=http://localhost:8081",
+      "camunda.operate.client.username=username",
+      "camunda.operate.client.password=password"
+    })
 @ContextConfiguration(classes = OperateSelfManagedBasicTest.TestConfig.class)
 public class OperateSelfManagedBasicTest {
 
-  @ImportAutoConfiguration({CommonClientConfiguration.class, OperateClientConfiguration.class, IdentityAutoConfiguration.class})
+  @ImportAutoConfiguration({
+    CommonClientConfiguration.class,
+    OperateClientConfiguration.class,
+    IdentityAutoConfiguration.class
+  })
   @EnableConfigurationProperties(ZeebeClientConfigurationProperties.class)
   public static class TestConfig {
     @Bean
-    public JsonMapper commonJsonMapper(){
+    public JsonMapper commonJsonMapper() {
       return new SdkObjectMapper();
     }
   }
 
-  @Autowired
-  private Authentication authentication;
+  @Autowired private Authentication authentication;
 
-  @Autowired
-  private CamundaOperateClient operateClient;
+  @Autowired private CamundaOperateClient operateClient;
 
   @Test
   public void testAuthentication() {
@@ -59,7 +60,8 @@ public class OperateSelfManagedBasicTest {
   @Test
   public void testCredential() {
     SimpleAuthentication simpleAuthentication = (SimpleAuthentication) authentication;
-    SimpleCredential simpleCredential = simpleAuthentication.getSimpleConfig().getProduct(Product.OPERATE);
+    SimpleCredential simpleCredential =
+        simpleAuthentication.getSimpleConfig().getProduct(Product.OPERATE);
 
     assertThat(simpleCredential.getUser()).isEqualTo("username");
     assertThat(simpleCredential.getPassword()).isEqualTo("password");

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedBasicTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedBasicTest.java
@@ -1,11 +1,11 @@
 package io.camunda.zeebe.spring.client.config.authentication;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import io.camunda.common.auth.Authentication;
 import io.camunda.common.auth.Product;
 import io.camunda.common.auth.SimpleAuthentication;
 import io.camunda.common.auth.SimpleCredential;
+import io.camunda.common.json.JsonMapper;
+import io.camunda.common.json.SdkObjectMapper;
 import io.camunda.identity.autoconfigure.IdentityAutoConfiguration;
 import io.camunda.operate.CamundaOperateClient;
 import io.camunda.zeebe.spring.client.configuration.CommonClientConfiguration;
@@ -16,32 +16,39 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @ExtendWith(SpringExtension.class)
 @TestPropertySource(
-    properties = {
-      "zeebe.client.broker.gatewayAddress=localhost12345",
-      "camunda.operate.client.url=http://localhost:8081",
-      "camunda.operate.client.username=username",
-      "camunda.operate.client.password=password"
-    })
+  properties = {
+    "zeebe.client.broker.gatewayAddress=localhost12345",
+    "camunda.operate.client.url=http://localhost:8081",
+    "camunda.operate.client.username=username",
+    "camunda.operate.client.password=password"
+  }
+)
 @ContextConfiguration(classes = OperateSelfManagedBasicTest.TestConfig.class)
 public class OperateSelfManagedBasicTest {
 
-  @ImportAutoConfiguration({
-    CommonClientConfiguration.class,
-    OperateClientConfiguration.class,
-    IdentityAutoConfiguration.class
-  })
+  @ImportAutoConfiguration({CommonClientConfiguration.class, OperateClientConfiguration.class, IdentityAutoConfiguration.class})
   @EnableConfigurationProperties(ZeebeClientConfigurationProperties.class)
-  public static class TestConfig {}
+  public static class TestConfig {
+    @Bean
+    public JsonMapper commonJsonMapper(){
+      return new SdkObjectMapper();
+    }
+  }
 
-  @Autowired private Authentication authentication;
+  @Autowired
+  private Authentication authentication;
 
-  @Autowired private CamundaOperateClient operateClient;
+  @Autowired
+  private CamundaOperateClient operateClient;
 
   @Test
   public void testAuthentication() {
@@ -52,8 +59,7 @@ public class OperateSelfManagedBasicTest {
   @Test
   public void testCredential() {
     SimpleAuthentication simpleAuthentication = (SimpleAuthentication) authentication;
-    SimpleCredential simpleCredential =
-        simpleAuthentication.getSimpleConfig().getProduct(Product.OPERATE);
+    SimpleCredential simpleCredential = simpleAuthentication.getSimpleConfig().getProduct(Product.OPERATE);
 
     assertThat(simpleCredential.getUser()).isEqualTo("username");
     assertThat(simpleCredential.getPassword()).isEqualTo("password");

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedBasicWithZeebeCredentialsTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedBasicWithZeebeCredentialsTest.java
@@ -1,11 +1,11 @@
 package io.camunda.zeebe.spring.client.config.authentication;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import io.camunda.common.auth.Authentication;
 import io.camunda.common.auth.Product;
 import io.camunda.common.auth.SimpleAuthentication;
 import io.camunda.common.auth.SimpleCredential;
+import io.camunda.common.json.JsonMapper;
+import io.camunda.common.json.SdkObjectMapper;
 import io.camunda.identity.autoconfigure.IdentityAutoConfiguration;
 import io.camunda.operate.CamundaOperateClient;
 import io.camunda.zeebe.spring.client.configuration.CommonClientConfiguration;
@@ -16,36 +16,43 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @ExtendWith(SpringExtension.class)
 @TestPropertySource(
-    properties = {
-      "zeebe.client.broker.gatewayAddress=localhost12345",
-      "zeebe.authorization.server.url=http://zeebe-authorization-server",
-      "zeebe.client.id=client-id",
-      "zeebe.client.secret=client-secret",
-      "zeebe.token.audience=sample-audience",
-      "camunda.operate.client.url=http://localhost:8081",
-      "camunda.operate.client.username=username",
-      "camunda.operate.client.password=password"
-    })
+  properties = {
+    "zeebe.client.broker.gatewayAddress=localhost12345",
+    "zeebe.authorization.server.url=http://zeebe-authorization-server",
+    "zeebe.client.id=client-id",
+    "zeebe.client.secret=client-secret",
+    "zeebe.token.audience=sample-audience",
+    "camunda.operate.client.url=http://localhost:8081",
+    "camunda.operate.client.username=username",
+    "camunda.operate.client.password=password"
+  }
+)
 @ContextConfiguration(classes = OperateSelfManagedBasicWithZeebeCredentialsTest.TestConfig.class)
 public class OperateSelfManagedBasicWithZeebeCredentialsTest {
 
-  @ImportAutoConfiguration({
-    CommonClientConfiguration.class,
-    OperateClientConfiguration.class,
-    IdentityAutoConfiguration.class
-  })
+  @ImportAutoConfiguration({CommonClientConfiguration.class, OperateClientConfiguration.class, IdentityAutoConfiguration.class})
   @EnableConfigurationProperties(ZeebeClientConfigurationProperties.class)
-  public static class TestConfig {}
+  public static class TestConfig {
+    @Bean
+    public JsonMapper commonJsonMapper(){
+      return new SdkObjectMapper();
+    }
+  }
 
-  @Autowired private Authentication authentication;
+  @Autowired
+  private Authentication authentication;
 
-  @Autowired private CamundaOperateClient operateClient;
+  @Autowired
+  private CamundaOperateClient operateClient;
 
   @Test
   public void testAuthentication() {
@@ -56,8 +63,7 @@ public class OperateSelfManagedBasicWithZeebeCredentialsTest {
   @Test
   public void testCredential() {
     SimpleAuthentication simpleAuthentication = (SimpleAuthentication) authentication;
-    SimpleCredential simpleCredential =
-        simpleAuthentication.getSimpleConfig().getProduct(Product.OPERATE);
+    SimpleCredential simpleCredential = simpleAuthentication.getSimpleConfig().getProduct(Product.OPERATE);
 
     assertThat(simpleCredential.getUser()).isEqualTo("username");
     assertThat(simpleCredential.getPassword()).isEqualTo("password");

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedBasicWithZeebeCredentialsTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedBasicWithZeebeCredentialsTest.java
@@ -1,5 +1,7 @@
 package io.camunda.zeebe.spring.client.config.authentication;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.camunda.common.auth.Authentication;
 import io.camunda.common.auth.Product;
 import io.camunda.common.auth.SimpleAuthentication;
@@ -21,38 +23,37 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 @ExtendWith(SpringExtension.class)
 @TestPropertySource(
-  properties = {
-    "zeebe.client.broker.gatewayAddress=localhost12345",
-    "zeebe.authorization.server.url=http://zeebe-authorization-server",
-    "zeebe.client.id=client-id",
-    "zeebe.client.secret=client-secret",
-    "zeebe.token.audience=sample-audience",
-    "camunda.operate.client.url=http://localhost:8081",
-    "camunda.operate.client.username=username",
-    "camunda.operate.client.password=password"
-  }
-)
+    properties = {
+      "zeebe.client.broker.gatewayAddress=localhost12345",
+      "zeebe.authorization.server.url=http://zeebe-authorization-server",
+      "zeebe.client.id=client-id",
+      "zeebe.client.secret=client-secret",
+      "zeebe.token.audience=sample-audience",
+      "camunda.operate.client.url=http://localhost:8081",
+      "camunda.operate.client.username=username",
+      "camunda.operate.client.password=password"
+    })
 @ContextConfiguration(classes = OperateSelfManagedBasicWithZeebeCredentialsTest.TestConfig.class)
 public class OperateSelfManagedBasicWithZeebeCredentialsTest {
 
-  @ImportAutoConfiguration({CommonClientConfiguration.class, OperateClientConfiguration.class, IdentityAutoConfiguration.class})
+  @ImportAutoConfiguration({
+    CommonClientConfiguration.class,
+    OperateClientConfiguration.class,
+    IdentityAutoConfiguration.class
+  })
   @EnableConfigurationProperties(ZeebeClientConfigurationProperties.class)
   public static class TestConfig {
     @Bean
-    public JsonMapper commonJsonMapper(){
+    public JsonMapper commonJsonMapper() {
       return new SdkObjectMapper();
     }
   }
 
-  @Autowired
-  private Authentication authentication;
+  @Autowired private Authentication authentication;
 
-  @Autowired
-  private CamundaOperateClient operateClient;
+  @Autowired private CamundaOperateClient operateClient;
 
   @Test
   public void testAuthentication() {
@@ -63,7 +64,8 @@ public class OperateSelfManagedBasicWithZeebeCredentialsTest {
   @Test
   public void testCredential() {
     SimpleAuthentication simpleAuthentication = (SimpleAuthentication) authentication;
-    SimpleCredential simpleCredential = simpleAuthentication.getSimpleConfig().getProduct(Product.OPERATE);
+    SimpleCredential simpleCredential =
+        simpleAuthentication.getSimpleConfig().getProduct(Product.OPERATE);
 
     assertThat(simpleCredential.getUser()).isEqualTo("username");
     assertThat(simpleCredential.getPassword()).isEqualTo("password");

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedIdentityTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedIdentityTest.java
@@ -1,8 +1,8 @@
 package io.camunda.zeebe.spring.client.config.authentication;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import io.camunda.common.auth.*;
+import io.camunda.common.json.JsonMapper;
+import io.camunda.common.json.SdkObjectMapper;
 import io.camunda.identity.autoconfigure.IdentityAutoConfiguration;
 import io.camunda.operate.CamundaOperateClient;
 import io.camunda.zeebe.spring.client.configuration.CommonClientConfiguration;
@@ -13,40 +13,47 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @ExtendWith(SpringExtension.class)
 @TestPropertySource(
-    properties = {
-      "zeebe.client.broker.gatewayAddress=localhost12345",
-      "zeebe.authorization.server.url=http://zeebe-authorization-server",
-      "zeebe.client.id=client-id",
-      "zeebe.client.secret=client-secret",
-      "zeebe.token.audience=sample-audience",
-      "camunda.operate.client.url=http://localhost:8081",
-      "camunda.identity.issuer=http://some-oidc-issuer",
-      "camunda.identity.issuer-backend-url=http://some-oidc-issuer-backend-url",
-      "camunda.identity.type=MICROSOFT",
-      "camunda.identity.client-id=client-id2",
-      "camunda.identity.client-secret=client-secret2",
-      "camunda.identity.audience=sample-audience2"
-    })
+  properties = {
+    "zeebe.client.broker.gatewayAddress=localhost12345",
+    "zeebe.authorization.server.url=http://zeebe-authorization-server",
+    "zeebe.client.id=client-id",
+    "zeebe.client.secret=client-secret",
+    "zeebe.token.audience=sample-audience",
+    "camunda.operate.client.url=http://localhost:8081",
+    "camunda.identity.issuer=http://some-oidc-issuer",
+    "camunda.identity.issuer-backend-url=http://some-oidc-issuer-backend-url",
+    "camunda.identity.type=MICROSOFT",
+    "camunda.identity.client-id=client-id2",
+    "camunda.identity.client-secret=client-secret2",
+    "camunda.identity.audience=sample-audience2"
+  }
+)
 @ContextConfiguration(classes = OperateSelfManagedIdentityTest.TestConfig.class)
 public class OperateSelfManagedIdentityTest {
 
-  @ImportAutoConfiguration({
-    CommonClientConfiguration.class,
-    OperateClientConfiguration.class,
-    IdentityAutoConfiguration.class
-  })
+  @ImportAutoConfiguration({CommonClientConfiguration.class, OperateClientConfiguration.class, IdentityAutoConfiguration.class})
   @EnableConfigurationProperties(ZeebeClientConfigurationProperties.class)
-  public static class TestConfig {}
+  public static class TestConfig {
+    @Bean
+    public JsonMapper commonJsonMapper(){
+      return new SdkObjectMapper();
+    }
+  }
 
-  @Autowired private Authentication authentication;
+  @Autowired
+  private Authentication authentication;
 
-  @Autowired private CamundaOperateClient operateClient;
+  @Autowired
+  private CamundaOperateClient operateClient;
 
   @Test
   public void testAuthentication() {
@@ -56,10 +63,8 @@ public class OperateSelfManagedIdentityTest {
 
   @Test
   public void testCredential() {
-    SelfManagedAuthentication selfManagedAuthentication =
-        (SelfManagedAuthentication) authentication;
-    JwtCredential jwtCredential =
-        selfManagedAuthentication.getJwtConfig().getProduct(Product.OPERATE);
+    SelfManagedAuthentication selfManagedAuthentication = (SelfManagedAuthentication) authentication;
+    JwtCredential jwtCredential = selfManagedAuthentication.getJwtConfig().getProduct(Product.OPERATE);
 
     assertThat(jwtCredential.getClientId()).isEqualTo("client-id2");
     assertThat(jwtCredential.getClientSecret()).isEqualTo("client-secret2");

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedIdentityTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedIdentityTest.java
@@ -1,5 +1,7 @@
 package io.camunda.zeebe.spring.client.config.authentication;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.camunda.common.auth.*;
 import io.camunda.common.json.JsonMapper;
 import io.camunda.common.json.SdkObjectMapper;
@@ -18,42 +20,41 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 @ExtendWith(SpringExtension.class)
 @TestPropertySource(
-  properties = {
-    "zeebe.client.broker.gatewayAddress=localhost12345",
-    "zeebe.authorization.server.url=http://zeebe-authorization-server",
-    "zeebe.client.id=client-id",
-    "zeebe.client.secret=client-secret",
-    "zeebe.token.audience=sample-audience",
-    "camunda.operate.client.url=http://localhost:8081",
-    "camunda.identity.issuer=http://some-oidc-issuer",
-    "camunda.identity.issuer-backend-url=http://some-oidc-issuer-backend-url",
-    "camunda.identity.type=MICROSOFT",
-    "camunda.identity.client-id=client-id2",
-    "camunda.identity.client-secret=client-secret2",
-    "camunda.identity.audience=sample-audience2"
-  }
-)
+    properties = {
+      "zeebe.client.broker.gatewayAddress=localhost12345",
+      "zeebe.authorization.server.url=http://zeebe-authorization-server",
+      "zeebe.client.id=client-id",
+      "zeebe.client.secret=client-secret",
+      "zeebe.token.audience=sample-audience",
+      "camunda.operate.client.url=http://localhost:8081",
+      "camunda.identity.issuer=http://some-oidc-issuer",
+      "camunda.identity.issuer-backend-url=http://some-oidc-issuer-backend-url",
+      "camunda.identity.type=MICROSOFT",
+      "camunda.identity.client-id=client-id2",
+      "camunda.identity.client-secret=client-secret2",
+      "camunda.identity.audience=sample-audience2"
+    })
 @ContextConfiguration(classes = OperateSelfManagedIdentityTest.TestConfig.class)
 public class OperateSelfManagedIdentityTest {
 
-  @ImportAutoConfiguration({CommonClientConfiguration.class, OperateClientConfiguration.class, IdentityAutoConfiguration.class})
+  @ImportAutoConfiguration({
+    CommonClientConfiguration.class,
+    OperateClientConfiguration.class,
+    IdentityAutoConfiguration.class
+  })
   @EnableConfigurationProperties(ZeebeClientConfigurationProperties.class)
   public static class TestConfig {
     @Bean
-    public JsonMapper commonJsonMapper(){
+    public JsonMapper commonJsonMapper() {
       return new SdkObjectMapper();
     }
   }
 
-  @Autowired
-  private Authentication authentication;
+  @Autowired private Authentication authentication;
 
-  @Autowired
-  private CamundaOperateClient operateClient;
+  @Autowired private CamundaOperateClient operateClient;
 
   @Test
   public void testAuthentication() {
@@ -63,8 +64,10 @@ public class OperateSelfManagedIdentityTest {
 
   @Test
   public void testCredential() {
-    SelfManagedAuthentication selfManagedAuthentication = (SelfManagedAuthentication) authentication;
-    JwtCredential jwtCredential = selfManagedAuthentication.getJwtConfig().getProduct(Product.OPERATE);
+    SelfManagedAuthentication selfManagedAuthentication =
+        (SelfManagedAuthentication) authentication;
+    JwtCredential jwtCredential =
+        selfManagedAuthentication.getJwtConfig().getProduct(Product.OPERATE);
 
     assertThat(jwtCredential.getClientId()).isEqualTo("client-id2");
     assertThat(jwtCredential.getClientSecret()).isEqualTo("client-secret2");

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedKeycloakTokenUrlTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedKeycloakTokenUrlTest.java
@@ -1,5 +1,7 @@
 package io.camunda.zeebe.spring.client.config.authentication;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.camunda.common.auth.*;
 import io.camunda.common.json.JsonMapper;
 import io.camunda.common.json.SdkObjectMapper;
@@ -18,37 +20,36 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 @ExtendWith(SpringExtension.class)
 @TestPropertySource(
-  properties = {
-    "zeebe.client.broker.gatewayAddress=localhost12345",
-    "zeebe.authorization.server.url=http://zeebe-authorization-server",
-    "zeebe.client.id=client-id",
-    "zeebe.client.secret=client-secret",
-    "zeebe.token.audience=sample-audience",
-    "camunda.operate.client.keycloak-token-url=https://local-keycloak/auth/realms/camunda-platform/protocol/openid-connect/token",
-    "camunda.operate.client.url=http://localhost:8081"
-  }
-)
+    properties = {
+      "zeebe.client.broker.gatewayAddress=localhost12345",
+      "zeebe.authorization.server.url=http://zeebe-authorization-server",
+      "zeebe.client.id=client-id",
+      "zeebe.client.secret=client-secret",
+      "zeebe.token.audience=sample-audience",
+      "camunda.operate.client.keycloak-token-url=https://local-keycloak/auth/realms/camunda-platform/protocol/openid-connect/token",
+      "camunda.operate.client.url=http://localhost:8081"
+    })
 @ContextConfiguration(classes = OperateSelfManagedKeycloakTokenUrlTest.TestConfig.class)
 public class OperateSelfManagedKeycloakTokenUrlTest {
 
-  @ImportAutoConfiguration({CommonClientConfiguration.class, OperateClientConfiguration.class, IdentityAutoConfiguration.class})
+  @ImportAutoConfiguration({
+    CommonClientConfiguration.class,
+    OperateClientConfiguration.class,
+    IdentityAutoConfiguration.class
+  })
   @EnableConfigurationProperties(ZeebeClientConfigurationProperties.class)
   public static class TestConfig {
     @Bean
-    public JsonMapper commonJsonMapper(){
+    public JsonMapper commonJsonMapper() {
       return new SdkObjectMapper();
     }
   }
 
-  @Autowired
-  private Authentication authentication;
+  @Autowired private Authentication authentication;
 
-  @Autowired
-  private CamundaOperateClient operateClient;
+  @Autowired private CamundaOperateClient operateClient;
 
   @Test
   public void testAuthentication() {
@@ -58,11 +59,12 @@ public class OperateSelfManagedKeycloakTokenUrlTest {
 
   @Test
   public void testCredential() {
-    SelfManagedAuthentication selfManagedAuthentication = (SelfManagedAuthentication) authentication;
-    JwtCredential jwtCredential = selfManagedAuthentication.getJwtConfig().getProduct(Product.OPERATE);
+    SelfManagedAuthentication selfManagedAuthentication =
+        (SelfManagedAuthentication) authentication;
+    JwtCredential jwtCredential =
+        selfManagedAuthentication.getJwtConfig().getProduct(Product.OPERATE);
 
     assertThat(jwtCredential.getClientId()).isEqualTo("client-id");
     assertThat(jwtCredential.getClientSecret()).isEqualTo("client-secret");
   }
-
 }

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedKeycloakTokenUrlTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedKeycloakTokenUrlTest.java
@@ -1,8 +1,8 @@
 package io.camunda.zeebe.spring.client.config.authentication;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import io.camunda.common.auth.*;
+import io.camunda.common.json.JsonMapper;
+import io.camunda.common.json.SdkObjectMapper;
 import io.camunda.identity.autoconfigure.IdentityAutoConfiguration;
 import io.camunda.operate.CamundaOperateClient;
 import io.camunda.zeebe.spring.client.configuration.CommonClientConfiguration;
@@ -13,35 +13,42 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @ExtendWith(SpringExtension.class)
 @TestPropertySource(
-    properties = {
-      "zeebe.client.broker.gatewayAddress=localhost12345",
-      "zeebe.authorization.server.url=http://zeebe-authorization-server",
-      "zeebe.client.id=client-id",
-      "zeebe.client.secret=client-secret",
-      "zeebe.token.audience=sample-audience",
-      "camunda.operate.client.keycloak-token-url=https://local-keycloak/auth/realms/camunda-platform/protocol/openid-connect/token",
-      "camunda.operate.client.url=http://localhost:8081"
-    })
+  properties = {
+    "zeebe.client.broker.gatewayAddress=localhost12345",
+    "zeebe.authorization.server.url=http://zeebe-authorization-server",
+    "zeebe.client.id=client-id",
+    "zeebe.client.secret=client-secret",
+    "zeebe.token.audience=sample-audience",
+    "camunda.operate.client.keycloak-token-url=https://local-keycloak/auth/realms/camunda-platform/protocol/openid-connect/token",
+    "camunda.operate.client.url=http://localhost:8081"
+  }
+)
 @ContextConfiguration(classes = OperateSelfManagedKeycloakTokenUrlTest.TestConfig.class)
 public class OperateSelfManagedKeycloakTokenUrlTest {
 
-  @ImportAutoConfiguration({
-    CommonClientConfiguration.class,
-    OperateClientConfiguration.class,
-    IdentityAutoConfiguration.class
-  })
+  @ImportAutoConfiguration({CommonClientConfiguration.class, OperateClientConfiguration.class, IdentityAutoConfiguration.class})
   @EnableConfigurationProperties(ZeebeClientConfigurationProperties.class)
-  public static class TestConfig {}
+  public static class TestConfig {
+    @Bean
+    public JsonMapper commonJsonMapper(){
+      return new SdkObjectMapper();
+    }
+  }
 
-  @Autowired private Authentication authentication;
+  @Autowired
+  private Authentication authentication;
 
-  @Autowired private CamundaOperateClient operateClient;
+  @Autowired
+  private CamundaOperateClient operateClient;
 
   @Test
   public void testAuthentication() {
@@ -51,12 +58,11 @@ public class OperateSelfManagedKeycloakTokenUrlTest {
 
   @Test
   public void testCredential() {
-    SelfManagedAuthentication selfManagedAuthentication =
-        (SelfManagedAuthentication) authentication;
-    JwtCredential jwtCredential =
-        selfManagedAuthentication.getJwtConfig().getProduct(Product.OPERATE);
+    SelfManagedAuthentication selfManagedAuthentication = (SelfManagedAuthentication) authentication;
+    JwtCredential jwtCredential = selfManagedAuthentication.getJwtConfig().getProduct(Product.OPERATE);
 
     assertThat(jwtCredential.getClientId()).isEqualTo("client-id");
     assertThat(jwtCredential.getClientSecret()).isEqualTo("client-secret");
   }
+
 }

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedKeycloakUrlTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedKeycloakUrlTest.java
@@ -1,11 +1,11 @@
 package io.camunda.zeebe.spring.client.config.authentication;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import io.camunda.common.auth.Authentication;
 import io.camunda.common.auth.JwtCredential;
 import io.camunda.common.auth.Product;
 import io.camunda.common.auth.SelfManagedAuthentication;
+import io.camunda.common.json.JsonMapper;
+import io.camunda.common.json.SdkObjectMapper;
 import io.camunda.identity.autoconfigure.IdentityAutoConfiguration;
 import io.camunda.operate.CamundaOperateClient;
 import io.camunda.zeebe.spring.client.configuration.CommonClientConfiguration;
@@ -16,35 +16,42 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @ExtendWith(SpringExtension.class)
 @TestPropertySource(
-    properties = {
-      "zeebe.client.broker.gatewayAddress=localhost12345",
-      "zeebe.authorization.server.url=http://zeebe-authorization-server",
-      "zeebe.client.id=client-id",
-      "zeebe.client.secret=client-secret",
-      "zeebe.token.audience=sample-audience",
-      "camunda.operate.client.keycloak-url=https://local-keycloak",
-      "camunda.operate.client.url=http://localhost:8081"
-    })
+  properties = {
+    "zeebe.client.broker.gatewayAddress=localhost12345",
+    "zeebe.authorization.server.url=http://zeebe-authorization-server",
+    "zeebe.client.id=client-id",
+    "zeebe.client.secret=client-secret",
+    "zeebe.token.audience=sample-audience",
+    "camunda.operate.client.keycloak-url=https://local-keycloak",
+    "camunda.operate.client.url=http://localhost:8081"
+  }
+)
 @ContextConfiguration(classes = OperateSelfManagedKeycloakUrlTest.TestConfig.class)
 public class OperateSelfManagedKeycloakUrlTest {
 
-  @ImportAutoConfiguration({
-    CommonClientConfiguration.class,
-    OperateClientConfiguration.class,
-    IdentityAutoConfiguration.class
-  })
+  @ImportAutoConfiguration({CommonClientConfiguration.class, OperateClientConfiguration.class, IdentityAutoConfiguration.class})
   @EnableConfigurationProperties(ZeebeClientConfigurationProperties.class)
-  public static class TestConfig {}
+  public static class TestConfig {
+    @Bean
+    public JsonMapper commonJsonMapper(){
+      return new SdkObjectMapper();
+    }
+  }
 
-  @Autowired private Authentication authentication;
+  @Autowired
+  private Authentication authentication;
 
-  @Autowired private CamundaOperateClient operateClient;
+  @Autowired
+  private CamundaOperateClient operateClient;
 
   @Test
   public void testAuthentication() {
@@ -54,10 +61,8 @@ public class OperateSelfManagedKeycloakUrlTest {
 
   @Test
   public void testCredential() {
-    SelfManagedAuthentication selfManagedAuthentication =
-        (SelfManagedAuthentication) authentication;
-    JwtCredential jwtCredential =
-        selfManagedAuthentication.getJwtConfig().getProduct(Product.OPERATE);
+    SelfManagedAuthentication selfManagedAuthentication = (SelfManagedAuthentication) authentication;
+    JwtCredential jwtCredential = selfManagedAuthentication.getJwtConfig().getProduct(Product.OPERATE);
 
     assertThat(jwtCredential.getClientId()).isEqualTo("client-id");
     assertThat(jwtCredential.getClientSecret()).isEqualTo("client-secret");

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedKeycloakUrlTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedKeycloakUrlTest.java
@@ -1,5 +1,7 @@
 package io.camunda.zeebe.spring.client.config.authentication;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.camunda.common.auth.Authentication;
 import io.camunda.common.auth.JwtCredential;
 import io.camunda.common.auth.Product;
@@ -21,37 +23,36 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 @ExtendWith(SpringExtension.class)
 @TestPropertySource(
-  properties = {
-    "zeebe.client.broker.gatewayAddress=localhost12345",
-    "zeebe.authorization.server.url=http://zeebe-authorization-server",
-    "zeebe.client.id=client-id",
-    "zeebe.client.secret=client-secret",
-    "zeebe.token.audience=sample-audience",
-    "camunda.operate.client.keycloak-url=https://local-keycloak",
-    "camunda.operate.client.url=http://localhost:8081"
-  }
-)
+    properties = {
+      "zeebe.client.broker.gatewayAddress=localhost12345",
+      "zeebe.authorization.server.url=http://zeebe-authorization-server",
+      "zeebe.client.id=client-id",
+      "zeebe.client.secret=client-secret",
+      "zeebe.token.audience=sample-audience",
+      "camunda.operate.client.keycloak-url=https://local-keycloak",
+      "camunda.operate.client.url=http://localhost:8081"
+    })
 @ContextConfiguration(classes = OperateSelfManagedKeycloakUrlTest.TestConfig.class)
 public class OperateSelfManagedKeycloakUrlTest {
 
-  @ImportAutoConfiguration({CommonClientConfiguration.class, OperateClientConfiguration.class, IdentityAutoConfiguration.class})
+  @ImportAutoConfiguration({
+    CommonClientConfiguration.class,
+    OperateClientConfiguration.class,
+    IdentityAutoConfiguration.class
+  })
   @EnableConfigurationProperties(ZeebeClientConfigurationProperties.class)
   public static class TestConfig {
     @Bean
-    public JsonMapper commonJsonMapper(){
+    public JsonMapper commonJsonMapper() {
       return new SdkObjectMapper();
     }
   }
 
-  @Autowired
-  private Authentication authentication;
+  @Autowired private Authentication authentication;
 
-  @Autowired
-  private CamundaOperateClient operateClient;
+  @Autowired private CamundaOperateClient operateClient;
 
   @Test
   public void testAuthentication() {
@@ -61,8 +62,10 @@ public class OperateSelfManagedKeycloakUrlTest {
 
   @Test
   public void testCredential() {
-    SelfManagedAuthentication selfManagedAuthentication = (SelfManagedAuthentication) authentication;
-    JwtCredential jwtCredential = selfManagedAuthentication.getJwtConfig().getProduct(Product.OPERATE);
+    SelfManagedAuthentication selfManagedAuthentication =
+        (SelfManagedAuthentication) authentication;
+    JwtCredential jwtCredential =
+        selfManagedAuthentication.getJwtConfig().getProduct(Product.OPERATE);
 
     assertThat(jwtCredential.getClientId()).isEqualTo("client-id");
     assertThat(jwtCredential.getClientSecret()).isEqualTo("client-secret");


### PR DESCRIPTION
Currently, the token provider not refresh a token unless it is reported invalid by the server.

This behaviour does not work with the zeebe client.

This fix refactors the jwt authentication to check the validity of a token BEFORE sending the request and eventually refreshing the token upfront.

closes #631 