### PR TITLE
feat(simple-authentication): add the management of CSRF token for the…

### DIFF
--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/Authentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/Authentication.java
@@ -4,7 +4,7 @@ import java.util.Map;
 
 public interface Authentication {
 
-  Map.Entry<String, String> getTokenHeader(Product product);
+  Map<String, String> getTokenHeader(Product product);
 
   void resetToken(Product product);
 

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/DefaultNoopAuthentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/DefaultNoopAuthentication.java
@@ -27,7 +27,7 @@ public class DefaultNoopAuthentication implements Authentication {
   }
 
   @Override
-  public Map.Entry<String, String> getTokenHeader(Product product) {
+  public Map<String, String> getTokenHeader(Product product) {
     throw new UnsupportedOperationException("Unable to determine authentication");
   }
 }

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/JwtAuthentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/JwtAuthentication.java
@@ -1,10 +1,8 @@
 package io.camunda.common.auth;
 
 import java.time.LocalDateTime;
-import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Map.Entry;
 
 public abstract class JwtAuthentication implements Authentication {
 
@@ -25,7 +23,7 @@ public abstract class JwtAuthentication implements Authentication {
   }
 
   @Override
-  public final Entry<String, String> getTokenHeader(Product product) {
+  public final Map<String, String> getTokenHeader(Product product) {
     if (!tokens.containsKey(product) || !isValid(tokens.get(product))) {
       JwtToken newToken = generateToken(product, jwtConfig.getProduct(product));
       tokens.put(product, newToken);
@@ -35,8 +33,8 @@ public abstract class JwtAuthentication implements Authentication {
 
   protected abstract JwtToken generateToken(Product product, JwtCredential credential);
 
-  private Entry<String, String> authHeader(String token) {
-    return new AbstractMap.SimpleEntry<>("Authorization", "Bearer " + token);
+  private Map<String, String> authHeader(String token) {
+    return Map.of("Authorization", "Bearer " + token);
   }
 
   private boolean isValid(JwtToken jwtToken) {

--- a/camunda-sdk-java/java-common/src/test/java/io/camunda/common/http/DefaultHttpClientTest.java
+++ b/camunda-sdk-java/java-common/src/test/java/io/camunda/common/http/DefaultHttpClientTest.java
@@ -44,8 +44,7 @@ public class DefaultHttpClientTest {
     // when
     when(chClient.execute(any(HttpGet.class))).thenReturn(response);
     when(response.getCode()).thenReturn(200);
-    when(authentication.getTokenHeader(any()))
-        .thenReturn(new AbstractMap.SimpleEntry<>("key", "value"));
+    when(authentication.getTokenHeader(any())).thenReturn(Map.of("key", "value"));
     when(response.getEntity().getContent())
         .thenReturn(new ByteArrayInputStream("{\"name\" : \"test-name\"}".getBytes()));
     MyResponseClass parsedResponse = defaultHttpClient.get(MyResponseClass.class, "123");
@@ -69,8 +68,7 @@ public class DefaultHttpClientTest {
     // when
     when(chClient.execute(any(HttpPost.class))).thenReturn(response);
     when(response.getCode()).thenReturn(200);
-    when(authentication.getTokenHeader(any()))
-        .thenReturn(new AbstractMap.SimpleEntry<>("key", "value"));
+    when(authentication.getTokenHeader(any())).thenReturn(Map.of("key", "value"));
     when(response.getEntity().getContent())
         .thenReturn(new ByteArrayInputStream("[{\"name\" : \"test-name\"}]".getBytes()));
     List parsedResponse =
@@ -95,8 +93,7 @@ public class DefaultHttpClientTest {
     // when
     when(chClient.execute(any(HttpDelete.class))).thenReturn(response);
     when(response.getCode()).thenReturn(200);
-    when(authentication.getTokenHeader(any()))
-        .thenReturn(new AbstractMap.SimpleEntry<>("key", "value"));
+    when(authentication.getTokenHeader(any())).thenReturn(Map.of("key", "value"));
     when(response.getEntity().getContent())
         .thenReturn(new ByteArrayInputStream("{\"name\" : \"test-name\"}".getBytes()));
     MyResponseClass parsedResponse =

--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientConfiguration.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientConfiguration.java
@@ -417,8 +417,8 @@ public class ZeebeClientConfiguration implements io.camunda.zeebe.client.ZeebeCl
 
     @Override
     public void applyCredentials(CredentialsApplier applier) {
-      final Map.Entry<String, String> authHeader = authentication.getTokenHeader(Product.ZEEBE);
-      applier.put(authHeader.getKey(), authHeader.getValue());
+      final Map<String, String> authHeader = authentication.getTokenHeader(Product.ZEEBE);
+      authHeader.forEach(applier::put);
     }
 
     @Override

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/AuthenticationConfigurationOidcTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/AuthenticationConfigurationOidcTest.java
@@ -11,6 +11,7 @@ import io.camunda.common.auth.Product;
 import io.camunda.common.auth.SelfManagedAuthentication;
 import io.camunda.zeebe.spring.client.configuration.AuthenticationConfiguration;
 import java.time.Instant;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -48,7 +49,7 @@ public class AuthenticationConfigurationOidcTest {
                             .put("expires_in", 300))));
     assertThat(authentication.getTokenHeader(Product.OPERATE))
         .isNotNull()
-        .isEqualTo(entry("Authorization", "Bearer " + accessToken));
+        .isEqualTo(Map.of("Authorization", "Bearer " + accessToken));
     verify(
         postRequestedFor(urlEqualTo("/auth-server/protocol/openid-connect/token"))
             .withHeader("Content-Type", equalTo("application/x-www-form-urlencoded")));
@@ -67,7 +68,7 @@ public class AuthenticationConfigurationOidcTest {
                             .put("expires_in", 300))));
     assertThat(authentication.getTokenHeader(Product.TASKLIST))
         .isNotNull()
-        .isEqualTo(entry("Authorization", "Bearer " + accessToken));
+        .isEqualTo(Map.of("Authorization", "Bearer " + accessToken));
     verify(
         postRequestedFor(urlEqualTo("/auth-server/protocol/openid-connect/token"))
             .withHeader("Content-Type", equalTo("application/x-www-form-urlencoded")));
@@ -86,7 +87,7 @@ public class AuthenticationConfigurationOidcTest {
                             .put("expires_in", 300))));
     assertThat(authentication.getTokenHeader(Product.OPTIMIZE))
         .isNotNull()
-        .isEqualTo(entry("Authorization", "Bearer " + accessToken));
+        .isEqualTo(Map.of("Authorization", "Bearer " + accessToken));
     verify(
         postRequestedFor(urlEqualTo("/auth-server/protocol/openid-connect/token"))
             .withHeader("Content-Type", equalTo("application/x-www-form-urlencoded")));
@@ -105,7 +106,7 @@ public class AuthenticationConfigurationOidcTest {
                             .put("expires_in", 300))));
     assertThat(authentication.getTokenHeader(Product.ZEEBE))
         .isNotNull()
-        .isEqualTo(entry("Authorization", "Bearer " + accessToken));
+        .isEqualTo(Map.of("Authorization", "Bearer " + accessToken));
     verify(
         postRequestedFor(urlEqualTo("/auth-server/protocol/openid-connect/token"))
             .withHeader("Content-Type", equalTo("application/x-www-form-urlencoded")));

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/AuthenticationConfigurationSaasTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/AuthenticationConfigurationSaasTest.java
@@ -8,6 +8,7 @@ import io.camunda.common.auth.Authentication;
 import io.camunda.common.auth.Product;
 import io.camunda.common.auth.SaaSAuthentication;
 import io.camunda.zeebe.spring.client.configuration.AuthenticationConfiguration;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -46,7 +47,7 @@ public class AuthenticationConfigurationSaasTest {
                             .put("expires_in", 300))));
     assertThat(authentication.getTokenHeader(Product.OPERATE))
         .isNotNull()
-        .isEqualTo(entry("Authorization", "Bearer " + ACCESS_TOKEN));
+        .isEqualTo(Map.of("Authorization", "Bearer " + ACCESS_TOKEN));
     verify(
         postRequestedFor(urlEqualTo("/auth-server"))
             .withHeader("Content-Type", equalTo("application/json")));
@@ -64,7 +65,7 @@ public class AuthenticationConfigurationSaasTest {
                             .put("expires_in", 300))));
     assertThat(authentication.getTokenHeader(Product.TASKLIST))
         .isNotNull()
