### PR TITLE
631 fix(common-authentication): Token not refreshed #633

### DIFF
--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/Authentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/Authentication.java
@@ -4,9 +4,11 @@ import java.util.Map;
 
 public interface Authentication {
 
-  Authentication build();
-
   Map.Entry<String, String> getTokenHeader(Product product);
 
   void resetToken(Product product);
+
+  interface AuthenticationBuilder {
+    Authentication build();
+  }
 }

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/DefaultNoopAuthentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/DefaultNoopAuthentication.java
@@ -17,10 +17,8 @@ public class DefaultNoopAuthentication implements Authentication {
   private final String errorMessage =
       "Unable to determine authentication. Please check your configuration";
 
-  @Override
-  public Authentication build() {
+  public DefaultNoopAuthentication() {
     LOG.error(errorMessage);
-    return this;
   }
 
   @Override

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/JwtAuthentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/JwtAuthentication.java
@@ -1,13 +1,10 @@
 package io.camunda.common.auth;
 
-import java.lang.invoke.MethodHandles;
 import java.time.LocalDateTime;
 import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public abstract class JwtAuthentication implements Authentication {
 

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/JwtAuthentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/JwtAuthentication.java
@@ -1,7 +1,67 @@
 package io.camunda.common.auth;
 
-/**
- * TODO: Figure out common functionality between SaaS and Self Managed that can be inserted here to
- * reduce code duplication. If not, remove this class
- */
-public abstract class JwtAuthentication implements Authentication {}
+import java.lang.invoke.MethodHandles;
+import java.time.LocalDateTime;
+import java.util.AbstractMap;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class JwtAuthentication implements Authentication {
+
+  private final JwtConfig jwtConfig;
+  private final Map<Product, JwtToken> tokens = new HashMap<>();
+
+  protected JwtAuthentication(JwtConfig jwtConfig) {
+    this.jwtConfig = jwtConfig;
+  }
+
+  public JwtConfig getJwtConfig() {
+    return jwtConfig;
+  }
+
+  @Override
+  public final void resetToken(Product product) {
+    tokens.remove(product);
+  }
+
+  @Override
+  public final Entry<String, String> getTokenHeader(Product product) {
+    if (!tokens.containsKey(product) || !isValid(tokens.get(product))) {
+      JwtToken newToken = generateToken(product, jwtConfig.getProduct(product));
+      tokens.put(product, newToken);
+    }
+    return authHeader(tokens.get(product).getToken());
+  }
+
+  protected abstract JwtToken generateToken(Product product, JwtCredential credential);
+
+  private Entry<String, String> authHeader(String token) {
+    return new AbstractMap.SimpleEntry<>("Authorization", "Bearer " + token);
+  }
+
+  private boolean isValid(JwtToken jwtToken) {
+    // a token is only counted valid if it is only valid for at least 30 seconds
+    return jwtToken.getExpiry().isAfter(LocalDateTime.now().minusSeconds(30));
+  }
+
+  protected static class JwtToken {
+    private final String token;
+    private final LocalDateTime expiry;
+
+    public JwtToken(String token, LocalDateTime expiry) {
+      this.token = token;
+      this.expiry = expiry;
+    }
+
+    public String getToken() {
+      return token;
+    }
+
+    public LocalDateTime getExpiry() {
+      return expiry;
+    }
+  }
+}

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/JwtAuthenticationBuilder.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/JwtAuthenticationBuilder.java
@@ -1,0 +1,22 @@
+package io.camunda.common.auth;
+
+import io.camunda.common.auth.Authentication.AuthenticationBuilder;
+
+public abstract class JwtAuthenticationBuilder<T extends JwtAuthenticationBuilder<?>>
+    implements AuthenticationBuilder {
+  private JwtConfig jwtConfig;
+
+  public final T withJwtConfig(JwtConfig jwtConfig) {
+    this.jwtConfig = jwtConfig;
+    return self();
+  }
+
+  @Override
+  public final Authentication build() {
+    return build(jwtConfig);
+  }
+
+  protected abstract T self();
+
+  protected abstract Authentication build(JwtConfig jwtConfig);
+}

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SaaSAuthentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SaaSAuthentication.java
@@ -1,11 +1,8 @@
 package io.camunda.common.auth;
 
 import io.camunda.common.json.JsonMapper;
-import io.camunda.common.json.SdkObjectMapper;
 import java.lang.invoke.MethodHandles;
-import java.util.AbstractMap;
-import java.util.HashMap;
-import java.util.Map;
+import java.time.LocalDateTime;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
@@ -17,53 +14,29 @@ import org.slf4j.LoggerFactory;
 public class SaaSAuthentication extends JwtAuthentication {
 
   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-  private JwtConfig jwtConfig;
-  private Map<Product, String> tokens;
 
-  // TODO: have a single object mapper to be used all throughout the SDK, i.e.bean injection
-  private JsonMapper jsonMapper = new SdkObjectMapper();
+  private final JsonMapper jsonMapper;
 
-  public SaaSAuthentication() {
-    tokens = new HashMap<>();
+  public SaaSAuthentication(JwtConfig jwtConfig, JsonMapper jsonMapper) {
+    super(jwtConfig);
+    this.jsonMapper = jsonMapper;
   }
 
   public static SaaSAuthenticationBuilder builder() {
     return new SaaSAuthenticationBuilder();
   }
 
-  public JwtConfig getJwtConfig() {
-    return jwtConfig;
-  }
-
-  public void setJwtConfig(JwtConfig jwtConfig) {
-    this.jwtConfig = jwtConfig;
-  }
-
-  @Override
-  public Authentication build() {
-    return this;
-  }
-
-  @Override
-  public void resetToken(Product product) {
-    tokens.remove(product);
-  }
-
-  private String retrieveToken(Product product, JwtCredential jwtCredential) {
+  private TokenResponse retrieveToken(Product product, JwtCredential jwtCredential) {
     try (CloseableHttpClient client = HttpClients.createDefault()) {
       HttpPost request = buildRequest(jwtCredential);
-      TokenResponse tokenResponse =
-          client.execute(
-              request,
-              response ->
-                  jsonMapper.fromJson(
-                      EntityUtils.toString(response.getEntity()), TokenResponse.class));
-      tokens.put(product, tokenResponse.getAccessToken());
+      return client.execute(
+          request,
+          response ->
+              jsonMapper.fromJson(EntityUtils.toString(response.getEntity()), TokenResponse.class));
     } catch (Exception e) {
       LOG.error("Authenticating for " + product + " failed due to " + e);
       throw new RuntimeException("Unable to authenticate", e);
     }
-    return tokens.get(product);
   }
 
   private HttpPost buildRequest(JwtCredential jwtCredential) {
@@ -79,14 +52,10 @@ public class SaaSAuthentication extends JwtAuthentication {
   }
 
   @Override
-  public Map.Entry<String, String> getTokenHeader(Product product) {
-    String token;
-    if (tokens.containsKey(product)) {
-      token = tokens.get(product);
-    } else {
-      JwtCredential jwtCredential = jwtConfig.getProduct(product);
-      token = retrieveToken(product, jwtCredential);
-    }
-    return new AbstractMap.SimpleEntry<>("Authorization", "Bearer " + token);
+  protected JwtToken generateToken(Product product, JwtCredential credential) {
+    TokenResponse tokenResponse = retrieveToken(product, credential);
+    return new JwtToken(
+        tokenResponse.getAccessToken(),
+        LocalDateTime.now().plusSeconds(tokenResponse.getExpiresIn()));
   }
 }

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SaaSAuthenticationBuilder.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SaaSAuthenticationBuilder.java
@@ -1,19 +1,22 @@
 package io.camunda.common.auth;
 
-public class SaaSAuthenticationBuilder {
+import io.camunda.common.json.JsonMapper;
 
-  SaaSAuthentication saaSAuthentication;
+public class SaaSAuthenticationBuilder extends JwtAuthenticationBuilder<SaaSAuthenticationBuilder> {
+  private JsonMapper jsonMapper;
 
-  SaaSAuthenticationBuilder() {
-    saaSAuthentication = new SaaSAuthentication();
-  }
-
-  public SaaSAuthenticationBuilder jwtConfig(JwtConfig jwtConfig) {
-    saaSAuthentication.setJwtConfig(jwtConfig);
+  public SaaSAuthenticationBuilder withJsonMapper(JsonMapper jsonMapper) {
+    this.jsonMapper = jsonMapper;
     return this;
   }
 
-  public Authentication build() {
-    return saaSAuthentication.build();
+  @Override
+  protected SaaSAuthenticationBuilder self() {
+    return this;
+  }
+
+  @Override
+  protected SaaSAuthentication build(JwtConfig jwtConfig) {
+    return new SaaSAuthentication(jwtConfig, jsonMapper);
   }
 }

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SelfManagedAuthentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SelfManagedAuthentication.java
@@ -3,10 +3,7 @@ package io.camunda.common.auth;
 import io.camunda.common.auth.identity.IdentityConfig;
 import io.camunda.identity.sdk.Identity;
 import io.camunda.identity.sdk.authentication.Tokens;
-import java.lang.invoke.MethodHandles;
 import java.time.LocalDateTime;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class SelfManagedAuthentication extends JwtAuthentication {
 

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SelfManagedAuthenticationBuilder.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SelfManagedAuthenticationBuilder.java
@@ -2,25 +2,22 @@ package io.camunda.common.auth;
 
 import io.camunda.common.auth.identity.IdentityConfig;
 
-public class SelfManagedAuthenticationBuilder {
+public class SelfManagedAuthenticationBuilder
+    extends JwtAuthenticationBuilder<SelfManagedAuthenticationBuilder> {
+  private IdentityConfig identityConfig;
 
-  SelfManagedAuthentication selfManagedAuthentication;
-
-  SelfManagedAuthenticationBuilder() {
-    selfManagedAuthentication = new SelfManagedAuthentication();
-  }
-
-  public SelfManagedAuthenticationBuilder jwtConfig(JwtConfig jwtConfig) {
-    selfManagedAuthentication.setJwtConfig(jwtConfig);
+  public SelfManagedAuthenticationBuilder withIdentityConfig(IdentityConfig identityConfig) {
+    this.identityConfig = identityConfig;
     return this;
   }
 
-  public SelfManagedAuthenticationBuilder identityConfig(IdentityConfig identityConfig) {
-    selfManagedAuthentication.setIdentityConfig(identityConfig);
+  @Override
+  protected SelfManagedAuthenticationBuilder self() {
     return this;
   }
 
-  public Authentication build() {
-    return selfManagedAuthentication.build();
+  @Override
+  protected Authentication build(JwtConfig jwtConfig) {
+    return new SelfManagedAuthentication(jwtConfig, identityConfig);
   }
 }

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SimpleAuthentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SimpleAuthentication.java
@@ -16,36 +16,22 @@ public class SimpleAuthentication implements Authentication {
 
   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  private String simpleUrl;
-  private SimpleConfig simpleConfig;
-  private Map<Product, String> tokens;
+  private final SimpleConfig simpleConfig;
+  private final Map<Product, String> tokens = new HashMap<>();
 
-  private String authUrl;
+  private final String authUrl;
 
-  public void setSimpleUrl(String simpleUrl) {
-    this.simpleUrl = simpleUrl;
+  public SimpleAuthentication(String simpleUrl, SimpleConfig simpleConfig) {
+    this.simpleConfig = simpleConfig;
+    this.authUrl = simpleUrl + "/api/login";
   }
 
   public SimpleConfig getSimpleConfig() {
     return simpleConfig;
   }
 
-  public void setSimpleConfig(SimpleConfig simpleConfig) {
-    this.simpleConfig = simpleConfig;
-  }
-
-  public SimpleAuthentication() {
-    tokens = new HashMap<>();
-  }
-
   public static SimpleAuthenticationBuilder builder() {
     return new SimpleAuthenticationBuilder();
-  }
-
-  @Override
-  public Authentication build() {
-    authUrl = simpleUrl + "/api/login";
-    return this;
   }
 
   private String retrieveToken(Product product, SimpleCredential simpleCredential) {

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SimpleAuthenticationBuilder.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SimpleAuthenticationBuilder.java
@@ -1,24 +1,23 @@
 package io.camunda.common.auth;
 
-public class SimpleAuthenticationBuilder {
+import io.camunda.common.auth.Authentication.AuthenticationBuilder;
 
-  SimpleAuthentication simpleAuthentication;
+public class SimpleAuthenticationBuilder implements AuthenticationBuilder {
+  private String simpleUrl;
+  private SimpleConfig simpleConfig;
 
-  SimpleAuthenticationBuilder() {
-    simpleAuthentication = new SimpleAuthentication();
-  }
-
-  public SimpleAuthenticationBuilder simpleConfig(SimpleConfig simpleConfig) {
-    simpleAuthentication.setSimpleConfig(simpleConfig);
+  public SimpleAuthenticationBuilder withSimpleUrl(String simpleUrl) {
+    this.simpleUrl = simpleUrl;
     return this;
   }
 
-  public SimpleAuthenticationBuilder simpleUrl(String simpleUrl) {
-    simpleAuthentication.setSimpleUrl(simpleUrl);
+  public SimpleAuthenticationBuilder withSimpleConfig(SimpleConfig simpleConfig) {
+    this.simpleConfig = simpleConfig;
     return this;
   }
 
+  @Override
   public Authentication build() {
-    return simpleAuthentication.build();
+    return new SimpleAuthentication(simpleUrl, simpleConfig);
   }
 }

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/CamundaAutoConfiguration.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/CamundaAutoConfiguration.java
@@ -4,6 +4,7 @@ import static com.fasterxml.jackson.databind.DeserializationFeature.ACCEPT_EMPTY
 import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.common.json.SdkObjectMapper;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
@@ -69,5 +70,11 @@ public class CamundaAutoConfiguration {
   @ConditionalOnMissingBean
   public JsonMapper jsonMapper(ObjectMapper objectMapper) {
     return new ZeebeObjectMapper(objectMapper);
+  }
+
+  @Bean(name = "commonJsonMapper")
+  @ConditionalOnMissingBean
+  public io.camunda.common.json.JsonMapper commonJsonMapper(ObjectMapper objectMapper) {
+    return new SdkObjectMapper(objectMapper);
   }
 }

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/CommonClientConfiguration.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/CommonClientConfiguration.java
@@ -6,6 +6,7 @@ import io.camunda.common.auth.*;
 import io.camunda.common.auth.identity.IdentityConfig;
 import io.camunda.common.auth.identity.IdentityContainer;
 import io.camunda.common.exception.SdkException;
+import io.camunda.common.json.JsonMapper;
 import io.camunda.identity.sdk.Identity;
 import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.zeebe.spring.client.properties.*;
@@ -44,13 +45,16 @@ public class CommonClientConfiguration {
   private IdentityConfiguration identityConfigurationFromProperties;
 
   @Bean
-  public Authentication authentication() {
+  public Authentication authentication(JsonMapper jsonMapper) {
 
     // TODO: Refactor
     if (zeebeClientConfigurationProperties != null) {
       // check if Zeebe has clusterId provided, then must be SaaS
       if (zeebeClientConfigurationProperties.getCloud().getClusterId() != null) {
-        return SaaSAuthentication.builder().jwtConfig(configureJwtConfig()).build();
+        return SaaSAuthentication.builder()
+            .withJwtConfig(configureJwtConfig())
+            .withJsonMapper(jsonMapper)
+            .build();
       } else if (zeebeClientConfigurationProperties.getBroker().getGatewayAddress() != null
           || zeebeSelfManagedProperties.getGatewayAddress() != null) {
         // figure out if Self-Managed JWT or Self-Managed Basic
@@ -61,8 +65,8 @@ public class CommonClientConfiguration {
             JwtConfig jwtConfig = configureJwtConfig();
             IdentityConfig identityConfig = configureIdentities(jwtConfig);
             return SelfManagedAuthentication.builder()
-                .jwtConfig(jwtConfig)
-                .identityConfig(identityConfig)
+                .withJwtConfig(jwtConfig)
+                .withIdentityConfig(identityConfig)
                 .build();
           } else if (operateClientConfigurationProperties.getUsername() != null
               && operateClientConfigurationProperties.getPassword() != null) {
@@ -73,8 +77,8 @@ public class CommonClientConfiguration {
                     operateClientConfigurationProperties.getPassword());
             simpleConfig.addProduct(Product.OPERATE, simpleCredential);
             return SimpleAuthentication.builder()
-                .simpleConfig(simpleConfig)
-                .simpleUrl(operateClientConfigurationProperties.getUrl())
+                .withSimpleConfig(simpleConfig)
+                .withSimpleUrl(operateClientConfigurationProperties.getUrl())
                 .build();
           }
         }
@@ -85,8 +89,8 @@ public class CommonClientConfiguration {
             JwtConfig jwtConfig = configureJwtConfig();
             IdentityConfig identityConfig = configureIdentities(jwtConfig);
             return SelfManagedAuthentication.builder()
-                .jwtConfig(jwtConfig)
-                .identityConfig(identityConfig)
+                .withJwtConfig(jwtConfig)
+                .withIdentityConfig(identityConfig)
                 .build();
           }
         }
@@ -97,15 +101,15 @@ public class CommonClientConfiguration {
             JwtConfig jwtConfig = configureJwtConfig();
             IdentityConfig identityConfig = configureIdentities(jwtConfig);
             return SelfManagedAuthentication.builder()
-                .jwtConfig(jwtConfig)
-                .identityConfig(identityConfig)
+                .withJwtConfig(jwtConfig)
+                .withIdentityConfig(identityConfig)
                 .build();
           } else if (commonConfigurationProperties.getKeycloak().getTokenUrl() != null) {
             JwtConfig jwtConfig = configureJwtConfig();
             IdentityConfig identityConfig = configureIdentities(jwtConfig);
             return SelfManagedAuthentication.builder()
-                .jwtConfig(jwtConfig)
-                .identityConfig(identityConfig)
+                .withJwtConfig(jwtConfig)
+                .withIdentityConfig(identityConfig)
                 .build();
           } else if (commonConfigurationProperties.getUsername() != null
               && commonConfigurationProperties.getPassword() != null) {
@@ -116,14 +120,14 @@ public class CommonClientConfiguration {
                     commonConfigurationProperties.getPassword());
             simpleConfig.addProduct(Product.OPERATE, simpleCredential);
             return SimpleAuthentication.builder()
-                .simpleConfig(simpleConfig)
-                .simpleUrl(commonConfigurationProperties.getUrl())
+                .withSimpleConfig(simpleConfig)
+                .withSimpleUrl(commonConfigurationProperties.getUrl())
                 .build();
           }
         }
       }
     }
-    return new DefaultNoopAuthentication().build();
+    return new DefaultNoopAuthentication();
   }
 
   private JwtConfig configureJwtConfig() {

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientStarterAutoConfigurationCustomJsonMapperTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientStarterAutoConfigurationCustomJsonMapperTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.common.json.SdkObjectMapper;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
 import io.camunda.zeebe.spring.client.CamundaAutoConfiguration;
@@ -46,6 +47,10 @@ import org.springframework.test.util.ReflectionTestUtils;
 public class ZeebeClientStarterAutoConfigurationCustomJsonMapperTest {
 
   public static class TestConfig {
+    @Bean
+    public io.camunda.common.json.JsonMapper commonJsonMapper() {
+      return new SdkObjectMapper();
+    }
 
     @Primary
     @Bean(name = "overridingJsonMapper")

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSaasOperateCredentialTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSaasOperateCredentialTest.java
@@ -6,6 +6,8 @@ import io.camunda.common.auth.Authentication;
 import io.camunda.common.auth.JwtCredential;
 import io.camunda.common.auth.Product;
 import io.camunda.common.auth.SaaSAuthentication;
+import io.camunda.common.json.JsonMapper;
+import io.camunda.common.json.SdkObjectMapper;
 import io.camunda.operate.CamundaOperateClient;
 import io.camunda.zeebe.spring.client.configuration.CommonClientConfiguration;
 import io.camunda.zeebe.spring.client.configuration.OperateClientConfiguration;
@@ -15,6 +17,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -35,7 +38,12 @@ public class OperateSaasOperateCredentialTest {
 
   @ImportAutoConfiguration({CommonClientConfiguration.class, OperateClientConfiguration.class})
   @EnableConfigurationProperties(ZeebeClientConfigurationProperties.class)
-  public static class TestConfig {}
+  public static class TestConfig {
+    @Bean
+    public JsonMapper jsonMapper() {
+      return new SdkObjectMapper();
+    }
+  }
 
   @Autowired private Authentication authentication;
 

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSaasZeebeCredentialTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSaasZeebeCredentialTest.java
@@ -3,6 +3,8 @@ package io.camunda.zeebe.spring.client.config.authentication;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.common.auth.*;
+import io.camunda.common.json.JsonMapper;
+import io.camunda.common.json.SdkObjectMapper;
 import io.camunda.operate.CamundaOperateClient;
 import io.camunda.zeebe.spring.client.configuration.CommonClientConfiguration;
 import io.camunda.zeebe.spring.client.configuration.OperateClientConfiguration;
@@ -12,6 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -30,7 +33,12 @@ public class OperateSaasZeebeCredentialTest {
 
   @ImportAutoConfiguration({CommonClientConfiguration.class, OperateClientConfiguration.class})
   @EnableConfigurationProperties(ZeebeClientConfigurationProperties.class)
-  public static class TestConfig {}
+  public static class TestConfig {
+    @Bean
+    public JsonMapper jsonMapper() {
+      return new SdkObjectMapper();
+    }
+  }
 
   @Autowired private Authentication authentication;
 

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedBasicTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedBasicTest.java
@@ -6,6 +6,8 @@ import io.camunda.common.auth.Authentication;
 import io.camunda.common.auth.Product;
 import io.camunda.common.auth.SimpleAuthentication;
 import io.camunda.common.auth.SimpleCredential;
+import io.camunda.common.json.JsonMapper;
+import io.camunda.common.json.SdkObjectMapper;
 import io.camunda.identity.autoconfigure.IdentityAutoConfiguration;
 import io.camunda.operate.CamundaOperateClient;
 import io.camunda.zeebe.spring.client.configuration.CommonClientConfiguration;
@@ -16,6 +18,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -37,7 +40,12 @@ public class OperateSelfManagedBasicTest {
     IdentityAutoConfiguration.class
   })
   @EnableConfigurationProperties(ZeebeClientConfigurationProperties.class)
-  public static class TestConfig {}
+  public static class TestConfig {
+    @Bean
+    public JsonMapper jsonMapper() {
+      return new SdkObjectMapper();
+    }
+  }
 
   @Autowired private Authentication authentication;
 

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedBasicWithZeebeCredentialsTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedBasicWithZeebeCredentialsTest.java
@@ -6,6 +6,8 @@ import io.camunda.common.auth.Authentication;
 import io.camunda.common.auth.Product;
 import io.camunda.common.auth.SimpleAuthentication;
 import io.camunda.common.auth.SimpleCredential;
+import io.camunda.common.json.JsonMapper;
+import io.camunda.common.json.SdkObjectMapper;
 import io.camunda.identity.autoconfigure.IdentityAutoConfiguration;
 import io.camunda.operate.CamundaOperateClient;
 import io.camunda.zeebe.spring.client.configuration.CommonClientConfiguration;
@@ -16,6 +18,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -41,7 +44,12 @@ public class OperateSelfManagedBasicWithZeebeCredentialsTest {
     IdentityAutoConfiguration.class
   })
   @EnableConfigurationProperties(ZeebeClientConfigurationProperties.class)
-  public static class TestConfig {}
+  public static class TestConfig {
+    @Bean
+    public JsonMapper jsonMapper() {
+      return new SdkObjectMapper();
+    }
+  }
 
   @Autowired private Authentication authentication;
 

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedIdentityTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedIdentityTest.java
@@ -3,6 +3,8 @@ package io.camunda.zeebe.spring.client.config.authentication;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.common.auth.*;
+import io.camunda.common.json.JsonMapper;
+import io.camunda.common.json.SdkObjectMapper;
 import io.camunda.identity.autoconfigure.IdentityAutoConfiguration;
 import io.camunda.operate.CamundaOperateClient;
 import io.camunda.zeebe.spring.client.configuration.CommonClientConfiguration;
@@ -13,6 +15,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -42,7 +45,12 @@ public class OperateSelfManagedIdentityTest {
     IdentityAutoConfiguration.class
   })
   @EnableConfigurationProperties(ZeebeClientConfigurationProperties.class)
-  public static class TestConfig {}
+  public static class TestConfig {
+    @Bean
+    public JsonMapper jsonMapper() {
+      return new SdkObjectMapper();
+    }
+  }
 
   @Autowired private Authentication authentication;
 

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedKeycloakTokenUrlTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedKeycloakTokenUrlTest.java
@@ -3,6 +3,8 @@ package io.camunda.zeebe.spring.client.config.authentication;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.common.auth.*;
+import io.camunda.common.json.JsonMapper;
+import io.camunda.common.json.SdkObjectMapper;
 import io.camunda.identity.autoconfigure.IdentityAutoConfiguration;
 import io.camunda.operate.CamundaOperateClient;
 import io.camunda.zeebe.spring.client.configuration.CommonClientConfiguration;
@@ -13,6 +15,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -37,7 +40,12 @@ public class OperateSelfManagedKeycloakTokenUrlTest {
     IdentityAutoConfiguration.class
   })
   @EnableConfigurationProperties(ZeebeClientConfigurationProperties.class)
-  public static class TestConfig {}
+  public static class TestConfig {
+    @Bean
+    public JsonMapper jsonMapper() {
+      return new SdkObjectMapper();
+    }
+  }
 
   @Autowired private Authentication authentication;
 

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedKeycloakUrlTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/authentication/OperateSelfManagedKeycloakUrlTest.java
@@ -6,6 +6,8 @@ import io.camunda.common.auth.Authentication;
 import io.camunda.common.auth.JwtCredential;
 import io.camunda.common.auth.Product;
 import io.camunda.common.auth.SelfManagedAuthentication;
+import io.camunda.common.json.JsonMapper;
+import io.camunda.common.json.SdkObjectMapper;
 import io.camunda.identity.autoconfigure.IdentityAutoConfiguration;
 import io.camunda.operate.CamundaOperateClient;
 import io.camunda.zeebe.spring.client.configuration.CommonClientConfiguration;
@@ -16,6 +18,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -40,7 +43,12 @@ public class OperateSelfManagedKeycloakUrlTest {
     IdentityAutoConfiguration.class
   })
   @EnableConfigurationProperties(ZeebeClientConfigurationProperties.class)
-  public static class TestConfig {}
+  public static class TestConfig {
+    @Bean
+    public JsonMapper jsonMapper() {
+      return new SdkObjectMapper();
+    }
+  }
 
   @Autowired private Authentication authentication;
 


### PR DESCRIPTION
Currently, the token provider not refresh a token unless it is reported invalid by the server.

This behaviour does not work with the zeebe client.

This fix refactors the jwt authentication to check the validity of a token BEFORE sending the request and eventually refreshing the token upfront.

closes https://github.com/camunda-community-hub/spring-zeebe/issues/631