### PR TITLE
Fixes #796 Adding provision to have a result processor for workers

### DIFF
--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientAllAutoConfiguration.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientAllAutoConfiguration.java
@@ -1,8 +1,5 @@
 package io.camunda.zeebe.spring.client.configuration;
 
-import static io.camunda.zeebe.spring.client.configuration.PropertyUtil.*;
-import static io.camunda.zeebe.spring.client.properties.ZeebeClientConfigurationProperties.*;
-
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.api.worker.BackoffSupplier;
 import io.camunda.zeebe.client.impl.worker.ExponentialBackoffBuilderImpl;
@@ -15,6 +12,8 @@ import io.camunda.zeebe.spring.client.jobhandling.JobWorkerManager;
 import io.camunda.zeebe.spring.client.jobhandling.ZeebeClientExecutorService;
 import io.camunda.zeebe.spring.client.jobhandling.parameter.DefaultParameterResolverStrategy;
 import io.camunda.zeebe.spring.client.jobhandling.parameter.ParameterResolverStrategy;
+import io.camunda.zeebe.spring.client.jobhandling.result.DefaultResultProcessorStrategy;
+import io.camunda.zeebe.spring.client.jobhandling.result.ResultProcessorStrategy;
 import io.camunda.zeebe.spring.client.metrics.MetricsRecorder;
 import io.camunda.zeebe.spring.client.properties.CamundaClientProperties;
 import io.camunda.zeebe.spring.client.properties.PropertyBasedZeebeWorkerValueCustomizer;
@@ -24,6 +23,9 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Import;
+
+import static io.camunda.zeebe.spring.client.configuration.PropertyUtil.getOrLegacyOrDefault;
+import static io.camunda.zeebe.spring.client.properties.ZeebeClientConfigurationProperties.DEFAULT;
 
 @Conditional(ZeebeClientCondition.class)
 @Import({AnnotationProcessorConfiguration.class, JsonMapperConfiguration.class})
@@ -70,12 +72,22 @@ public class ZeebeClientAllAutoConfiguration {
   }
 
   @Bean
+  @ConditionalOnMissingBean
+  public ResultProcessorStrategy resultProcessorStrategy() {
+    return new DefaultResultProcessorStrategy();
+  }
+
+  @Bean
   public JobWorkerManager jobWorkerManager(
       final CommandExceptionHandlingStrategy commandExceptionHandlingStrategy,
       final MetricsRecorder metricsRecorder,
-      final ParameterResolverStrategy parameterResolverStrategy) {
+      final ParameterResolverStrategy parameterResolverStrategy,
+      final ResultProcessorStrategy resultProcessorStrategy) {
     return new JobWorkerManager(
-        commandExceptionHandlingStrategy, metricsRecorder, parameterResolverStrategy);
+        commandExceptionHandlingStrategy,
+        metricsRecorder,
+        parameterResolverStrategy,
+        resultProcessorStrategy);
   }
 
   @Bean

--- a/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/bean/MethodInfo.java
+++ b/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/bean/MethodInfo.java
@@ -1,6 +1,6 @@
 package io.camunda.zeebe.spring.client.bean;
 
-import static org.springframework.core.annotation.AnnotationUtils.findAnnotation;
+import org.springframework.core.StandardReflectionParameterNameDiscoverer;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
@@ -9,7 +9,8 @@ import java.lang.reflect.Parameter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.core.StandardReflectionParameterNameDiscoverer;
+
+import static org.springframework.core.annotation.AnnotationUtils.findAnnotation;
 
 public class MethodInfo implements BeanInfo {
 
@@ -84,6 +85,10 @@ public class MethodInfo implements BeanInfo {
       }
     }
     return result;
