### PR TITLE
[Backport 1110 to release/8.4] chore: upgrade org.camunda.community:community-hub-release-parent to 2.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.camunda.community</groupId>
     <artifactId>community-hub-release-parent</artifactId>
-    <version>1.4.4</version>
+    <version>2.0.1</version>
   </parent>
   <groupId>io.camunda.spring</groupId>
   <artifactId>spring-client-root</artifactId>


### PR DESCRIPTION
Upgrade org.camunda.community:community-hub-release-parent to 2.0.1