### PR TITLE
fix(simple-authentication): Fix an issue with SimpleAuthentication (#836)

### DIFF
--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SimpleAuthentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SimpleAuthentication.java
@@ -43,7 +43,7 @@ public class SimpleAuthentication implements Authentication {
                 String cookiePrefix = product.toString().toUpperCase() + "-SESSION";
                 for (Header cookieHeader : cookieHeaders) {
                   if (cookieHeader.getValue().startsWith(cookiePrefix)) {
-                    cookieCandidate = response.getHeader("Set-Cookie").getValue();
+                    cookieCandidate = cookieHeader.getValue();
                     break;
                   }
                 }

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/AuthenticationConfigurationSimpleTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/AuthenticationConfigurationSimpleTest.java
@@ -33,7 +33,10 @@ public class AuthenticationConfigurationSimpleTest {
     stubFor(
         post("/api/login")
             .willReturn(
-                ok().withHeader("Set-Cookie", "OPERATE-SESSION=3205A03818447100591792E774DB8AF6")));
+                ok().withHeader("Set-Cookie", "OPERATE-SESSION=3205A03818447100591792E774DB8AF6")
+                    .withHeader(
+                        "Set-Cookie",
+                        "OPERATE-X-CSRF-TOKEN=139196d4-7768-451c-aa66-078e1ed74785")));
     assertThat(authentication.getTokenHeader(Product.OPERATE))
         .isNotNull()
         .isEqualTo(entry("Cookie", "OPERATE-SESSION=3205A03818447100591792E774DB8AF6"));
@@ -48,8 +51,10 @@ public class AuthenticationConfigurationSimpleTest {
     stubFor(
         post("/api/login")
             .willReturn(
-                ok().withHeader(
-                        "Set-Cookie", "TASKLIST-SESSION=3205A03818447100591792E774DB8AF6")));
+                ok().withHeader("Set-Cookie", "TASKLIST-SESSION=3205A03818447100591792E774DB8AF6")
+                    .withHeader(
+                        "Set-Cookie",
+                        "OPERATE-X-CSRF-TOKEN=139196d4-7768-451c-aa66-078e1ed74785")));
     assertThat(authentication.getTokenHeader(Product.TASKLIST))
         .isNotNull()
         .isEqualTo(entry("Cookie", "TASKLIST-SESSION=3205A03818447100591792E774DB8AF6"));


### PR DESCRIPTION
Backport of #836 

* fix(simple-authentication): Fix an issue with SimpleAuthentication when CRSF protection is enabled (multiple Set-Cookie headers)