-        .isEqualTo(entry("Authorization", "Bearer " + ACCESS_TOKEN));
+        .isEqualTo(Map.of("Authorization", "Bearer " + ACCESS_TOKEN));
     verify(
         postRequestedFor(urlEqualTo("/auth-server"))
             .withHeader("Content-Type", equalTo("application/json")));
@@ -82,7 +83,7 @@ public class AuthenticationConfigurationSaasTest {
                             .put("expires_in", 300))));
     assertThat(authentication.getTokenHeader(Product.OPTIMIZE))
         .isNotNull()
-        .isEqualTo(entry("Authorization", "Bearer " + ACCESS_TOKEN));
+        .isEqualTo(Map.of("Authorization", "Bearer " + ACCESS_TOKEN));
     verify(
         postRequestedFor(urlEqualTo("/auth-server"))
             .withHeader("Content-Type", equalTo("application/json")));
@@ -100,7 +101,7 @@ public class AuthenticationConfigurationSaasTest {
                             .put("expires_in", 300))));
     assertThat(authentication.getTokenHeader(Product.ZEEBE))
         .isNotNull()
-        .isEqualTo(entry("Authorization", "Bearer " + ACCESS_TOKEN));
+        .isEqualTo(Map.of("Authorization", "Bearer " + ACCESS_TOKEN));
     verify(
         postRequestedFor(urlEqualTo("/auth-server"))
             .withHeader("Content-Type", equalTo("application/json")));

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/AuthenticationConfigurationSimpleTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/AuthenticationConfigurationSimpleTest.java
@@ -8,6 +8,8 @@ import io.camunda.common.auth.Authentication;
 import io.camunda.common.auth.Product;
 import io.camunda.common.auth.SimpleAuthentication;
 import io.camunda.zeebe.spring.client.configuration.AuthenticationConfiguration;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -28,6 +30,11 @@ public class AuthenticationConfigurationSimpleTest {
     assertThat(authentication).isExactlyInstanceOf(SimpleAuthentication.class);
   }
 
