### PR TITLE
backport/8.3: fix(common-authentication): Token not refreshed

### DIFF
--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/Authentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/Authentication.java
@@ -4,9 +4,12 @@ import java.util.Map;
 
 public interface Authentication {
 
-  Authentication build();
 
   Map.Entry<String, String> getTokenHeader(Product product);
 
   void resetToken(Product product);
+
+  interface AuthenticationBuilder {
+    Authentication build();
+  }
 }

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/DefaultNoopAuthentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/DefaultNoopAuthentication.java
@@ -17,10 +17,8 @@ public class DefaultNoopAuthentication implements Authentication {
 
   private final String errorMessage = "Unable to determine authentication. Please check your configuration";
 
-  @Override
-  public Authentication build() {
+  public DefaultNoopAuthentication() {
     LOG.error(errorMessage);
-    return this;
   }
 
   @Override

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/JwtAuthentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/JwtAuthentication.java
@@ -1,9 +1,70 @@
 package io.camunda.common.auth;
 
-/**
- * TODO: Figure out common functionality between SaaS and Self Managed that can be inserted here
- * to reduce code duplication. If not, remove this class
- */
-public abstract class JwtAuthentication implements Authentication {
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.lang.invoke.MethodHandles;
+import java.time.LocalDateTime;
+import java.util.AbstractMap;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+
+public abstract class JwtAuthentication implements Authentication {
+  private static final Logger LOG = LoggerFactory.getLogger(MethodHandles
+    .lookup().lookupClass());
+
+  private final JwtConfig jwtConfig;
+  private final Map<Product, JwtToken> tokens = new HashMap<>();
+
+  protected JwtAuthentication(JwtConfig jwtConfig) {this.jwtConfig = jwtConfig;}
+
+  public JwtConfig getJwtConfig() {
+    return jwtConfig;
+  }
+
+  @Override
+  public final void resetToken(Product product) {
+    tokens.remove(product);
+  }
+  @Override
+  public final Entry<String, String> getTokenHeader(Product product) {
+    if (!tokens.containsKey(product) || !isValid(tokens.get(product))) {
+      JwtToken newToken = generateToken(product,jwtConfig.getProduct(product));
+      tokens.put(product, newToken);
+    }
+    return authHeader(tokens.get(product).getToken());
+  }
+
+  protected abstract JwtToken generateToken(Product product, JwtCredential credential);
+
+  private Entry<String,String> authHeader(String token){
+    return new AbstractMap.SimpleEntry<>("Authorization", "Bearer " + token);
+  }
+
+  private boolean isValid(JwtToken jwtToken) {
+    // a token is only counted valid if it is only valid for at least 30 seconds
+    return jwtToken.getExpiry().isAfter(LocalDateTime.now().minusSeconds(30));
+  }
+
+
+
+  protected static class JwtToken {
+    private final String token;
+    private final LocalDateTime expiry;
+
+    public JwtToken(String token, LocalDateTime expiry) {
+      this.token = token;
+      this.expiry = expiry;
+    }
+
+    public String getToken() {
+      return token;
+    }
+
+    public LocalDateTime getExpiry() {
+      return expiry;
+    }
+  }
 }

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/JwtAuthenticationBuilder.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/JwtAuthenticationBuilder.java
@@ -1,0 +1,22 @@
+package io.camunda.common.auth;
+
+import io.camunda.common.auth.Authentication.AuthenticationBuilder;
+
+public abstract class JwtAuthenticationBuilder<
+    T extends JwtAuthenticationBuilder<?>> implements AuthenticationBuilder {
+  private JwtConfig jwtConfig;
+
+  public final T withJwtConfig(JwtConfig jwtConfig) {
+    this.jwtConfig = jwtConfig;
+    return self();
+  }
+
+  @Override
+  public final Authentication build() {
+    return build(jwtConfig);
+  }
+
+  protected abstract T self();
+
+  protected abstract Authentication build(JwtConfig jwtConfig);
+}

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SaaSAuthenticationBuilder.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SaaSAuthenticationBuilder.java
@@ -1,20 +1,22 @@
 package io.camunda.common.auth;
 
-public class SaaSAuthenticationBuilder {
+import io.camunda.common.json.JsonMapper;
 
-  SaaSAuthentication saaSAuthentication;
+public class SaaSAuthenticationBuilder extends JwtAuthenticationBuilder<SaaSAuthenticationBuilder> {
+  private JsonMapper jsonMapper;
 
-  SaaSAuthenticationBuilder() {
-    saaSAuthentication = new SaaSAuthentication();
-  }
-
-  public SaaSAuthenticationBuilder jwtConfig(JwtConfig jwtConfig) {
-    saaSAuthentication.setJwtConfig(jwtConfig);
+  public SaaSAuthenticationBuilder withJsonMapper(JsonMapper jsonMapper) {
+    this.jsonMapper = jsonMapper;
     return this;
   }
 
-  public Authentication build() {
-    return saaSAuthentication.build();
+  @Override
+  protected SaaSAuthenticationBuilder self() {
+    return this;
   }
 
+  @Override
+  protected SaaSAuthentication build(JwtConfig jwtConfig) {
+    return new SaaSAuthentication(jwtConfig, jsonMapper);
+  }
 }

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SelfManagedAuthenticationBuilder.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SelfManagedAuthenticationBuilder.java
@@ -1,38 +1,43 @@
 package io.camunda.common.auth;
 
-public class SelfManagedAuthenticationBuilder {
+import io.camunda.common.json.JsonMapper;
 
-  SelfManagedAuthentication selfManagedAuthentication;
+public class SelfManagedAuthenticationBuilder extends JwtAuthenticationBuilder<SelfManagedAuthenticationBuilder> {
+  private String keycloakUrl;
+  private String keycloakRealm;
+  private String keycloakTokenUrl;
+  private JsonMapper jsonMapper;
 
-  SelfManagedAuthenticationBuilder() {
-    selfManagedAuthentication = new SelfManagedAuthentication();
-  }
 
-  public SelfManagedAuthenticationBuilder jwtConfig(JwtConfig jwtConfig) {
-    selfManagedAuthentication.setJwtConfig(jwtConfig);
+  public SelfManagedAuthenticationBuilder withKeycloakUrl(String keycloakUrl) {
+    this.keycloakUrl = keycloakUrl;
     return this;
   }
 
-  public SelfManagedAuthenticationBuilder keycloakUrl(String keycloakUrl) {
-    selfManagedAuthentication.setKeycloakUrl(keycloakUrl);
+  public SelfManagedAuthenticationBuilder withKeycloakRealm(String keycloakRealm) {
+    this.keycloakRealm = keycloakRealm;
     return this;
   }
 
-  public SelfManagedAuthenticationBuilder keycloakRealm(String keycloakRealm) {
-    if (keycloakRealm != null) {
-      selfManagedAuthentication.setKeycloakRealm(keycloakRealm);
-    }
+  public SelfManagedAuthenticationBuilder withKeycloakTokenUrl(String keycloakTokenUrl) {
+    this.keycloakTokenUrl = keycloakTokenUrl;
     return this;
   }
 
-  public SelfManagedAuthenticationBuilder keycloakTokenUrl(String keycloakTokenUrl) {
-    if (keycloakTokenUrl != null) {
-      selfManagedAuthentication.setKeycloakTokenUrl(keycloakTokenUrl);
-    }
+  public SelfManagedAuthenticationBuilder withJsonMapper(JsonMapper jsonMapper){
+    this.jsonMapper = jsonMapper;
     return this;
   }
 
-  public Authentication build() {
-    return selfManagedAuthentication.build();
+
+  @Override
+  protected SelfManagedAuthenticationBuilder self() {
+    return this;
+  }
+
+  @Override
+  protected Authentication build(JwtConfig jwtConfig) {
+    String authUrl = keycloakTokenUrl != null ? keycloakTokenUrl : keycloakUrl+"/auth/realms/"+keycloakRealm+"/protocol/openid-connect/token";
+    return new SelfManagedAuthentication(jwtConfig,authUrl,jsonMapper);
   }
 }

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SimpleAuthentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SimpleAuthentication.java
@@ -17,35 +17,23 @@ public class SimpleAuthentication implements Authentication {
 
   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  private String simpleUrl;
-  private SimpleConfig simpleConfig;
-  private Map<Product, String> tokens;
+  private final SimpleConfig simpleConfig;
+  private final Map<Product, String> tokens = new HashMap<>();
 
-  private String authUrl;
+  private final String authUrl;
 
-  public void setSimpleUrl(String simpleUrl) {
-    this.simpleUrl = simpleUrl;
+  public SimpleAuthentication(String simpleUrl, SimpleConfig simpleConfig) {
+    this.simpleConfig = simpleConfig;
+    this.authUrl = simpleUrl+"/api/login";
   }
 
   public SimpleConfig getSimpleConfig() {
     return simpleConfig;
   }
 
-  public void setSimpleConfig(SimpleConfig simpleConfig) {
-    this.simpleConfig = simpleConfig;
-  }
-
-  public SimpleAuthentication() {
-    tokens = new HashMap<>();
-  }
-
   public static SimpleAuthenticationBuilder builder() { return new SimpleAuthenticationBuilder(); }
 
-  @Override
-  public Authentication build() {
-    authUrl = simpleUrl+"/api/login";
-    return this;
-  }
+
 
   private String retrieveToken(Product product, SimpleCredential simpleCredential) {
     try(CloseableHttpClient client = HttpClients.createDefault()) {

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SimpleAuthenticationBuilder.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SimpleAuthenticationBuilder.java
@@ -1,25 +1,25 @@
 package io.camunda.common.auth;
 
-public class SimpleAuthenticationBuilder {
+import io.camunda.common.auth.Authentication.AuthenticationBuilder;
 
-  SimpleAuthentication simpleAuthentication;
+public class SimpleAuthenticationBuilder implements AuthenticationBuilder {
+  private String simpleUrl;
+  private SimpleConfig simpleConfig;
 
-  SimpleAuthenticationBuilder() {
-    simpleAuthentication = new SimpleAuthentication();
-  }
-
-  public SimpleAuthenticationBuilder simpleConfig(SimpleConfig simpleConfig) {
-    simpleAuthentication.setSimpleConfig(simpleConfig);
+  public SimpleAuthenticationBuilder withSimpleUrl(String simpleUrl){
+    this.simpleUrl = simpleUrl;
     return this;
   }
 
-  public SimpleAuthenticationBuilder simpleUrl(String simpleUrl) {
-    simpleAuthentication.setSimpleUrl(simpleUrl);
+  public SimpleAuthenticationBuilder withSimpleConfig(SimpleConfig simpleConfig){
+    this.simpleConfig = simpleConfig;
     return this;
   }
 
+
+  @Override
   public Authentication build() {
-    return simpleAuthentication.build();
+    return new SimpleAuthentication(simpleUrl,simpleConfig);
   }
 
 }

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/CamundaAutoConfiguration.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/CamundaAutoConfiguration.java
@@ -1,12 +1,17 @@
 package io.camunda.zeebe.spring.client;
 
+import static com.fasterxml.jackson.databind.DeserializationFeature.ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT;
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.common.json.SdkObjectMapper;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
 import io.camunda.zeebe.spring.client.configuration.*;
 import io.camunda.zeebe.spring.client.event.ZeebeLifecycleEventProducer;
 import io.camunda.zeebe.spring.client.testsupport.SpringZeebeTestContext;
+import java.lang.invoke.MethodHandles;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -17,15 +22,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.lang.invoke.MethodHandles;
-
-import static com.fasterxml.jackson.databind.DeserializationFeature.ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT;
-import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
-
-/**
- *
- * Enabled by META-INF of Spring Boot Starter to provide beans for Camunda Clients
- */
+/** Enabled by META-INF of Spring Boot Starter to provide beans for Camunda Clients */
 @Configuration
 @ImportAutoConfiguration({
   ZeebeClientProdAutoConfiguration.class,
@@ -35,29 +32,38 @@ import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKN
   ZeebeActuatorConfiguration.class,
   MetricsDefaultConfiguration.class
 })
-@AutoConfigureAfter(JacksonAutoConfiguration.class) // make sure Spring created ObjectMapper is preferred if available
+@AutoConfigureAfter(
+    JacksonAutoConfiguration
+        .class) // make sure Spring created ObjectMapper is preferred if available
 public class CamundaAutoConfiguration {
 
+  public static final ObjectMapper DEFAULT_OBJECT_MAPPER =
+      new ObjectMapper()
+          .configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
+          .configure(ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT, true);
   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  public static final ObjectMapper DEFAULT_OBJECT_MAPPER = new ObjectMapper()
-    .configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
-    .configure(ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT, true);
-
   @Bean
-  @ConditionalOnMissingBean(SpringZeebeTestContext.class) // only run if we are not running in a test case - as otherwise the the lifecycle is controlled by the test
-  public ZeebeLifecycleEventProducer zeebeLifecycleEventProducer(final ZeebeClient client, final ApplicationEventPublisher publisher) {
+  @ConditionalOnMissingBean(
+      SpringZeebeTestContext
+          .class) // only run if we are not running in a test case - as otherwise the the lifecycle
+                  // is controlled by the test
+  public ZeebeLifecycleEventProducer zeebeLifecycleEventProducer(
+      final ZeebeClient client, final ApplicationEventPublisher publisher) {
     return new ZeebeLifecycleEventProducer(client, publisher);
   }
 
   /**
-   * Registering a JsonMapper bean when there is none already exists in {@link org.springframework.beans.factory.BeanFactory}.
+   * Registering a JsonMapper bean when there is none already exists in {@link
+   * org.springframework.beans.factory.BeanFactory}.
    *
-   * NOTE: This method SHOULD NOT be explicitly called as it might lead to unexpected behaviour due to the
-   * {@link ConditionalOnMissingBean} annotation. i.e. Calling this method when another JsonMapper bean is defined in the context
-   * might throw {@link org.springframework.beans.factory.NoSuchBeanDefinitionException}
+   * <p>NOTE: This method SHOULD NOT be explicitly called as it might lead to unexpected behaviour
+   * due to the {@link ConditionalOnMissingBean} annotation. i.e. Calling this method when another
+   * JsonMapper bean is defined in the context might throw {@link
+   * org.springframework.beans.factory.NoSuchBeanDefinitionException}
    *
-   * @return a new JsonMapper bean if none already exists in {@link org.springframework.beans.factory.BeanFactory}
+   * @return a new JsonMapper bean if none already exists in {@link
+   *     org.springframework.beans.factory.BeanFactory}
    */
   @Bean(name = "zeebeJsonMapper")
   @ConditionalOnMissingBean
@@ -65,4 +71,9 @@ public class CamundaAutoConfiguration {
     return new ZeebeObjectMapper(objectMapper);
   }
 
+  @Bean(name = "commonJsonMapper")
+  @ConditionalOnMissingBean
+  public io.camunda.common.json.JsonMapper commonJsonMapper(ObjectMapper objectMapper) {
+    return new SdkObjectMapper(objectMapper);
+  }
 }

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/CommonClientConfiguration.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/CommonClientConfiguration.java
@@ -1,14 +1,20 @@
 package io.camunda.zeebe.spring.client.configuration;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.common.auth.*;
+import io.camunda.common.json.JsonMapper;
+import io.camunda.common.json.SdkObjectMapper;
 import io.camunda.zeebe.spring.client.properties.*;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 
-@EnableConfigurationProperties({CommonConfigurationProperties.class, ZeebeSelfManagedProperties.class})
+@EnableConfigurationProperties({
+  CommonConfigurationProperties.class,
+  ZeebeSelfManagedProperties.class
+})
 public class CommonClientConfiguration {
-
 
   @Autowired(required = false)
   CommonConfigurationProperties commonConfigurationProperties;
@@ -31,92 +37,114 @@ public class CommonClientConfiguration {
   @Autowired(required = false)
   ZeebeSelfManagedProperties zeebeSelfManagedProperties;
 
+
+
   @Bean
-  public Authentication authentication() {
+  public Authentication authentication(JsonMapper jsonMapper) {
 
     // TODO: Refactor
     if (zeebeClientConfigurationProperties != null) {
       // check if Zeebe has clusterId provided, then must be SaaS
       if (zeebeClientConfigurationProperties.getCloud().getClusterId() != null) {
         return SaaSAuthentication.builder()
-          .jwtConfig(configureJwtConfig())
-          .build();
-      } else if (zeebeClientConfigurationProperties.getBroker().getGatewayAddress() != null || zeebeSelfManagedProperties.getGatewayAddress() != null) {
+            .withJwtConfig(configureJwtConfig())
+            .withJsonMapper(jsonMapper)
+            .build();
+      } else if (zeebeClientConfigurationProperties.getBroker().getGatewayAddress() != null
+          || zeebeSelfManagedProperties.getGatewayAddress() != null) {
         // figure out if Self-Managed JWT or Self-Managed Basic
         if (operateClientConfigurationProperties != null) {
           if (operateClientConfigurationProperties.getKeycloakUrl() != null) {
             return SelfManagedAuthentication.builder()
-              .jwtConfig(configureJwtConfig())
-              .keycloakUrl(operateClientConfigurationProperties.getKeycloakUrl())
-              .keycloakRealm(operateClientConfigurationProperties.getKeycloakRealm())
-              .build();
-          } else if (operateClientConfigurationProperties.getKeycloakTokenUrl() != null)  {
+                .withJwtConfig(configureJwtConfig())
+                .withKeycloakUrl(operateClientConfigurationProperties.getKeycloakUrl())
+                .withKeycloakRealm(operateClientConfigurationProperties.getKeycloakRealm())
+                .withJsonMapper(jsonMapper)
+                .build();
+          } else if (operateClientConfigurationProperties.getKeycloakTokenUrl() != null) {
             return SelfManagedAuthentication.builder()
-              .jwtConfig(configureJwtConfig())
-              .keycloakTokenUrl(operateClientConfigurationProperties.getKeycloakTokenUrl())
-              .build();
-          }  else if (operateClientConfigurationProperties.getUsername() != null && operateClientConfigurationProperties.getPassword() != null) {
+                .withJwtConfig(configureJwtConfig())
+                .withKeycloakTokenUrl(operateClientConfigurationProperties.getKeycloakTokenUrl())
+                .withJsonMapper(jsonMapper)
+                .build();
+          } else if (operateClientConfigurationProperties.getUsername() != null
+              && operateClientConfigurationProperties.getPassword() != null) {
             SimpleConfig simpleConfig = new SimpleConfig();
-            SimpleCredential simpleCredential = new SimpleCredential(operateClientConfigurationProperties.getUsername(), operateClientConfigurationProperties.getPassword());
+            SimpleCredential simpleCredential =
+                new SimpleCredential(
+                    operateClientConfigurationProperties.getUsername(),
+                    operateClientConfigurationProperties.getPassword());
             simpleConfig.addProduct(Product.OPERATE, simpleCredential);
             return SimpleAuthentication.builder()
-              .simpleConfig(simpleConfig)
-              .simpleUrl(operateClientConfigurationProperties.getUrl())
-              .build();
+                .withSimpleConfig(simpleConfig)
+                .withSimpleUrl(operateClientConfigurationProperties.getUrl())
+                .build();
           }
         }
 
         if (commonConfigurationProperties != null) {
           if (commonConfigurationProperties.getKeycloak().getUrl() != null) {
             return SelfManagedAuthentication.builder()
-              .jwtConfig(configureJwtConfig())
-              .keycloakUrl(commonConfigurationProperties.getKeycloak().getUrl())
-              .keycloakRealm(commonConfigurationProperties.getKeycloak().getRealm())
-              .build();
+                .withJwtConfig(configureJwtConfig())
+                .withKeycloakUrl(commonConfigurationProperties.getKeycloak().getUrl())
+                .withKeycloakRealm(commonConfigurationProperties.getKeycloak().getRealm())
+                .withJsonMapper(jsonMapper)
+                .build();
           } else if (commonConfigurationProperties.getKeycloak().getTokenUrl() != null) {
             return SelfManagedAuthentication.builder()
-              .jwtConfig(configureJwtConfig())
-              .keycloakTokenUrl(commonConfigurationProperties.getKeycloak().getTokenUrl())
-              .build();
-          } else if (commonConfigurationProperties.getUsername() != null && commonConfigurationProperties.getPassword() != null) {
+                .withJwtConfig(configureJwtConfig())
+                .withKeycloakTokenUrl(commonConfigurationProperties.getKeycloak().getTokenUrl())
+                .withJsonMapper(jsonMapper)
+                .build();
+          } else if (commonConfigurationProperties.getUsername() != null
+              && commonConfigurationProperties.getPassword() != null) {
             SimpleConfig simpleConfig = new SimpleConfig();
-            SimpleCredential simpleCredential = new SimpleCredential(commonConfigurationProperties.getUsername(), commonConfigurationProperties.getPassword());
+            SimpleCredential simpleCredential =
+                new SimpleCredential(
+                    commonConfigurationProperties.getUsername(),
+                    commonConfigurationProperties.getPassword());
             simpleConfig.addProduct(Product.OPERATE, simpleCredential);
             return SimpleAuthentication.builder()
-              .simpleConfig(simpleConfig)
-              .simpleUrl(commonConfigurationProperties.getUrl())
-              .build();
+                .withSimpleConfig(simpleConfig)
+                .withSimpleUrl(commonConfigurationProperties.getUrl())
+                .build();
           }
         }
       }
     }
-    return new DefaultNoopAuthentication().build();
+    return new DefaultNoopAuthentication();
   }
 
   private JwtConfig configureJwtConfig() {
     JwtConfig jwtConfig = new JwtConfig();
     // ZEEBE
-    if (zeebeClientConfigurationProperties.getCloud().getClientId() != null && zeebeClientConfigurationProperties.getCloud().getClientSecret() != null) {
-      jwtConfig.addProduct(Product.ZEEBE, new JwtCredential(
-        zeebeClientConfigurationProperties.getCloud().getClientId(),
-        zeebeClientConfigurationProperties.getCloud().getClientSecret(),
-        zeebeClientConfigurationProperties.getCloud().getAudience(),
-        zeebeClientConfigurationProperties.getCloud().getAuthUrl())
-      );
-    } else if (zeebeSelfManagedProperties.getClientId() != null && zeebeSelfManagedProperties.getClientSecret() != null) {
-      jwtConfig.addProduct(Product.ZEEBE, new JwtCredential(
-        zeebeSelfManagedProperties.getClientId(),
-        zeebeSelfManagedProperties.getClientSecret(),
-        zeebeSelfManagedProperties.getAudience(),
-        zeebeSelfManagedProperties.getAuthServer())
-      );
-    } else if (commonConfigurationProperties.getClientId() != null && commonConfigurationProperties.getClientSecret() != null) {
-      jwtConfig.addProduct(Product.ZEEBE, new JwtCredential(
-        commonConfigurationProperties.getClientId(),
-        commonConfigurationProperties.getClientSecret(),
-        zeebeClientConfigurationProperties.getCloud().getAudience(),
-        zeebeClientConfigurationProperties.getCloud().getAuthUrl())
-      );
+    if (zeebeClientConfigurationProperties.getCloud().getClientId() != null
+        && zeebeClientConfigurationProperties.getCloud().getClientSecret() != null) {
+      jwtConfig.addProduct(
+          Product.ZEEBE,
+          new JwtCredential(
+              zeebeClientConfigurationProperties.getCloud().getClientId(),
+              zeebeClientConfigurationProperties.getCloud().getClientSecret(),
+              zeebeClientConfigurationProperties.getCloud().getAudience(),
+              zeebeClientConfigurationProperties.getCloud().getAuthUrl()));
+    } else if (zeebeSelfManagedProperties.getClientId() != null
+        && zeebeSelfManagedProperties.getClientSecret() != null) {
+      jwtConfig.addProduct(
+          Product.ZEEBE,
+          new JwtCredential(
+              zeebeSelfManagedProperties.getClientId(),
+              zeebeSelfManagedProperties.getClientSecret(),
+              zeebeSelfManagedProperties.getAudience(),
+              zeebeSelfManagedProperties.getAuthServer()));
+    } else if (commonConfigurationProperties.getClientId() != null
+        && commonConfigurationProperties.getClientSecret() != null) {
+      jwtConfig.addProduct(
+          Product.ZEEBE,
+          new JwtCredential(
+              commonConfigurationProperties.getClientId(),
+              commonConfigurationProperties.getClientSecret(),
+              zeebeClientConfigurationProperties.getCloud().getAudience(),
+              zeebeClientConfigurationProperties.getCloud().getAuthUrl()));
     }
 
     // OPERATE
@@ -129,19 +157,42 @@ public class CommonClientConfiguration {
       if (operateClientConfigurationProperties.getBaseUrl() != null) {
         operateAudience = operateClientConfigurationProperties.getBaseUrl();
       }
-      if (operateClientConfigurationProperties.getClientId() != null && operateClientConfigurationProperties.getClientSecret() != null) {
-        jwtConfig.addProduct(Product.OPERATE, new JwtCredential(operateClientConfigurationProperties.getClientId(), operateClientConfigurationProperties.getClientSecret(), operateAudience, operateAuthUrl));
-      } else if (commonConfigurationProperties.getClientId() != null && commonConfigurationProperties.getClientSecret() != null) {
-        jwtConfig.addProduct(Product.OPERATE, new JwtCredential(
-          commonConfigurationProperties.getClientId(),
-          commonConfigurationProperties.getClientSecret(),
-          operateAudience,
-          operateAuthUrl)
-        );
-      } else if (zeebeClientConfigurationProperties.getCloud().getClientId() != null && zeebeClientConfigurationProperties.getCloud().getClientSecret() != null) {
-        jwtConfig.addProduct(Product.OPERATE, new JwtCredential(zeebeClientConfigurationProperties.getCloud().getClientId(), zeebeClientConfigurationProperties.getCloud().getClientSecret(), operateAudience, operateAuthUrl));
-      } else if (zeebeSelfManagedProperties.getClientId() != null && zeebeSelfManagedProperties.getClientSecret() != null) {
-        jwtConfig.addProduct(Product.OPERATE, new JwtCredential(zeebeSelfManagedProperties.getClientId(), zeebeSelfManagedProperties.getClientSecret(), operateAudience, operateAuthUrl));
+      if (operateClientConfigurationProperties.getClientId() != null
+          && operateClientConfigurationProperties.getClientSecret() != null) {
+        jwtConfig.addProduct(
+            Product.OPERATE,
+            new JwtCredential(
+                operateClientConfigurationProperties.getClientId(),
+                operateClientConfigurationProperties.getClientSecret(),
+                operateAudience,
+                operateAuthUrl));
+      } else if (commonConfigurationProperties.getClientId() != null
+          && commonConfigurationProperties.getClientSecret() != null) {
+        jwtConfig.addProduct(
+            Product.OPERATE,
+            new JwtCredential(
+                commonConfigurationProperties.getClientId(),
+                commonConfigurationProperties.getClientSecret(),
+                operateAudience,
+                operateAuthUrl));
+      } else if (zeebeClientConfigurationProperties.getCloud().getClientId() != null
+          && zeebeClientConfigurationProperties.getCloud().getClientSecret() != null) {
+        jwtConfig.addProduct(
+            Product.OPERATE,
+            new JwtCredential(
+                zeebeClientConfigurationProperties.getCloud().getClientId(),
+                zeebeClientConfigurationProperties.getCloud().getClientSecret(),
+                operateAudience,
+                operateAuthUrl));
+      } else if (zeebeSelfManagedProperties.getClientId() != null
+          && zeebeSelfManagedProperties.getClientSecret() != null) {
+        jwtConfig.addProduct(
+            Product.OPERATE,
+            new JwtCredential(
+                zeebeSelfManagedProperties.getClientId(),
+                zeebeSelfManagedProperties.getClientSecret(),
+                operateAudience,
+                operateAuthUrl));
       } else {
         throw new RuntimeException("Unable to determine OPERATE credentials");
       }

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientStarterAutoConfigurationCustomJsonMapperTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientStarterAutoConfigurationCustomJsonMapperTest.java
@@ -1,11 +1,16 @@
 package io.camunda.zeebe.spring.client.config;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.common.json.SdkObjectMapper;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
 import io.camunda.zeebe.spring.client.CamundaAutoConfiguration;
 import io.camunda.zeebe.spring.client.configuration.ZeebeClientProdAutoConfiguration;
+import java.time.Duration;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,69 +23,40 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.util.AopTestUtils;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import java.time.Duration;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 @ExtendWith(SpringExtension.class)
 @TestPropertySource(
-  properties = {
-    "zeebe.client.broker.gatewayAddress=localhost12345",
-    "zeebe.client.requestTimeout=99s",
-    "zeebe.client.job.timeout=99s",
-    "zeebe.client.job.pollInterval=99s",
-    "zeebe.client.worker.maxJobsActive=99",
-    "zeebe.client.worker.threads=99",
-    "zeebe.client.worker.defaultName=testName",
-    "zeebe.client.worker.defaultType=testType",
-    "zeebe.client.worker.override.foo.enabled=false",
-    "zeebe.client.message.timeToLive=99s",
-    "zeebe.client.security.certpath=aPath",
-    "zeebe.client.security.plaintext=true"
-  }
-)
-@ContextConfiguration(classes = { ZeebeClientStarterAutoConfigurationCustomJsonMapperTest.TestConfig.class, CamundaAutoConfiguration.class })
+    properties = {
+      "zeebe.client.broker.gatewayAddress=localhost12345",
+      "zeebe.client.requestTimeout=99s",
+      "zeebe.client.job.timeout=99s",
+      "zeebe.client.job.pollInterval=99s",
+      "zeebe.client.worker.maxJobsActive=99",
+      "zeebe.client.worker.threads=99",
+      "zeebe.client.worker.defaultName=testName",
+      "zeebe.client.worker.defaultType=testType",
+      "zeebe.client.worker.override.foo.enabled=false",
+      "zeebe.client.message.timeToLive=99s",
+      "zeebe.client.security.certpath=aPath",
+      "zeebe.client.security.plaintext=true"
+    })
+@ContextConfiguration(
+    classes = {
+      ZeebeClientStarterAutoConfigurationCustomJsonMapperTest.TestConfig.class,
+      CamundaAutoConfiguration.class
+    })
 public class ZeebeClientStarterAutoConfigurationCustomJsonMapperTest {
 
-  public static class TestConfig {
-
-    @Primary
-    @Bean(name = "overridingJsonMapper")
-    public io.camunda.zeebe.client.api.JsonMapper zeebeJsonMapper() {
-      ObjectMapper objectMapper = new ObjectMapper()
-        .configure(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES, true)
-        .configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, true);
-      return new ZeebeObjectMapper(objectMapper);
-    }
-
-    @Bean(name = "aSecondJsonMapper")
-    public io.camunda.zeebe.client.api.JsonMapper aSecondJsonMapper() {
-      ObjectMapper objectMapper = new ObjectMapper()
-        .configure(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES, true)
-        .configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, true);
-      return new ZeebeObjectMapper(objectMapper);
-    }
-
-    @Bean(name = "jsonMapper")
-    public ZeebeClientStarterAutoConfigurationCustomJsonMapperTest.JsonMapper jsonMapper() {
-      return new ZeebeClientStarterAutoConfigurationCustomJsonMapperTest.JsonMapper();
-    }
-  }
-
-  @Autowired
-  private io.camunda.zeebe.client.api.JsonMapper jsonMapper;
-  @Autowired
-  private ZeebeClientProdAutoConfiguration autoConfiguration;
-  @Autowired
-  private ApplicationContext applicationContext;
+  @Autowired private io.camunda.zeebe.client.api.JsonMapper jsonMapper;
+  @Autowired private ZeebeClientProdAutoConfiguration autoConfiguration;
+  @Autowired private ApplicationContext applicationContext;
 
   @Test
   void getJsonMapper() {
     assertThat(jsonMapper).isNotNull();
     assertThat(autoConfiguration).isNotNull();
 
-    Map<String, io.camunda.zeebe.client.api.JsonMapper> jsonMapperBeans = applicationContext.getBeansOfType(io.camunda.zeebe.client.api.JsonMapper.class);
+    Map<String, io.camunda.zeebe.client.api.JsonMapper> jsonMapperBeans =
+        applicationContext.getBeansOfType(io.camunda.zeebe.client.api.JsonMapper.class);
     Object objectMapper = ReflectionTestUtils.getField(jsonMapper, "objectMapper");
 
     assertThat(jsonMapperBeans.size()).isEqualTo(2);
@@ -90,29 +66,69 @@ public class ZeebeClientStarterAutoConfigurationCustomJsonMapperTest {
     assertThat(jsonMapperBeans.get("aSecondJsonMapper")).isNotSameAs(jsonMapper);
     assertThat(objectMapper).isNotNull();
     assertThat(objectMapper).isInstanceOf(ObjectMapper.class);
-    assertThat(((ObjectMapper)objectMapper).getDeserializationConfig()).isNotNull();
-    assertThat(((ObjectMapper)objectMapper).getDeserializationConfig().isEnabled(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES)).isTrue();
-    assertThat(((ObjectMapper)objectMapper).getDeserializationConfig().isEnabled(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)).isTrue();
+    assertThat(((ObjectMapper) objectMapper).getDeserializationConfig()).isNotNull();
+    assertThat(
+            ((ObjectMapper) objectMapper)
+                .getDeserializationConfig()
+                .isEnabled(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES))
+        .isTrue();
+    assertThat(
+            ((ObjectMapper) objectMapper)
+                .getDeserializationConfig()
+                .isEnabled(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES))
+        .isTrue();
   }
 
   @Test
   void testBuilder() {
-    //ZeebeClientBuilder builder = autoConfiguration.builder(jsonMapper, Collections.emptyList());
-    //assertThat(builder).isNotNull();
+    // ZeebeClientBuilder builder = autoConfiguration.builder(jsonMapper, Collections.emptyList());
+    // assertThat(builder).isNotNull();
 
     ZeebeClient client = applicationContext.getBean(ZeebeClient.class);
-    final io.camunda.zeebe.client.api.JsonMapper clientJsonMapper = AopTestUtils.getUltimateTargetObject(client.getConfiguration().getJsonMapper());
+    final io.camunda.zeebe.client.api.JsonMapper clientJsonMapper =
+        AopTestUtils.getUltimateTargetObject(client.getConfiguration().getJsonMapper());
     assertThat(clientJsonMapper).isSameAs(jsonMapper);
     assertThat(clientJsonMapper).isSameAs(applicationContext.getBean("overridingJsonMapper"));
     assertThat(client.getConfiguration().getGatewayAddress()).isEqualTo("localhost12345");
-    assertThat(client.getConfiguration().getDefaultRequestTimeout()).isEqualTo(Duration.ofSeconds(99));
+    assertThat(client.getConfiguration().getDefaultRequestTimeout())
+        .isEqualTo(Duration.ofSeconds(99));
     assertThat(client.getConfiguration().getCaCertificatePath()).isEqualTo("aPath");
     assertThat(client.getConfiguration().isPlaintextConnectionEnabled()).isTrue();
     assertThat(client.getConfiguration().getDefaultJobWorkerMaxJobsActive()).isEqualTo(99);
-    assertThat(client.getConfiguration().getDefaultJobPollInterval()).isEqualTo(Duration.ofSeconds(99));
+    assertThat(client.getConfiguration().getDefaultJobPollInterval())
+        .isEqualTo(Duration.ofSeconds(99));
   }
 
-  private static class JsonMapper {
+  public static class TestConfig {
+    @Bean
+    public io.camunda.common.json.JsonMapper commonJsonMapper() {
+      return new SdkObjectMapper();
+    }
 
+    @Primary
+    @Bean(name = "overridingJsonMapper")
+    public io.camunda.zeebe.client.api.JsonMapper zeebeJsonMapper() {
+      ObjectMapper objectMapper =
+          new ObjectMapper()
+              .configure(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES, true)
+              .configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, true);
+      return new ZeebeObjectMapper(objectMapper);
+    }
+
+    @Bean(name = "aSecondJsonMapper")
+    public io.camunda.zeebe.client.api.JsonMapper aSecondJsonMapper() {
+      ObjectMapper objectMapper =
+          new ObjectMapper()
+              .configure(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES, true)
+              .configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, true);
+      return new ZeebeObjectMapper(objectMapper);
+    }
+
+    @Bean(name = "jsonMapper")
+    public ZeebeClientStarterAutoConfigurationCustomJsonMapperTest.JsonMapper jsonMapper() {
+      return new ZeebeClientStarterAutoConfigurationCustomJsonMapperTest.JsonMapper();
+    }
   }
+
+  private static class JsonMapper {}
 }

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSaasOperateCredentialTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSaasOperateCredentialTest.java
@@ -4,6 +4,8 @@ import io.camunda.common.auth.Authentication;
 import io.camunda.common.auth.JwtCredential;
 import io.camunda.common.auth.Product;
 import io.camunda.common.auth.SaaSAuthentication;
+import io.camunda.common.json.JsonMapper;
+import io.camunda.common.json.SdkObjectMapper;
 import io.camunda.operate.CamundaOperateClient;
 import io.camunda.zeebe.spring.client.configuration.CommonClientConfiguration;
 import io.camunda.zeebe.spring.client.configuration.OperateClientConfiguration;
@@ -13,6 +15,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -37,7 +40,10 @@ public class OperateSaasOperateCredentialTest {
   @ImportAutoConfiguration({CommonClientConfiguration.class, OperateClientConfiguration.class})
   @EnableConfigurationProperties(ZeebeClientConfigurationProperties.class)
   public static class TestConfig {
-
+    @Bean
+    public JsonMapper jsonMapper(){
+      return new SdkObjectMapper();
+    }
   }
 
   @Autowired

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSaasZeebeCredentialTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSaasZeebeCredentialTest.java
@@ -1,6 +1,8 @@
 package io.camunda.zeebe.spring.client.config.authentication;
 
 import io.camunda.common.auth.*;
+import io.camunda.common.json.JsonMapper;
+import io.camunda.common.json.SdkObjectMapper;
 import io.camunda.operate.CamundaOperateClient;
 import io.camunda.zeebe.spring.client.configuration.CommonClientConfiguration;
 import io.camunda.zeebe.spring.client.configuration.OperateClientConfiguration;
@@ -10,6 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -32,7 +35,10 @@ public class OperateSaasZeebeCredentialTest {
   @ImportAutoConfiguration({CommonClientConfiguration.class, OperateClientConfiguration.class})
   @EnableConfigurationProperties(ZeebeClientConfigurationProperties.class)
   public static class TestConfig {
-
+    @Bean
+    public JsonMapper jsonMapper(){
+      return new SdkObjectMapper();
+    }
   }
 
   @Autowired

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedBasicTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedBasicTest.java
@@ -1,7 +1,10 @@
 package io.camunda.zeebe.spring.client.config.authentication;
 
 import io.camunda.common.auth.*;
+import io.camunda.common.json.JsonMapper;
+import io.camunda.common.json.SdkObjectMapper;
 import io.camunda.operate.CamundaOperateClient;
+import io.camunda.zeebe.spring.client.CamundaAutoConfiguration;
 import io.camunda.zeebe.spring.client.configuration.CommonClientConfiguration;
 import io.camunda.zeebe.spring.client.configuration.OperateClientConfiguration;
 import io.camunda.zeebe.spring.client.properties.ZeebeClientConfigurationProperties;
@@ -10,6 +13,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -32,10 +36,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ContextConfiguration(classes = OperateSelfManagedBasicTest.TestConfig.class)
 public class OperateSelfManagedBasicTest {
 
+
+
   @ImportAutoConfiguration({CommonClientConfiguration.class, OperateClientConfiguration.class})
   @EnableConfigurationProperties(ZeebeClientConfigurationProperties.class)
   public static class TestConfig {
-
+    @Bean
+    public JsonMapper jsonMapper(){
+      return new SdkObjectMapper();
+    }
   }
 
   @Autowired

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedKeycloakTokenUrlTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedKeycloakTokenUrlTest.java
@@ -1,6 +1,8 @@
 package io.camunda.zeebe.spring.client.config.authentication;
 
 import io.camunda.common.auth.*;
+import io.camunda.common.json.JsonMapper;
+import io.camunda.common.json.SdkObjectMapper;
 import io.camunda.operate.CamundaOperateClient;
 import io.camunda.zeebe.spring.client.configuration.CommonClientConfiguration;
 import io.camunda.zeebe.spring.client.configuration.OperateClientConfiguration;
@@ -10,6 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -34,7 +37,10 @@ public class OperateSelfManagedKeycloakTokenUrlTest {
   @ImportAutoConfiguration({CommonClientConfiguration.class, OperateClientConfiguration.class})
   @EnableConfigurationProperties(ZeebeClientConfigurationProperties.class)
   public static class TestConfig {
-
+    @Bean
+    public JsonMapper jsonMapper(){
+      return new SdkObjectMapper();
+    }
   }
 
   @Autowired

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedKeycloakUrlTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedKeycloakUrlTest.java
@@ -4,6 +4,8 @@ import io.camunda.common.auth.Authentication;
 import io.camunda.common.auth.JwtCredential;
 import io.camunda.common.auth.Product;
 import io.camunda.common.auth.SelfManagedAuthentication;
+import io.camunda.common.json.JsonMapper;
+import io.camunda.common.json.SdkObjectMapper;
 import io.camunda.operate.CamundaOperateClient;
 import io.camunda.zeebe.spring.client.configuration.CommonClientConfiguration;
 import io.camunda.zeebe.spring.client.configuration.OperateClientConfiguration;
@@ -13,6 +15,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -37,7 +40,10 @@ public class OperateSelfManagedKeycloakUrlTest {
   @ImportAutoConfiguration({CommonClientConfiguration.class, OperateClientConfiguration.class})
   @EnableConfigurationProperties(ZeebeClientConfigurationProperties.class)
   public static class TestConfig {
-
+    @Bean
+    public JsonMapper jsonMapper(){
+      return new SdkObjectMapper();
+    }
   }
 
   @Autowired


### PR DESCRIPTION
Currently, the token provider not refresh a token unless it is reported invalid by the server.

This behaviour does not work with the zeebe client.

This fix refactors the jwt authentication to check the validity of a token BEFORE sending the request and eventually refreshing the token upfront.

closes #631 