### PR TITLE
fix: a token is only counted valid if the expiry is later than in 30 seconds

### DIFF
--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/JwtAuthentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/JwtAuthentication.java
@@ -40,8 +40,8 @@ public abstract class JwtAuthentication implements Authentication {
   }
 
   private boolean isValid(JwtToken jwtToken) {
-    // a token is only counted valid if it is only valid for at least 30 seconds
-    return jwtToken.getExpiry().isAfter(LocalDateTime.now().minusSeconds(30));
+    // a token is only counted valid if the expiry is later than in 30 seconds
+    return jwtToken.getExpiry().isAfter(LocalDateTime.now().plusSeconds(30));
   }
 
   protected static class JwtToken {


### PR DESCRIPTION
…seconds (#775)

(cherry picked from commit 6cd49349fcac7105da469b0690f5b1b98beff266)