### PR TITLE
feat: add resource to identity config

### DIFF
--- a/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/CommonClientConfiguration.java
+++ b/spring-boot-starter-camunda/src/main/java/io/camunda/zeebe/spring/client/configuration/CommonClientConfiguration.java
@@ -289,6 +289,7 @@ public class CommonClientConfiguration {
             .withType(identityConfigurationFromProperties.getType().name())
             .withCertPath(identityConfigurationFromProperties.getCertPath())
             .withCertStorePassword(identityConfigurationFromProperties.getCertStorePassword())
+            .withResource(identityConfigurationFromProperties.getResource())
             .build();
     Identity operateIdentity = new Identity(operateIdentityConfiguration);
     return new IdentityContainer(operateIdentity, operateIdentityConfiguration);


### PR DESCRIPTION
This pull request introduces a small enhancement to the `configureOperateIdentityContainer` method in the `CommonClientConfiguration` class. The change adds support for configuring an additional property, `resource`, in the `IdentityConfiguration` object.

* [`CommonClientConfiguration.java`](diffhunk://#diff-bbb3ae62bfdde155c24385e9555b64273f43b0daa719cbb81b902080668e2655R292): Added a call to `.withResource(identityConfigurationFromProperties.getResource())` to include the `resource` property in the `IdentityConfiguration` setup.