### PR TITLE
chore: prepare bump zeebe version to 8.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ camunda:
     zeebe:
       enabled: true
       base-url: http://localhost:26500
+      rest-address: http://localhost:8080
     operate:
       enabled: true
       base-url: http://localhost:8081
@@ -192,6 +193,7 @@ camunda:
     zeebe:
       enabled: true
       base-url: http://localhost:26500
+      rest-address: http://localhost:8080
       audience: zeebe-api
     operate:
       enabled: true

--- a/README.md
+++ b/README.md
@@ -156,8 +156,9 @@ camunda:
       password: demo
     zeebe:
       enabled: true
-      base-url: http://localhost:26500
-      rest-address: http://localhost:8080
+      gateway-url: http://localhost:26500
+      base-url: http://localhost:8080
+      prefer-rest-over-grpc: false
     operate:
       enabled: true
       base-url: http://localhost:8081
@@ -192,8 +193,9 @@ camunda:
       issuer: http://localhost:18080/auth/realms/camunda-platform
     zeebe:
       enabled: true
-      base-url: http://localhost:26500
-      rest-address: http://localhost:8080
+      gateway-url: http://localhost:26500
+      base-url: http://localhost:8080
+      prefer-rest-over-grpc: false
       audience: zeebe-api
     operate:
       enabled: true

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,9 @@
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
 
-    <zeebe.version>8.4.5</zeebe.version>
-    <identity.version>8.4.5</identity.version>
+    <zeebe.version>8.5.0-RC2</zeebe.version>
+    <version.zeebe-process-test-extension>8.5.0-alpha2</version.zeebe-process-test-extension>
+    <identity.version>8.5.0-alpha2</identity.version>
 
     <spring-boot.version>3.2.4</spring-boot.version>
     <commons-beanutils.version>1.9.4</commons-beanutils.version>
@@ -83,12 +84,12 @@
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-process-test-extension</artifactId>
-        <version>${zeebe.version}</version>
+        <version>${version.zeebe-process-test-extension}</version>
       </dependency>
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-process-test-extension-testcontainer</artifactId>
-        <version>${zeebe.version}</version>
+        <version>${version.zeebe-process-test-extension}</version>
       </dependency>
       <dependency>
         <groupId>io.camunda.spring</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,7 @@
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
 
-    <zeebe.version>8.5.0-RC2</zeebe.version>
-    <version.zeebe-process-test-extension>8.5.0-alpha2</version.zeebe-process-test-extension>
+    <zeebe.version>8.5.0</zeebe.version>
     <identity.version>8.5.0</identity.version>
 
     <spring-boot.version>3.2.4</spring-boot.version>
@@ -84,12 +83,12 @@
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-process-test-extension</artifactId>
-        <version>${version.zeebe-process-test-extension}</version>
+        <version>${zeebe.version}</version>
       </dependency>
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-process-test-extension-testcontainer</artifactId>
-        <version>${version.zeebe-process-test-extension}</version>
+        <version>${zeebe.version}</version>
       </dependency>
       <dependency>
         <groupId>io.camunda.spring</groupId>

--- a/spring-boot-starter-camunda/pom.xml
+++ b/spring-boot-starter-camunda/pom.xml
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>org.wiremock</groupId>
       <artifactId>wiremock-standalone</artifactId>
