### PR TITLE
bug(object-mapper): Fix our custom mappers creation to avoid mutating the initial ObjectMapper

### DIFF
--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/JsonMapperConfiguration.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/JsonMapperConfiguration.java
@@ -24,7 +24,7 @@ public class JsonMapperConfiguration {
     if (objectMapper == null) {
       return new ZeebeObjectMapper();
     }
-    return new ZeebeObjectMapper(objectMapper);
+    return new ZeebeObjectMapper(objectMapper.copy());
   }
 
   @Bean(name = "commonJsonMapper")
@@ -33,6 +33,6 @@ public class JsonMapperConfiguration {
     if (objectMapper == null) {
       return new SdkObjectMapper();
     }
-    return new SdkObjectMapper(objectMapper);
+    return new SdkObjectMapper(objectMapper.copy());
   }
 }

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/JsonMapperConfigurationTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/JsonMapperConfigurationTest.java
@@ -1,31 +1,25 @@
 package io.camunda.zeebe.spring.client.config;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.common.json.JsonMapper;
-import io.camunda.common.json.SdkObjectMapper;
-import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
-import io.camunda.zeebe.spring.client.configuration.AuthenticationConfiguration;
 import io.camunda.zeebe.spring.client.configuration.JsonMapperConfiguration;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
-@SpringBootTest(classes = {JacksonAutoConfiguration.class,JsonMapperConfiguration.class})
+@SpringBootTest(classes = {JacksonAutoConfiguration.class, JsonMapperConfiguration.class})
 public class JsonMapperConfigurationTest {
 
-  @Autowired
-  private io.camunda.zeebe.client.api.JsonMapper zeebeJsonMapper;
+  @Autowired private io.camunda.zeebe.client.api.JsonMapper zeebeJsonMapper;
 
-  @Autowired
-  private JsonMapper commonJsonMapper;
+  @Autowired private JsonMapper commonJsonMapper;
 
   @Test
   public void shouldSerializeNullValuesInJson() throws JsonProcessingException {

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/JsonMapperConfigurationTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/JsonMapperConfigurationTest.java
@@ -1,0 +1,47 @@
+package io.camunda.zeebe.spring.client.config;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.common.json.JsonMapper;
+import io.camunda.common.json.SdkObjectMapper;
+import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
+import io.camunda.zeebe.spring.client.configuration.AuthenticationConfiguration;
+import io.camunda.zeebe.spring.client.configuration.JsonMapperConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(classes = {JacksonAutoConfiguration.class,JsonMapperConfiguration.class})
+public class JsonMapperConfigurationTest {
+
+  @Autowired
+  private io.camunda.zeebe.client.api.JsonMapper zeebeJsonMapper;
+
+  @Autowired
+  private JsonMapper commonJsonMapper;
+
+  @Test
+  public void shouldSerializeNullValuesInJson() throws JsonProcessingException {
+    // given
+    final Map<String, Object> map = new HashMap<>();
+    map.put("key", null);
+    map.put("key2", "value2");
+    // when
+    final JsonNode zeebeJsonNode = new ObjectMapper().readTree(zeebeJsonMapper.toJson(map));
+    final JsonNode commonJsonNode = new ObjectMapper().readTree(commonJsonMapper.toJson(map));
+
+    // then
+    assertThat(zeebeJsonNode.get("key")).isNotNull();
+    assertThat(commonJsonNode.get("key")).isNull();
+
+    assertThat(zeebeJsonNode.get("key2").asText()).isEqualTo("value2");
+    assertThat(commonJsonNode.get("key2").asText()).isEqualTo("value2");
+  }
+}


### PR DESCRIPTION
## Description

We can't set a process variable to null, because the ObjectMapper was configured to ignore NULL values.
This was a side effect due to the `ZeebeObjectMapper` and `SdkObjectMapper` using the `objectMapper` and mutating it.

To avoid breaking things, I just copied the initial mapper to keep the current behavior for the said mappers while avoiding the mutations.

I plan to backport this in: 
- 8.4
- 8.5


closes https://github.com/camunda/connectors/issues/2648