+  @BeforeEach
+  void setUp() {
+    authentication.resetToken(Product.OPERATE);
+  }
+
   @Test
   void shouldHaveOperateAuth() {
     stubFor(
@@ -39,7 +46,10 @@ public class AuthenticationConfigurationSimpleTest {
                         "OPERATE-X-CSRF-TOKEN=139196d4-7768-451c-aa66-078e1ed74785")));
     assertThat(authentication.getTokenHeader(Product.OPERATE))
         .isNotNull()
-        .isEqualTo(entry("Cookie", "OPERATE-SESSION=3205A03818447100591792E774DB8AF6"));
+        .isEqualTo(
+            Map.of(
+                "Cookie",
+                "OPERATE-SESSION=3205A03818447100591792E774DB8AF6; OPERATE-X-CSRF-TOKEN=139196d4-7768-451c-aa66-078e1ed74785"));
     verify(
         postRequestedFor(urlEqualTo("/api/login"))
             .withHeader(
@@ -57,7 +67,32 @@ public class AuthenticationConfigurationSimpleTest {
                         "OPERATE-X-CSRF-TOKEN=139196d4-7768-451c-aa66-078e1ed74785")));
     assertThat(authentication.getTokenHeader(Product.TASKLIST))
         .isNotNull()
-        .isEqualTo(entry("Cookie", "TASKLIST-SESSION=3205A03818447100591792E774DB8AF6"));
+        .isEqualTo(Map.of("Cookie", "TASKLIST-SESSION=3205A03818447100591792E774DB8AF6"));
+    verify(
+        postRequestedFor(urlEqualTo("/api/login"))
+            .withHeader(
+                "Content-Type", equalTo("application/x-www-form-urlencoded; charset=ISO-8859-1")));
+  }
+
+  @Test
+  void shouldHaveCSRFToken() {
+    stubFor(
+        post("/api/login")
+            .willReturn(
+                ok().withHeader(
+                        "Set-Cookie", "OPERATE-X-CSRF-TOKEN=139196d4-7768-451c-aa66-078e1ed74785")
+                    .withHeader(
+                        "OPERATE-X-CSRF-TOKEN",
+                        "WwbfQ33kHNEHu99ioC39yCMuVE2JjQnK_vYEpGPQGxBv1Nfn10pSDzapEpzfcJJvbiE2kG6jDMbFVVBSMy9K_K5dlV1")));
+
+    assertThat(authentication.getTokenHeader(Product.OPERATE))
+        .isNotNull()
+        .isEqualTo(
+            Map.of(
+                "Cookie",
+                "OPERATE-X-CSRF-TOKEN=139196d4-7768-451c-aa66-078e1ed74785",
+                "OPERATE-X-CSRF-TOKEN",
+                "WwbfQ33kHNEHu99ioC39yCMuVE2JjQnK_vYEpGPQGxBv1Nfn10pSDzapEpzfcJJvbiE2kG6jDMbFVVBSMy9K_K5dlV1"));
     verify(
         postRequestedFor(urlEqualTo("/api/login"))
             .withHeader(

--- a/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientConfigurationTest.java
+++ b/spring-boot-starter-camunda/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientConfigurationTest.java
@@ -13,7 +13,7 @@ import io.camunda.zeebe.spring.client.properties.CamundaClientProperties;
 import io.camunda.zeebe.spring.client.properties.ZeebeClientConfigurationProperties;
 import io.grpc.ClientInterceptor;
 import java.util.List;
-import java.util.Map.Entry;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.env.MockEnvironment;
 
@@ -40,7 +40,7 @@ public class ZeebeClientConfigurationTest {
   private static Authentication authentication() {
     return new Authentication() {
       @Override
-      public Entry<String, String> getTokenHeader(Product product) {
+      public Map<String, String> getTokenHeader(Product product) {
         return null;
       }
 


### PR DESCRIPTION
Add the management of CSRF token for the simple authentication

Another header has to be managed when operate has `CAMUNDA_OPERATE_CSRFPREVENTIONENABLED=true`
This PR allow `spring-zeebe` to manage the CSRF token if it has been enabled.