-      <version>3.4.2</version>
+      <version>3.5.1</version>
       <scope>test</scope>
     </dependency>
 

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientConfiguration.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientConfiguration.java
@@ -74,38 +74,38 @@ public class ZeebeClientConfiguration implements io.camunda.zeebe.client.ZeebeCl
 
   @Override
   public URI getRestAddress() {
-    return URI.create(camundaClientProperties.getZeebe().getRestAddress().toString());
+    return URI.create(camundaClientProperties.getZeebe().getBaseUrl().toString());
   }
 
   @Override
   public URI getGrpcAddress() {
-    return URI.create(camundaClientProperties.getZeebe().getBaseUrl().toString());
+    return URI.create(camundaClientProperties.getZeebe().getGatewayUrl().toString());
   }
 
   private String composeGatewayAddress() {
     // check if port is set
-    if (camundaClientProperties.getZeebe().getBaseUrl().getPort() != -1) {
+    if (camundaClientProperties.getZeebe().getGatewayUrl().getPort() != -1) {
       String gatewayAddress =
-          camundaClientProperties.getZeebe().getBaseUrl().getHost()
+          camundaClientProperties.getZeebe().getGatewayUrl().getHost()
               + ":"
-              + camundaClientProperties.getZeebe().getBaseUrl().getPort();
+              + camundaClientProperties.getZeebe().getGatewayUrl().getPort();
       LOG.debug("Gateway port is set, address will be '{}'", gatewayAddress);
       return gatewayAddress;
     }
     // check if default port can be applied
-    if (camundaClientProperties.getZeebe().getBaseUrl().getDefaultPort() != -1) {
+    if (camundaClientProperties.getZeebe().getGatewayUrl().getDefaultPort() != -1) {
       String gatewayAddress =
-          camundaClientProperties.getZeebe().getBaseUrl().getHost()
+          camundaClientProperties.getZeebe().getGatewayUrl().getHost()
               + ":"
-              + camundaClientProperties.getZeebe().getBaseUrl().getDefaultPort();
+              + camundaClientProperties.getZeebe().getGatewayUrl().getDefaultPort();
       LOG.debug("Gateway port has default, address will be '{}'", gatewayAddress);
       return gatewayAddress;
     }
     LOG.debug(
         "Gateway cannot be determined, address will be '{}'",
-        camundaClientProperties.getZeebe().getBaseUrl().getHost());
+        camundaClientProperties.getZeebe().getGatewayUrl().getHost());
     // do not use any port
-    return camundaClientProperties.getZeebe().getBaseUrl().getHost();
+    return camundaClientProperties.getZeebe().getGatewayUrl().getHost();
   }
 
   @Override
@@ -221,7 +221,7 @@ public class ZeebeClientConfiguration implements io.camunda.zeebe.client.ZeebeCl
   }
 
   private boolean composePlaintext() {
-    String protocol = camundaClientProperties.getZeebe().getBaseUrl().getProtocol();
+    String protocol = camundaClientProperties.getZeebe().getGatewayUrl().getProtocol();
     if (protocol.equals("http")) {
       return true;
     }
@@ -231,7 +231,7 @@ public class ZeebeClientConfiguration implements io.camunda.zeebe.client.ZeebeCl
     throw new IllegalStateException(
         String.format(
             "Unrecognized zeebe protocol '%s'",
-            camundaClientProperties.getZeebe().getBaseUrl().getProtocol()));
+            camundaClientProperties.getZeebe().getGatewayUrl().getProtocol()));
   }
 
   @Override