+  }
+
+  public Class<?> getReturnType() {
+    return method.getReturnType();
   }
 
   public static MethodInfoBuilder builder() {

--- a/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/jobhandling/JobHandlerInvokingSpringBeans.java
+++ b/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/jobhandling/JobHandlerInvokingSpringBeans.java
@@ -7,16 +7,18 @@ import io.camunda.zeebe.client.api.response.ActivatedJob;
 import io.camunda.zeebe.client.api.worker.JobClient;
 import io.camunda.zeebe.client.api.worker.JobHandler;
 import io.camunda.zeebe.client.impl.Loggers;
-import io.camunda.zeebe.spring.client.annotation.*;
 import io.camunda.zeebe.spring.client.annotation.value.ZeebeWorkerValue;
 import io.camunda.zeebe.spring.client.exception.ZeebeBpmnError;
 import io.camunda.zeebe.spring.client.jobhandling.parameter.ParameterResolver;
 import io.camunda.zeebe.spring.client.jobhandling.parameter.ParameterResolverStrategy;
+import io.camunda.zeebe.spring.client.jobhandling.result.ResultProcessor;
+import io.camunda.zeebe.spring.client.jobhandling.result.ResultProcessorStrategy;
 import io.camunda.zeebe.spring.client.metrics.MetricsRecorder;
+import org.slf4j.Logger;
+
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
-import org.slf4j.Logger;
 
 /** Zeebe JobHandler that invokes a Spring bean */
 public class JobHandlerInvokingSpringBeans implements JobHandler {
@@ -26,16 +28,23 @@ public class JobHandlerInvokingSpringBeans implements JobHandler {
   private final CommandExceptionHandlingStrategy commandExceptionHandlingStrategy;
   private final MetricsRecorder metricsRecorder;
   private final List<ParameterResolver> parameterResolvers;
+  private final ResultProcessor resultProcessor;
 
   public JobHandlerInvokingSpringBeans(
       ZeebeWorkerValue workerValue,
       CommandExceptionHandlingStrategy commandExceptionHandlingStrategy,
       MetricsRecorder metricsRecorder,
-      ParameterResolverStrategy parameterResolverStrategy) {
+      ParameterResolverStrategy parameterResolverStrategy,
+      ResultProcessorStrategy resultProcessorStrategy) {
     this.workerValue = workerValue;
     this.commandExceptionHandlingStrategy = commandExceptionHandlingStrategy;
     this.metricsRecorder = metricsRecorder;
     this.parameterResolvers = createParameterResolvers(parameterResolverStrategy);
+    this.resultProcessor = createResultProcessor(resultProcessorStrategy);
+  }
+
+  private ResultProcessor createResultProcessor(ResultProcessorStrategy resultProcessorStrategy) {
+    return resultProcessorStrategy.createProcessor(workerValue.getMethodInfo().getReturnType());
   }
 
   private List<ParameterResolver> createParameterResolvers(
@@ -57,6 +66,7 @@ public class JobHandlerInvokingSpringBeans implements JobHandler {
       Object result = null;
       try {
         result = workerValue.getMethodInfo().invoke(args.toArray());
+        result = resultProcessor.process(result);
       } catch (Throwable t) {
         metricsRecorder.increase(
             MetricsRecorder.METRIC_NAME_JOB, MetricsRecorder.ACTION_FAILED, job.getType());

--- a/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/jobhandling/JobWorkerManager.java
+++ b/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/jobhandling/JobWorkerManager.java
@@ -6,15 +6,17 @@ import io.camunda.zeebe.client.api.worker.JobWorker;
 import io.camunda.zeebe.client.api.worker.JobWorkerBuilderStep1;
 import io.camunda.zeebe.spring.client.annotation.value.ZeebeWorkerValue;
 import io.camunda.zeebe.spring.client.jobhandling.parameter.ParameterResolverStrategy;
+import io.camunda.zeebe.spring.client.jobhandling.result.ResultProcessorStrategy;
 import io.camunda.zeebe.spring.client.metrics.MetricsRecorder;
 import io.camunda.zeebe.spring.client.metrics.ZeebeClientMetricsBridge;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.lang.invoke.MethodHandles;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class JobWorkerManager {
 
@@ -25,16 +27,20 @@ public class JobWorkerManager {
   private final MetricsRecorder metricsRecorder;
   private final ParameterResolverStrategy parameterResolverStrategy;
 
+  private final ResultProcessorStrategy resultProcessorStrategy;
+
   private List<JobWorker> openedWorkers = new ArrayList<>();
   private List<ZeebeWorkerValue> workerValues = new ArrayList<>();
 
   public JobWorkerManager(
       CommandExceptionHandlingStrategy commandExceptionHandlingStrategy,
       MetricsRecorder metricsRecorder,
-      ParameterResolverStrategy parameterResolverStrategy) {
+      ParameterResolverStrategy parameterResolverStrategy,
+      ResultProcessorStrategy resultProcessorStrategy) {
     this.commandExceptionHandlingStrategy = commandExceptionHandlingStrategy;
     this.metricsRecorder = metricsRecorder;
     this.parameterResolverStrategy = parameterResolverStrategy;
+    this.resultProcessorStrategy = resultProcessorStrategy;
   }
 
   public JobWorker openWorker(ZeebeClient client, ZeebeWorkerValue zeebeWorkerValue) {
@@ -45,7 +51,8 @@ public class JobWorkerManager {
             zeebeWorkerValue,
             commandExceptionHandlingStrategy,
             metricsRecorder,
-            parameterResolverStrategy));
+            parameterResolverStrategy,
+            resultProcessorStrategy));
   }
 
   public JobWorker openWorker(

--- a/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/jobhandling/result/DefaultResultProcessor.java
+++ b/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/jobhandling/result/DefaultResultProcessor.java
@@ -1,0 +1,8 @@
+package io.camunda.zeebe.spring.client.jobhandling.result;
+
+public class DefaultResultProcessor implements ResultProcessor {
+  @Override
+  public Object process(Object result) {
+    return result;
+  }
+}

--- a/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/jobhandling/result/DefaultResultProcessorStrategy.java
+++ b/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/jobhandling/result/DefaultResultProcessorStrategy.java
@@ -1,0 +1,8 @@
+package io.camunda.zeebe.spring.client.jobhandling.result;
+
+public class DefaultResultProcessorStrategy implements ResultProcessorStrategy {
+  @Override
+  public ResultProcessor createProcessor(Class<?> resultType) {
+    return new DefaultResultProcessor();
+  }
+}

--- a/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/jobhandling/result/ResultProcessor.java
+++ b/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/jobhandling/result/ResultProcessor.java
@@ -1,0 +1,6 @@
+package io.camunda.zeebe.spring.client.jobhandling.result;
+
+public interface ResultProcessor {
+
+  Object process(Object result);
+}

--- a/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/jobhandling/result/ResultProcessorStrategy.java
+++ b/spring-client-zeebe/src/main/java/io/camunda/zeebe/spring/client/jobhandling/result/ResultProcessorStrategy.java
@@ -1,0 +1,6 @@
+package io.camunda.zeebe.spring.client.jobhandling.result;
+
+public interface ResultProcessorStrategy {
+
+  ResultProcessor createProcessor(Class<?> resultType);
+}

--- a/spring-client-zeebe/src/test/java/io/camunda/zeebe/spring/client/jobhandling/result/DefaultResultProcessorStrategyTest.java
+++ b/spring-client-zeebe/src/test/java/io/camunda/zeebe/spring/client/jobhandling/result/DefaultResultProcessorStrategyTest.java
@@ -1,0 +1,18 @@
+package io.camunda.zeebe.spring.client.jobhandling.result;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class DefaultResultProcessorStrategyTest {
+
+  private final DefaultResultProcessorStrategy resultProcessorStrategy = new DefaultResultProcessorStrategy();
+  @Test
+  void createProcessorShouldReturnDefaultProcessor() {
+    //Given
+    String inputValue = "input";
+    //When
+    ResultProcessor resultProcessor = resultProcessorStrategy.createProcessor(inputValue.getClass());
+    //Then
+    Assertions.assertTrue(resultProcessor instanceof DefaultResultProcessor);
+  }
+}

--- a/spring-client-zeebe/src/test/java/io/camunda/zeebe/spring/client/jobhandling/result/DefaultResultProcessorTest.java
+++ b/spring-client-zeebe/src/test/java/io/camunda/zeebe/spring/client/jobhandling/result/DefaultResultProcessorTest.java
@@ -1,0 +1,20 @@
+package io.camunda.zeebe.spring.client.jobhandling.result;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class DefaultResultProcessorTest {
+
+  private final DefaultResultProcessor defaultResultProcessor = new DefaultResultProcessor();
+
+  @Test
+  public void testProcessMethodShouldReturnResult() {
+    //Given
+    String inputValue = "input";
+    //When
+    Object resultValue = defaultResultProcessor.process(inputValue);
+    //Then
+    Assertions.assertEquals(inputValue, resultValue);
+  }
+
+}


### PR DESCRIPTION
We want to do additional processing on the incoming and outgoing variables of the worker before they can go into/come from SaaS. Adding the provision to have a custom result processor.

This PR also contains review comments fixes from previous closed PR. I closed the other one because of the wrong email address being used.