### PR TITLE
Underlying HTTP client evaluates system properties, e.g. proxy settings

### DIFF
--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SaaSAuthentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SaaSAuthentication.java
@@ -22,7 +22,7 @@ public class SaaSAuthentication extends JwtAuthentication {
   }
 
   private TokenResponse retrieveToken(Product product, JwtCredential jwtCredential) {
-    try (CloseableHttpClient client = HttpClients.createDefault()) {
+    try (CloseableHttpClient client = HttpClients.createSystem()) {
       HttpPost request = buildRequest(jwtCredential);
       return client.execute(
           request,

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SimpleAuthentication.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/auth/SimpleAuthentication.java
@@ -32,7 +32,7 @@ public class SimpleAuthentication implements Authentication {
   }
 
   private Map<String, String> retrieveToken(Product product, SimpleCredential simpleCredential) {
-    try (CloseableHttpClient client = HttpClients.createDefault()) {
+    try (CloseableHttpClient client = HttpClients.createSystem()) {
       HttpPost request = buildRequest(simpleCredential);
 
       Map<String, String> headers =

--- a/camunda-sdk-java/java-common/src/main/java/io/camunda/common/http/DefaultHttpClient.java
+++ b/camunda-sdk-java/java-common/src/main/java/io/camunda/common/http/DefaultHttpClient.java
@@ -41,7 +41,7 @@ public class DefaultHttpClient implements HttpClient {
 
   public DefaultHttpClient(Authentication authentication) {
     this.authentication = authentication;
-    this.httpClient = HttpClients.createDefault();
+    this.httpClient = HttpClients.createSystem();
     this.jsonMapper = new SdkObjectMapper();
     this.productMap = new HashMap<>();
   }


### PR DESCRIPTION
Currently, the underlying HTTP clients cannot be configured to use a proxy (which is unfortunately needed quite of the enterprise environments)

Therefore I suggest this PR to support e.g. http_proxy and https_proxy