@@ -361,7 +361,7 @@ public class ZeebeClientConfiguration implements io.camunda.zeebe.client.ZeebeCl
 
   @Override
   public boolean preferRestOverGrpc() {
-    return false;
+    return camundaClientProperties.getZeebe().isPreferRestOverGrpc();
   }
 
   @Override

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/properties/common/ZeebeClientProperties.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/properties/common/ZeebeClientProperties.java
@@ -15,8 +15,8 @@ public class ZeebeClientProperties extends ApiProperties {
   private String overrideAuthority;
   private ZeebeWorkerValue defaults;
   private Map<String, ZeebeWorkerValue> override;
-
-  private URL restAddress;
+  private URL gatewayUrl;
+  private boolean preferRestOverGrpc;
 
   public ZeebeWorkerValue getDefaults() {
     return defaults;
@@ -90,11 +90,19 @@ public class ZeebeClientProperties extends ApiProperties {
     this.maxMessageSize = maxMessageSize;
   }
 
-  public URL getRestAddress() {
-    return restAddress;
+  public URL getGatewayUrl() {
+    return gatewayUrl;
   }
 
-  public void setRestAddress(URL restAddress) {
-    this.restAddress = restAddress;
+  public void setGatewayUrl(URL gatewayUrl) {
+    this.gatewayUrl = gatewayUrl;
+  }
+
+  public boolean isPreferRestOverGrpc() {
+    return preferRestOverGrpc;
+  }
+
+  public void setPreferRestOverGrpc(boolean preferRestOverGrpc) {
+    this.preferRestOverGrpc = preferRestOverGrpc;
   }
 }

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/properties/common/ZeebeClientProperties.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/properties/common/ZeebeClientProperties.java
@@ -1,6 +1,7 @@
 package io.camunda.zeebe.spring.client.properties.common;
 
 import io.camunda.zeebe.spring.client.annotation.value.ZeebeWorkerValue;
+import java.net.URL;
 import java.time.Duration;
 import java.util.Map;
 
@@ -14,6 +15,8 @@ public class ZeebeClientProperties extends ApiProperties {
   private String overrideAuthority;
   private ZeebeWorkerValue defaults;
   private Map<String, ZeebeWorkerValue> override;
+
+  private URL restAddress;
 
   public ZeebeWorkerValue getDefaults() {
     return defaults;
@@ -85,5 +88,13 @@ public class ZeebeClientProperties extends ApiProperties {
 
   public void setMaxMessageSize(Integer maxMessageSize) {
     this.maxMessageSize = maxMessageSize;
+  }
+
+  public URL getRestAddress() {
+    return restAddress;
+  }
+
+  public void setRestAddress(URL restAddress) {
+    this.restAddress = restAddress;
   }
 }

--- a/spring-boot-starter-camunda/src/main/resources/application-camunda-oidc.yaml
+++ b/spring-boot-starter-camunda/src/main/resources/application-camunda-oidc.yaml
@@ -10,6 +10,7 @@ camunda:
       enabled: true
       base-url: http://localhost:26500
       audience: zeebe-api
+      rest-address: http://localhost:8080
     operate:
       enabled: true
       base-url: http://localhost:8081

--- a/spring-boot-starter-camunda/src/main/resources/application-camunda-oidc.yaml
+++ b/spring-boot-starter-camunda/src/main/resources/application-camunda-oidc.yaml
@@ -8,9 +8,10 @@ camunda:
       issuer: http://localhost:18080/auth/realms/camunda-platform
     zeebe:
       enabled: true
-      base-url: http://localhost:26500
+      base-url: http://localhost:8080
+      gateway-url: http://localhost:26500
       audience: zeebe-api
-      rest-address: http://localhost:8080
+      prefer-rest-over-grpc: false
     operate:
       enabled: true
       base-url: http://localhost:8081

--- a/spring-boot-starter-camunda/src/main/resources/application-camunda-saas.yaml
+++ b/spring-boot-starter-camunda/src/main/resources/application-camunda-saas.yaml
@@ -9,6 +9,7 @@ camunda:
       enabled: true
       audience: zeebe.camunda.io
       base-url: https://${camunda.client.cluster-id}.${camunda.client.region}.zeebe.camunda.io
+      rest-address: https://${camunda.client.cluster-id}.${camunda.client.region}.zeebe.camunda.io
     operate:
       enabled: true
       audience: operate.camunda.io

--- a/spring-boot-starter-camunda/src/main/resources/application-camunda-saas.yaml
+++ b/spring-boot-starter-camunda/src/main/resources/application-camunda-saas.yaml
@@ -8,8 +8,9 @@ camunda:
     zeebe:
       enabled: true
       audience: zeebe.camunda.io
-      base-url: https://${camunda.client.cluster-id}.${camunda.client.region}.zeebe.camunda.io
-      rest-address: https://${camunda.client.cluster-id}.${camunda.client.region}.zeebe.camunda.io
+      base-url: https://${camunda.client.region}.zeebe.camunda.io/${camunda.client.cluster-id}
+      gateway-url: https://${camunda.client.cluster-id}.${camunda.client.region}.zeebe.camunda.io
+      prefer-rest-over-grpc: false
     operate:
       enabled: true
       audience: operate.camunda.io

--- a/spring-boot-starter-camunda/src/main/resources/application-camunda-simple.yaml
+++ b/spring-boot-starter-camunda/src/main/resources/application-camunda-simple.yaml
@@ -9,6 +9,7 @@ camunda:
     zeebe:
       enabled: true
       base-url: http://localhost:26500
+      rest-address: http://localhost:8080
     operate:
       enabled: true
       base-url: http://localhost:8081

--- a/spring-boot-starter-camunda/src/main/resources/application-camunda-simple.yaml
+++ b/spring-boot-starter-camunda/src/main/resources/application-camunda-simple.yaml
@@ -8,8 +8,9 @@ camunda:
       password: demo
     zeebe:
       enabled: true
-      base-url: http://localhost:26500
-      rest-address: http://localhost:8080
+      base-url: http://localhost:8080
+      gateway-url: http://localhost:26500
+      prefer-rest-over-grpc: false
     operate:
       enabled: true
       base-url: http://localhost:8081

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/legacy/ZeebeClientStarterAutoConfigurationCustomJsonMapperTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/legacy/ZeebeClientStarterAutoConfigurationCustomJsonMapperTest.java
@@ -28,6 +28,8 @@ import org.springframework.test.util.ReflectionTestUtils;
 @ExtendWith(SpringExtension.class)
 @TestPropertySource(
     properties = {
+      "camunda.client.zeebe.base-url=http://localhost:12345",
+      "camunda.client.zeebe.rest-address=http://localhost:8080",
       "zeebe.client.broker.gatewayAddress=localhost12345",
       "zeebe.client.requestTimeout=99s",
       "zeebe.client.job.timeout=99s",

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/legacy/ZeebeClientStarterAutoConfigurationCustomJsonMapperTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/legacy/ZeebeClientStarterAutoConfigurationCustomJsonMapperTest.java
@@ -29,7 +29,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 @TestPropertySource(
     properties = {
       "camunda.client.zeebe.base-url=http://localhost:12345",
-      "camunda.client.zeebe.rest-address=http://localhost:8080",
+      "camunda.client.zeebe.gateway-url=http://localhost:12346",
       "zeebe.client.broker.gatewayAddress=localhost12345",
       "zeebe.client.requestTimeout=99s",
       "zeebe.client.job.timeout=99s",

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/legacy/ZeebeClientStarterAutoConfigurationTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/legacy/ZeebeClientStarterAutoConfigurationTest.java
@@ -25,7 +25,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 @TestPropertySource(
     properties = {
       "camunda.client.zeebe.base-url=http://localhost:12345",
-      "camunda.client.zeebe.rest-address=http://localhost:8080",
+      "camunda.client.zeebe.gateway-url=http://localhost:12346",
       "zeebe.client.broker.gatewayAddress=localhost12345",
       "zeebe.client.requestTimeout=99s",
       "zeebe.client.job.timeout=99s",

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/legacy/ZeebeClientStarterAutoConfigurationTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/legacy/ZeebeClientStarterAutoConfigurationTest.java
@@ -24,6 +24,8 @@ import org.springframework.test.util.ReflectionTestUtils;
 @ExtendWith(SpringExtension.class)
 @TestPropertySource(
     properties = {
+      "camunda.client.zeebe.base-url=http://localhost:12345",
+      "camunda.client.zeebe.rest-address=http://localhost:8080",
       "zeebe.client.broker.gatewayAddress=localhost12345",
       "zeebe.client.requestTimeout=99s",
       "zeebe.client.job.timeout=99s",

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/properties/CamundaClientPropertiesOidcTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/properties/CamundaClientPropertiesOidcTest.java
@@ -16,7 +16,10 @@ public class CamundaClientPropertiesOidcTest {
   @Test
   void shouldLoadDefaults_oidc() {
     assertThat(properties.getMode()).isEqualTo(ClientMode.oidc);
-    assertThat(properties.getZeebe().getBaseUrl().toString()).isEqualTo("http://localhost:26500");
+    assertThat(properties.getZeebe().getGatewayUrl().toString())
+        .isEqualTo("http://localhost:26500");
+    assertThat(properties.getZeebe().getBaseUrl().toString()).isEqualTo("http://localhost:8080");
+    assertThat(properties.getZeebe().isPreferRestOverGrpc()).isEqualTo(false);
     assertThat(properties.getZeebe().getEnabled()).isEqualTo(true);
     assertThat(properties.getOperate().getBaseUrl().toString()).isEqualTo("http://localhost:8081");
     assertThat(properties.getOperate().getEnabled()).isEqualTo(true);

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/properties/CamundaClientPropertiesSaasTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/properties/CamundaClientPropertiesSaasTest.java
@@ -19,8 +19,11 @@ public class CamundaClientPropertiesSaasTest {
 
   @Test
   void shouldPopulateBaseUrlsForSaas() {
-    assertThat(properties.getZeebe().getBaseUrl().toString())
+    assertThat(properties.getZeebe().getGatewayUrl().toString())
         .isEqualTo("https://my-cluster-id.bru-2.zeebe.camunda.io");
+    assertThat(properties.getZeebe().getBaseUrl().toString())
+        .isEqualTo("https://bru-2.zeebe.camunda.io/my-cluster-id");
+    assertThat(properties.getZeebe().isPreferRestOverGrpc()).isEqualTo(false);
     assertThat(properties.getOperate().getBaseUrl().toString())
         .isEqualTo("https://bru-2.operate.camunda.io/my-cluster-id");
     assertThat(properties.getTasklist().getBaseUrl().toString())

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/properties/CamundaClientPropertiesSimpleTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/properties/CamundaClientPropertiesSimpleTest.java
@@ -18,7 +18,10 @@ public class CamundaClientPropertiesSimpleTest {
     assertThat(properties.getMode()).isEqualTo(simple);
     assertThat(properties.getAuth().getUsername()).isEqualTo("demo");
     assertThat(properties.getAuth().getPassword()).isEqualTo("demo");
-    assertThat(properties.getZeebe().getBaseUrl().toString()).isEqualTo("http://localhost:26500");
+    assertThat(properties.getZeebe().getGatewayUrl().toString())
+        .isEqualTo("http://localhost:26500");
+    assertThat(properties.getZeebe().getBaseUrl().toString()).isEqualTo("http://localhost:8080");
+    assertThat(properties.getZeebe().isPreferRestOverGrpc()).isEqualTo(false);
     assertThat(properties.getZeebe().getEnabled()).isEqualTo(true);
     assertThat(properties.getOperate().getBaseUrl().toString()).isEqualTo("http://localhost:8081");
     assertThat(properties.getOperate().getEnabled()).isEqualTo(true);


### PR DESCRIPTION
Hello,

I wanted to use spring-zeebe with Zeebe 8.5.0 that have now a REST API

I will set zeebe version with 8.5.0 once it is released this week